### PR TITLE
fix(release): only mark projects affected by their own dependency updates

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -14,6 +14,11 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
+  "pluginsConfig": {
+    "@nx/js": {
+      "projectsAffectedByDependencyUpdates": "auto"
+    }
+  },
   "plugins": [
     {
       "plugin": "@nx/js/typescript",


### PR DESCRIPTION
## Summary

- Set `projectsAffectedByDependencyUpdates` to `"auto"` in `nx.json`
- Lock file changes now only affect projects that actually depend on the updated packages, instead of all projects

## Problem

Any `feat` or `fix` commit that modified `package-lock.json` (e.g. by adding a dependency to one package) caused `nx release` to bump **all** packages, because Nx's default affected detection treats lock file changes as affecting every project.

This led to cascading releases where a single `feat(pipeline)` commit released all 16 packages.

## Test plan

- [x] `npx nx show projects --affected --base=f0dcf9a --head=d997ee2` now returns only `@lde/pipeline` and `@lde/pipeline-void` instead of all 17 projects