### PR TITLE
feat(pipeline): add Stage abstraction for pipeline composition

### DIFF
--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -1,5 +1,6 @@
 export * from './pipeline.js';
 export * from './selector.js';
+export * from './stage.js';
 export * from './step.js';
 export * from './step/sparqlQuery.js';
 export * from './builder.js';

--- a/packages/pipeline/src/stage.ts
+++ b/packages/pipeline/src/stage.ts
@@ -1,0 +1,47 @@
+import type { Quad } from '@rdfjs/types';
+import type { ExecutableDataset, Executor } from './sparql/executor.js';
+import { NotSupported } from './sparql/executor.js';
+
+export interface StageOptions {
+  name: string;
+  executors: Executor | Executor[];
+}
+
+export class Stage {
+  readonly name: string;
+  private readonly executors: Executor[];
+
+  constructor(options: StageOptions) {
+    this.name = options.name;
+    this.executors = Array.isArray(options.executors)
+      ? options.executors
+      : [options.executors];
+  }
+
+  async run(
+    dataset: ExecutableDataset
+  ): Promise<AsyncIterable<Quad> | NotSupported> {
+    const streams: AsyncIterable<Quad>[] = [];
+
+    for (const executor of this.executors) {
+      const result = await executor.execute(dataset);
+      if (!(result instanceof NotSupported)) {
+        streams.push(result);
+      }
+    }
+
+    if (streams.length === 0) {
+      return new NotSupported('All executors returned NotSupported');
+    }
+
+    return mergeStreams(streams);
+  }
+}
+
+async function* mergeStreams(
+  streams: AsyncIterable<Quad>[]
+): AsyncIterable<Quad> {
+  for (const stream of streams) {
+    yield* stream;
+  }
+}

--- a/packages/pipeline/test/stage.test.ts
+++ b/packages/pipeline/test/stage.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { DataFactory } from 'n3';
+import type { Quad } from '@rdfjs/types';
+import { Stage } from '../src/stage.js';
+import type { Executor, ExecutableDataset } from '../src/sparql/executor.js';
+import { NotSupported } from '../src/sparql/executor.js';
+import { Dataset } from '@lde/dataset';
+
+const { namedNode, quad } = DataFactory;
+
+const q1 = quad(
+  namedNode('http://example.org/s1'),
+  namedNode('http://example.org/p'),
+  namedNode('http://example.org/o1')
+);
+const q2 = quad(
+  namedNode('http://example.org/s2'),
+  namedNode('http://example.org/p'),
+  namedNode('http://example.org/o2')
+);
+const q3 = quad(
+  namedNode('http://example.org/s3'),
+  namedNode('http://example.org/p'),
+  namedNode('http://example.org/o3')
+);
+
+function mockExecutor(quads: Quad[]): Executor {
+  return {
+    async execute(): Promise<AsyncIterable<Quad> | NotSupported> {
+      return (async function* () {
+        yield* quads;
+      })();
+    },
+  };
+}
+
+function notSupportedExecutor(message = 'not supported'): Executor {
+  return {
+    async execute(): Promise<AsyncIterable<Quad> | NotSupported> {
+      return new NotSupported(message);
+    },
+  };
+}
+
+const dataset: ExecutableDataset = new Dataset({
+  iri: new URL('http://example.org/dataset'),
+  distributions: [],
+});
+
+async function collectQuads(iterable: AsyncIterable<Quad>): Promise<Quad[]> {
+  const result: Quad[] = [];
+  for await (const quad of iterable) {
+    result.push(quad);
+  }
+  return result;
+}
+
+describe('Stage', () => {
+  it('yields quads from a single executor', async () => {
+    const stage = new Stage({
+      name: 'test',
+      executors: mockExecutor([q1, q2]),
+    });
+
+    const result = await stage.run(dataset);
+    expect(result).not.toBeInstanceOf(NotSupported);
+
+    const quads = await collectQuads(result as AsyncIterable<Quad>);
+    expect(quads).toEqual([q1, q2]);
+  });
+
+  it('returns NotSupported when single executor returns NotSupported', async () => {
+    const stage = new Stage({
+      name: 'test',
+      executors: notSupportedExecutor(),
+    });
+
+    const result = await stage.run(dataset);
+    expect(result).toBeInstanceOf(NotSupported);
+    expect((result as NotSupported).message).toBe(
+      'All executors returned NotSupported'
+    );
+  });
+
+  it('yields all quads merged from multiple executors', async () => {
+    const stage = new Stage({
+      name: 'test',
+      executors: [mockExecutor([q1]), mockExecutor([q2, q3])],
+    });
+
+    const result = await stage.run(dataset);
+    expect(result).not.toBeInstanceOf(NotSupported);
+
+    const quads = await collectQuads(result as AsyncIterable<Quad>);
+    expect(quads).toEqual([q1, q2, q3]);
+  });
+
+  it('yields quads only from successful executors when some return NotSupported', async () => {
+    const stage = new Stage({
+      name: 'test',
+      executors: [
+        notSupportedExecutor(),
+        mockExecutor([q1, q2]),
+        notSupportedExecutor(),
+      ],
+    });
+
+    const result = await stage.run(dataset);
+    expect(result).not.toBeInstanceOf(NotSupported);
+
+    const quads = await collectQuads(result as AsyncIterable<Quad>);
+    expect(quads).toEqual([q1, q2]);
+  });
+
+  it('returns NotSupported when all executors return NotSupported', async () => {
+    const stage = new Stage({
+      name: 'test',
+      executors: [notSupportedExecutor('a'), notSupportedExecutor('b')],
+    });
+
+    const result = await stage.run(dataset);
+    expect(result).toBeInstanceOf(NotSupported);
+    expect((result as NotSupported).message).toBe(
+      'All executors returned NotSupported'
+    );
+  });
+});

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
       fileParallelism: false,
       coverage: {
         thresholds: {
-          functions: 90.66,
-          lines: 89.73,
-          branches: 79.28,
-          statements: 89.88,
+          functions: 91.02,
+          lines: 90.18,
+          branches: 80.13,
+          statements: 90.32,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Add `Stage` class that orchestrates one or more `Executor`s (aggregate mode — no selector yet)
- `Stage.run()` executes all executors, skips `NotSupported` results, and merges output streams sequentially
- Returns `NotSupported` when all executors return `NotSupported`
- Export `Stage` and `StageOptions` from `@lde/pipeline` barrel
- Mark Phase 2 step 5 as done in design doc, add "Stage is not an Executor" clarification

## Test plan

- [x] Single executor returning quads — Stage yields those quads
- [x] Single executor returning `NotSupported` — Stage returns `NotSupported`
- [x] Multiple executors all returning quads — Stage yields all quads merged
- [x] Multiple executors, some `NotSupported` — Stage yields quads from successful ones only
- [x] Multiple executors, all `NotSupported` — Stage returns `NotSupported`
- [x] `npx nx typecheck pipeline` passes
- [x] `npx nx test pipeline` passes (69/69)
- [x] `npx nx test pipeline-void` passes (25/25)