### PR TITLE
feat(pipeline): add StageSelector interface and SparqlSelector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39255,7 +39255,11 @@
         "fetch-sparql-endpoint": "^6.0.0",
         "filenamify-url": "^3.0.0",
         "n3": "^1.17.0",
+        "sparqljs": "^3.7.3",
         "tslib": "^2.3.0"
+      },
+      "devDependencies": {
+        "@types/sparqljs": "^3.1.12"
       }
     },
     "packages/pipeline-void": {

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -44,6 +44,10 @@
     "fetch-sparql-endpoint": "^6.0.0",
     "filenamify-url": "^3.0.0",
     "n3": "^1.17.0",
+    "sparqljs": "^3.7.3",
     "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/sparqljs": "^3.1.12"
   }
 }

--- a/packages/pipeline/src/sparql/index.ts
+++ b/packages/pipeline/src/sparql/index.ts
@@ -11,3 +11,5 @@ export {
 } from './executor.js';
 
 export { collect } from './collect.js';
+
+export { SparqlSelector, type SparqlSelectorOptions } from './selector.js';

--- a/packages/pipeline/src/sparql/selector.ts
+++ b/packages/pipeline/src/sparql/selector.ts
@@ -1,0 +1,98 @@
+import type { Term } from '@rdfjs/types';
+import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
+import {
+  Generator,
+  Parser,
+  type SelectQuery,
+  type Variable,
+  type VariableTerm,
+} from 'sparqljs';
+import type { StageSelectorBindings, StageSelector } from '../stage.js';
+
+const parser = new Parser();
+const generator = new Generator();
+
+export interface SparqlSelectorOptions {
+  /** SELECT query projecting at least one named variable. A LIMIT in the query sets the default page size. */
+  query: string;
+  /** SPARQL endpoint URL. */
+  endpoint: URL;
+  /** Results per page. Overrides any LIMIT in the query. @default 10 */
+  pageSize?: number;
+  /** Custom fetcher instance. */
+  fetcher?: SparqlEndpointFetcher;
+}
+
+/**
+ * {@link StageSelector} that pages through SPARQL SELECT results,
+ * yielding all projected variable bindings (NamedNode values only) per row.
+ *
+ * Pagination is an internal detail — consumers iterate binding rows directly.
+ * If the query contains a LIMIT, it is used as the default page size
+ * (can be overridden by the `pageSize` option). Pagination continues
+ * until a page returns fewer results than the page size.
+ */
+export class SparqlSelector implements StageSelector {
+  private readonly parsed: SelectQuery;
+  private readonly endpoint: URL;
+  private readonly pageSize: number;
+  private readonly fetcher: SparqlEndpointFetcher;
+
+  constructor(options: SparqlSelectorOptions) {
+    const parsed = parser.parse(options.query);
+    if (parsed.type !== 'query' || parsed.queryType !== 'SELECT') {
+      throw new Error('Query must be a SELECT query');
+    }
+
+    const variables = parsed.variables.filter(isVariableTerm);
+    if (variables.length === 0) {
+      throw new Error(
+        'Query must project at least one named variable (SELECT * is not supported)'
+      );
+    }
+
+    this.parsed = parsed;
+    this.endpoint = options.endpoint;
+    this.pageSize = options.pageSize ?? parsed.limit ?? 10;
+    this.fetcher = options.fetcher ?? new SparqlEndpointFetcher();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<StageSelectorBindings> {
+    let offset = 0;
+
+    while (true) {
+      this.parsed.limit = this.pageSize;
+      this.parsed.offset = offset;
+      const paginatedQuery = generator.stringify(this.parsed);
+
+      const stream = (await this.fetcher.fetchBindings(
+        this.endpoint.toString(),
+        paginatedQuery
+      )) as AsyncIterable<Record<string, Term>>;
+
+      let pageSize = 0;
+      for await (const record of stream) {
+        const row = Object.fromEntries(
+          Object.entries(record).filter(
+            ([, term]) => term.termType === 'NamedNode'
+          )
+        ) as StageSelectorBindings;
+
+        if (Object.keys(row).length > 0) {
+          yield row;
+          pageSize++;
+        }
+      }
+
+      if (pageSize === 0 || pageSize < this.pageSize) {
+        return;
+      }
+
+      offset += pageSize;
+    }
+  }
+}
+
+function isVariableTerm(v: Variable | object): v is VariableTerm {
+  return 'termType' in v && v.termType === 'Variable';
+}

--- a/packages/pipeline/src/stage.ts
+++ b/packages/pipeline/src/stage.ts
@@ -1,4 +1,4 @@
-import type { Quad } from '@rdfjs/types';
+import type { NamedNode, Quad } from '@rdfjs/types';
 import type { ExecutableDataset, Executor } from './sparql/executor.js';
 import { NotSupported } from './sparql/executor.js';
 
@@ -45,3 +45,10 @@ async function* mergeStreams(
     yield* stream;
   }
 }
