### PR TITLE
Add Executor interface

### DIFF
--- a/packages/pipeline/src/sparql/executor.ts
+++ b/packages/pipeline/src/sparql/executor.ts
@@ -11,8 +11,7 @@ export { NotSupported } from '../step.js';
 
 export interface Executor {
   execute(
-    dataset: ExecutableDataset,
-    options?: ExecuteOptions
+    dataset: ExecutableDataset
   ): Promise<AsyncIterable<Quad> | NotSupported>;
 }
 
@@ -57,7 +56,7 @@ export interface SparqlConstructExecutorOptions {
 /**
  * Options for `execute()`.
  */
-export interface ExecuteOptions {
+export interface SparqlConstructExecuteOptions {
   /**
    * Explicit SPARQL endpoint URL. If not provided, uses the dataset's SPARQL distribution.
    */
@@ -123,7 +122,7 @@ export class SparqlConstructExecutor implements Executor {
    */
   async execute(
     dataset: ExecutableDataset,
-    options?: ExecuteOptions
+    options?: SparqlConstructExecuteOptions
   ): Promise<QuadStream | NotSupported> {
     const distribution = dataset.getSparqlDistribution();
     let endpoint = options?.endpoint;

--- a/packages/pipeline/src/sparql/index.ts
+++ b/packages/pipeline/src/sparql/index.ts
@@ -5,7 +5,7 @@ export {
   readQueryFile,
   type ExecutableDataset,
   type Executor,
-  type ExecuteOptions,
+  type SparqlConstructExecuteOptions,
   type SparqlConstructExecutorOptions,
   type QuadStream,
 } from './executor.js';


### PR DESCRIPTION
## Summary
- Extract `Executor` interface from `SparqlConstructExecutor` as the foundational abstraction for Stage composition
- `Executor.execute(dataset)` takes only a dataset; implementation-specific options stay on concrete classes
- Rename `ExecuteOptions` to `SparqlConstructExecuteOptions`
- `SparqlConstructExecutor` now `implements Executor`

## Test plan
- [x] `npx nx typecheck pipeline` passes
- [x] `npx nx test pipeline` passes (64/64)
- [x] `npx nx test pipeline-void` passes (25/25)