### PR TITLE
feat(sparql-monitor): export SparqlMonitor class and options type

### DIFF
--- a/packages/sparql-monitor/src/index.ts
+++ b/packages/sparql-monitor/src/index.ts
@@ -1,4 +1,5 @@
 export type { MonitorConfig, Observation, ObservationStore } from './types.js';
+export { SparqlMonitor, type SparqlMonitorOptions } from './monitor.js';
 export { PostgresObservationStore } from './store.js';
 export { MonitorService, type MonitorServiceOptions } from './service.js';
 export { defineConfig, type SparqlMonitorConfig } from './config.js';


### PR DESCRIPTION
## Summary

Export `SparqlMonitor` class and `SparqlMonitorOptions` type from the sparql-monitor package's public API.

## Changes

* Add `SparqlMonitor` and `SparqlMonitorOptions` to public exports in `index.ts`
* Allows consumers to use `SparqlMonitor` directly for custom integrations