+
+/** A single row of variable bindings from a selector query. */
+export type StageSelectorBindings = Record<string, NamedNode>;
+
+/** Stage-level selector that yields variable bindings for use in executor queries. Pagination is an implementation detail. */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-empty-interface
+export interface StageSelector extends AsyncIterable<StageSelectorBindings> {}

--- a/packages/pipeline/test/sparql/selector.test.ts
+++ b/packages/pipeline/test/sparql/selector.test.ts
@@ -1,0 +1,351 @@
+import { SparqlSelector } from '../../src/sparql/selector.js';
+import type { StageSelector, StageSelectorBindings } from '../../src/stage.js';
+import { describe, it, expect, vi } from 'vitest';
+import { Readable } from 'node:stream';
+import { DataFactory } from 'n3';
+
+const { namedNode, literal, blankNode } = DataFactory;
+
+function bindingsStream(
+  records: Record<string, { termType: string; value: string }>[]
+): Promise<Readable> {
+  const stream = new Readable({
+    objectMode: true,
+    read() {
+      /* no-op */
+    },
+  });
+  for (const record of records) {
+    stream.push(record);
+  }
+  stream.push(null);
+  return Promise.resolve(stream);
+}
+
+describe('SparqlSelector', () => {
+  const endpoint = new URL('http://example.com/sparql');
+  const query = 'SELECT ?uri WHERE { ?uri a <http://example.com/Class> }';
+
+  it('yields all bindings when results are fewer than pageSize', async () => {
+    const mockFetcher = {
+      fetchBindings: vi
+        .fn()
+        .mockImplementation(() =>
+          bindingsStream([
+            { uri: namedNode('http://example.com/1') },
+            { uri: namedNode('http://example.com/2') },
+          ])
+        ),
+    };
+
+    const selector = new SparqlSelector({
+      query,
+      endpoint,
+      pageSize: 10,
+      fetcher: mockFetcher as never,
+    });
+
+    const rows: StageSelectorBindings[] = [];
+    for await (const row of selector) {
+      rows.push(row);
+    }
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].uri.value).toBe('http://example.com/1');
+    expect(rows[1].uri.value).toBe('http://example.com/2');
+  });
+
+  it('paginates with correct OFFSET increments', async () => {
+    const queries: string[] = [];
+    const mockFetcher = {
+      fetchBindings: vi
+        .fn()
+        .mockImplementation((_endpoint: string, q: string) => {
+          queries.push(q);
+          if (queries.length === 1) {
+            return bindingsStream([
+              { uri: namedNode('http://example.com/1') },
+              { uri: namedNode('http://example.com/2') },
+            ]);
+          }
+          return bindingsStream([{ uri: namedNode('http://example.com/3') }]);
+        }),
+    };
+
+    const selector = new SparqlSelector({
+      query,
+      endpoint,
+      pageSize: 2,
+      fetcher: mockFetcher as never,
+    });
+
+    const rows: StageSelectorBindings[] = [];
+    for await (const row of selector) {
+      rows.push(row);
+    }
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.uri.value)).toEqual([
+      'http://example.com/1',
+      'http://example.com/2',
+      'http://example.com/3',
+    ]);
+
+    expect(queries[0]).toMatch(/LIMIT\s+2/);
+    // sparqljs omits OFFSET 0 (the default).
+    expect(queries[0]).not.toMatch(/OFFSET/);
+    expect(queries[1]).toMatch(/LIMIT\s+2/);
+    expect(queries[1]).toMatch(/OFFSET\s+2/);
+  });
+
+  it('yields nothing for empty results', async () => {
+    const mockFetcher = {
+      fetchBindings: vi.fn().mockImplementation(() => bindingsStream([])),
+    };
+
+    const selector = new SparqlSelector({
+      query,
+      endpoint,
+      fetcher: mockFetcher as never,
+    });
+
+    const rows: unknown[] = [];
+    for await (const row of selector) {
+      rows.push(row);
+    }
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('respects custom pageSize in LIMIT clause', async () => {
+    const queries: string[] = [];
+    const mockFetcher = {
+      fetchBindings: vi
+        .fn()
+        .mockImplementation((_endpoint: string, q: string) => {
+          queries.push(q);
+          return bindingsStream([{ uri: namedNode('http://example.com/1') }]);
+        }),
+    };
+
+    const selector = new SparqlSelector({
+      query,
+      endpoint,
+      pageSize: 50,
+      fetcher: mockFetcher as never,
+    });
+
+    for await (const _row of selector) {
+      // consume
+    }
+
+    expect(queries[0]).toMatch(/LIMIT\s+50/);
+  });
+
+  it('skips rows where all projected variables are non-NamedNode', async () => {
+    const mockFetcher = {
+      fetchBindings: vi
+        .fn()
+        .mockImplementation(() =>
+          bindingsStream([
+            { uri: namedNode('http://example.com/1') },
+            { uri: literal('not a URI') },
+            { uri: blankNode('b0') },
+            { uri: namedNode('http://example.com/2') },
+          ])
+        ),
+    };
+
+    const selector = new SparqlSelector({
+      query,
+      endpoint,
+      pageSize: 10,
+      fetcher: mockFetcher as never,
+    });
+
+    const rows: StageSelectorBindings[] = [];
+    for await (const row of selector) {
+      rows.push(row);
+    }
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].uri.value).toBe('http://example.com/1');
+    expect(rows[1].uri.value).toBe('http://example.com/2');
+  });
+
+  it('defaults pageSize to 10', async () => {
+    const queries: string[] = [];
+    const mockFetcher = {
+      fetchBindings: vi
+        .fn()
+        .mockImplementation((_endpoint: string, q: string) => {
+          queries.push(q);
+          return bindingsStream([]);
+        }),
+    };
+
+    const selector = new SparqlSelector({
+      query,
+      endpoint,
+      fetcher: mockFetcher as never,
+    });
+
+    for await (const _row of selector) {
+      // consume
+    }
+
+    expect(queries[0]).toMatch(/LIMIT\s+10/);
+  });
+
+  it('uses query LIMIT as default pageSize', async () => {
+    const queries: string[] = [];
+    const mockFetcher = {
+      fetchBindings: vi
+        .fn()
+        .mockImplementation((_endpoint: string, q: string) => {
+          queries.push(q);
+          return bindingsStream([{ class: namedNode('http://example.com/a') }]);
+        }),
+    };
+
+    const selector = new SparqlSelector({
+      query: 'SELECT ?class WHERE { ?s a ?class } LIMIT 25',
+      endpoint,
+      fetcher: mockFetcher as never,
+    });
+
+    for await (const _row of selector) {
+      // consume
+    }
+
+    // Query LIMIT 25 becomes the pageSize.
+    expect(queries[0]).toMatch(/LIMIT\s+25/);
+  });
+
+  it('pageSize option overrides query LIMIT', async () => {
+    const queries: string[] = [];
+    const mockFetcher = {
+      fetchBindings: vi
+        .fn()
+        .mockImplementation((_endpoint: string, q: string) => {
+          queries.push(q);
+          return bindingsStream([{ class: namedNode('http://example.com/a') }]);
+        }),
+    };
+
+    const selector = new SparqlSelector({
+      query: 'SELECT ?class WHERE { ?s a ?class } LIMIT 25',
+      endpoint,
+      pageSize: 5,
+      fetcher: mockFetcher as never,
+    });
+
+    for await (const _row of selector) {
+      // consume
+    }
+
+    // Explicit pageSize overrides query LIMIT.
+    expect(queries[0]).toMatch(/LIMIT\s+5/);
+  });
+
+  it('collects all projected variables per row', async () => {
+    const mockFetcher = {
+      fetchBindings: vi.fn().mockImplementation(() =>
+        bindingsStream([
+          {
+            class: namedNode('http://example.com/Person'),
+            property: namedNode('http://example.com/name'),
+          },
+        ])
+      ),
+    };
+
+    const selector = new SparqlSelector({
+      query: 'SELECT ?class ?property WHERE { ?s a ?class ; ?property ?o }',
+      endpoint,
+      fetcher: mockFetcher as never,
+    });
+
+    const rows: StageSelectorBindings[] = [];
+    for await (const row of selector) {
+      rows.push(row);
+    }
+
+    expect(rows[0].class.value).toBe('http://example.com/Person');
+    expect(rows[0].property.value).toBe('http://example.com/name');
+  });
+
+  it('includes row when at least one variable is a NamedNode', async () => {
+    const mockFetcher = {
+      fetchBindings: vi.fn().mockImplementation(() =>
+        bindingsStream([
+          {
+            class: namedNode('http://example.com/Person'),
+            label: literal('Person'),
+          },
+        ])
+      ),
+    };
+
+    const selector = new SparqlSelector({
+      query:
+        'SELECT ?class ?label WHERE { ?s a ?class ; <http://www.w3.org/2000/01/rdf-schema#label> ?label }',
+      endpoint,
+      fetcher: mockFetcher as never,
+    });
+
+    const rows: StageSelectorBindings[] = [];
+    for await (const row of selector) {
+      rows.push(row);
+    }
+
+    // Row is included because ?class is a NamedNode; ?label (literal) is omitted.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].class.value).toBe('http://example.com/Person');
+    expect(rows[0].label).toBeUndefined();
+  });
+
+  it('throws on non-SELECT queries', () => {
+    expect(
+      () =>
+        new SparqlSelector({
+          query: 'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }',
+          endpoint,
+        })
+    ).toThrow('Query must be a SELECT query');
+  });
+
+  it('throws on SELECT * queries', () => {
+    expect(
+      () =>
+        new SparqlSelector({
+          query: 'SELECT * WHERE { ?s ?p ?o }',
+          endpoint,
+        })
+    ).toThrow('SELECT * is not supported');
+  });
+
+  it('is assignable to StageSelector', async () => {
+    const mockFetcher = {
+      fetchBindings: vi
+        .fn()
+        .mockImplementation(() =>
+          bindingsStream([{ uri: namedNode('http://example.com/1') }])
+        ),
+    };
+
+    // Verify SparqlSelector satisfies StageSelector.
+    const selector: StageSelector = new SparqlSelector({
+      query,
+      endpoint,
+      fetcher: mockFetcher as never,
+    });
+
+    const rows: StageSelectorBindings[] = [];
+    for await (const row of selector) {
+      rows.push(row);
+    }
+
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
       fileParallelism: false,
       coverage: {
         thresholds: {
-          functions: 91.02,
-          lines: 90.18,
-          branches: 80.13,
-          statements: 90.32,
+          functions: 91.46,
+          lines: 91.11,
+          branches: 81.81,
+          statements: 91.23,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Add `StageSelector` interface as `AsyncIterable<StageSelectorBindings>` — consumers iterate binding rows directly with `for await`, pagination is hidden
- Add `SparqlSelector` implementing paginated SPARQL SELECT queries using `sparqljs` AST manipulation
- Type the `fetchBindings` stream as `AsyncIterable<Record<string, Term>>` and use discriminant narrowing — no manual NamedNode construction
- Filter each result row to NamedNode values via `Object.fromEntries`/`Object.entries`
- Query LIMIT sets default page size (like LD Workbench); `pageSize` option overrides
- Update design doc to document selector/executor batching separation

## Test plan

- [x] `npx nx typecheck pipeline` passes
- [x] `npx nx lint pipeline` passes  
- [x] `npx nx test pipeline` — 82 tests pass
- [x] `npx nx test pipeline-void` — 25 tests pass (no regressions)