### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      eslint:
+        patterns:
+          - '@typescript-eslint/*'
+          - 'eslint'
+          - 'eslint-plugin-svelte'
+      fastify:
+        patterns:
+          - '@fastify/*'
+          - 'fastify'
+      vitest:
+        patterns:
+          - '@vitest/*'
+          - 'vitest'
+    ignore:
+      # Upgrade Nx manually with `nx migrate latest`
+      - dependency-name: '@nx/*'
+      - dependency-name: 'nx'


### PR DESCRIPTION
## Summary

- Add Dependabot configuration for weekly dependency updates
- Group eslint, fastify, and vitest package updates
- Exclude `@nx/*` and `nx` packages (should be upgraded via `nx migrate` to run necessary codemods)