### PR TITLE
feat(pipeline): wire selector bindings into executor via VALUES injection

### DIFF
--- a/packages/pipeline/src/sparql/index.ts
+++ b/packages/pipeline/src/sparql/index.ts
@@ -8,6 +8,7 @@ export {
   type SparqlConstructExecuteOptions,
   type SparqlConstructExecutorOptions,
   type QuadStream,
+  type VariableBindings,
 } from './executor.js';
 
 export { collect } from './collect.js';

--- a/packages/pipeline/src/sparql/selector.ts
+++ b/packages/pipeline/src/sparql/selector.ts
@@ -7,7 +7,8 @@ import {
   type Variable,
   type VariableTerm,
 } from 'sparqljs';
-import type { StageSelectorBindings, StageSelector } from '../stage.js';
+import type { StageSelector } from '../stage.js';
+import type { VariableBindings } from './executor.js';
 
 const parser = new Parser();
 const generator = new Generator();
@@ -57,7 +58,7 @@ export class SparqlSelector implements StageSelector {
     this.fetcher = options.fetcher ?? new SparqlEndpointFetcher();
   }
 
-  async *[Symbol.asyncIterator](): AsyncIterableIterator<StageSelectorBindings> {
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<VariableBindings> {
     let offset = 0;
 
     while (true) {
@@ -76,7 +77,7 @@ export class SparqlSelector implements StageSelector {
           Object.entries(record).filter(
             ([, term]) => term.termType === 'NamedNode'
           )
-        ) as StageSelectorBindings;
+        ) as VariableBindings;
 
         if (Object.keys(row).length > 0) {
           yield row;

--- a/packages/pipeline/src/sparql/values.ts
+++ b/packages/pipeline/src/sparql/values.ts
@@ -1,5 +1,5 @@
 import type { ConstructQuery, ValuesPattern } from 'sparqljs';
-import type { StageSelectorBindings } from '../stage.js';
+import type { VariableBindings } from './executor.js';
 
 /**
  * Inject a VALUES clause into a parsed CONSTRUCT query for the given binding rows.
@@ -12,7 +12,7 @@ import type { StageSelectorBindings } from '../stage.js';
  */
 export function injectValues(
   query: ConstructQuery,
-  bindings: StageSelectorBindings[]
+  bindings: VariableBindings[]
 ): ConstructQuery {
   const valuesPattern: ValuesPattern = {
     type: 'values',

--- a/packages/pipeline/test/sparql/selector.test.ts
+++ b/packages/pipeline/test/sparql/selector.test.ts
@@ -1,5 +1,6 @@
 import { SparqlSelector } from '../../src/sparql/selector.js';
-import type { StageSelector, StageSelectorBindings } from '../../src/stage.js';
+import type { StageSelector } from '../../src/stage.js';
+import type { VariableBindings } from '../../src/sparql/executor.js';
 import { describe, it, expect, vi } from 'vitest';
 import { Readable } from 'node:stream';
 import { DataFactory } from 'n3';
@@ -45,7 +46,7 @@ describe('SparqlSelector', () => {
       fetcher: mockFetcher as never,
     });
 
-    const rows: StageSelectorBindings[] = [];
+    const rows: VariableBindings[] = [];
     for await (const row of selector) {
       rows.push(row);
     }
@@ -79,7 +80,7 @@ describe('SparqlSelector', () => {
       fetcher: mockFetcher as never,
     });
 
-    const rows: StageSelectorBindings[] = [];
+    const rows: VariableBindings[] = [];
     for await (const row of selector) {
       rows.push(row);
     }
@@ -163,7 +164,7 @@ describe('SparqlSelector', () => {
       fetcher: mockFetcher as never,
     });
 
-    const rows: StageSelectorBindings[] = [];
+    const rows: VariableBindings[] = [];
     for await (const row of selector) {
       rows.push(row);
     }
@@ -266,7 +267,7 @@ describe('SparqlSelector', () => {
       fetcher: mockFetcher as never,
     });
 
-    const rows: StageSelectorBindings[] = [];
+    const rows: VariableBindings[] = [];
     for await (const row of selector) {
       rows.push(row);
     }
@@ -294,7 +295,7 @@ describe('SparqlSelector', () => {
       fetcher: mockFetcher as never,
     });
 
-    const rows: StageSelectorBindings[] = [];
+    const rows: VariableBindings[] = [];
     for await (const row of selector) {
       rows.push(row);
     }
@@ -341,7 +342,7 @@ describe('SparqlSelector', () => {
       fetcher: mockFetcher as never,
     });
 
-    const rows: StageSelectorBindings[] = [];
+    const rows: VariableBindings[] = [];
     for await (const row of selector) {
       rows.push(row);
     }

--- a/packages/pipeline/test/stage.test.ts
+++ b/packages/pipeline/test/stage.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { DataFactory } from 'n3';
 import type { Quad } from '@rdfjs/types';
 import { Stage } from '../src/stage.js';
-import type { Executor, ExecutableDataset } from '../src/sparql/executor.js';
+import type { StageSelector } from '../src/stage.js';
+import type {
+  Executor,
+  ExecutableDataset,
+  SparqlConstructExecuteOptions,
+} from '../src/sparql/executor.js';
 import { NotSupported } from '../src/sparql/executor.js';
 import { Dataset } from '@lde/dataset';
 
@@ -26,7 +31,10 @@ const q3 = quad(
 
 function mockExecutor(quads: Quad[]): Executor {
   return {
-    async execute(): Promise<AsyncIterable<Quad> | NotSupported> {
+    async execute(
+      _dataset: ExecutableDataset,
+      _options?: SparqlConstructExecuteOptions
+    ): Promise<AsyncIterable<Quad> | NotSupported> {
       return (async function* () {
         yield* quads;
       })();
@@ -34,10 +42,38 @@ function mockExecutor(quads: Quad[]): Executor {
   };
 }
 
+function capturingExecutor(quads: Quad[]): Executor & {
+  execute: ReturnType<typeof vi.fn>;
+} {
+  const executor = {
+    execute: vi.fn(
+      async (
+        _dataset: ExecutableDataset,
+        _options?: SparqlConstructExecuteOptions
+      ): Promise<AsyncIterable<Quad> | NotSupported> => {
+        return (async function* () {
+          yield* quads;
+        })();
+      }
+    ),
+  };
+  return executor;
+}
+
 function notSupportedExecutor(message = 'not supported'): Executor {
   return {
     async execute(): Promise<AsyncIterable<Quad> | NotSupported> {
       return new NotSupported(message);
+    },
+  };
+}
+
+function mockSelector(
+  rows: Record<string, ReturnType<typeof namedNode>>[]
+): StageSelector {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* rows;
     },
   };
 }
@@ -123,5 +159,57 @@ describe('Stage', () => {
     expect((result as NotSupported).message).toBe(
       'All executors returned NotSupported'
     );
+  });
+
+  it('passes selector bindings to executors', async () => {
+    const executor = capturingExecutor([q1]);
+    const bindings = [
+      { class: namedNode('http://example.org/Person') },
+      { class: namedNode('http://example.org/Book') },
+    ];
+
+    const stage = new Stage({
+      name: 'test',
+      executors: executor,
+      selector: mockSelector(bindings),
+    });
+
+    const result = await stage.run(dataset);
+    expect(result).not.toBeInstanceOf(NotSupported);
+
+    expect(executor.execute).toHaveBeenCalledWith(dataset, {
+      bindings,
+    });
+  });
+
+  it('does not pass bindings when selector yields nothing', async () => {
+    const executor = capturingExecutor([q1]);
+
+    const stage = new Stage({
+      name: 'test',
+      executors: executor,
+      selector: mockSelector([]),
+    });
+
+    const result = await stage.run(dataset);
+    expect(result).not.toBeInstanceOf(NotSupported);
+
+    expect(executor.execute).toHaveBeenCalledWith(dataset, undefined);
+  });
+
+  it('works without a selector (backward compatibility)', async () => {
+    const executor = capturingExecutor([q1, q2]);
+
+    const stage = new Stage({
+      name: 'test',
+      executors: executor,
+    });
+
+    const result = await stage.run(dataset);
+    expect(result).not.toBeInstanceOf(NotSupported);
+
+    const quads = await collectQuads(result as AsyncIterable<Quad>);
+    expect(quads).toEqual([q1, q2]);
+    expect(executor.execute).toHaveBeenCalledWith(dataset, undefined);
   });
 });

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
       fileParallelism: false,
       coverage: {
         thresholds: {
-          functions: 91.76,
-          lines: 91.53,
-          branches: 81.71,
-          statements: 91.64,
+          functions: 91.86,
+          lines: 91.84,
+          branches: 82.51,
+          statements: 91.94,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Introduce `VariableBindings` type in `executor.ts` as the canonical binding row type; remove `StageSelectorBindings`
- Add `bindings?: VariableBindings[]` to `SparqlConstructExecuteOptions` and the `Executor` interface
- Wire `injectValues(ast, bindings)` in `SparqlConstructExecutor.execute()` — only when bindings are non-empty
- Add optional `selector?: StageSelector` to `Stage`; `run()` collects all binding rows and passes them to each executor
- Update `values.ts`, `selector.ts`, and all tests to use `VariableBindings`
- Export `VariableBindings` from the sparql barrel

## Test plan

- [x] Executor injects VALUES clause when bindings are provided
- [x] Executor omits VALUES clause without bindings or with empty bindings
- [x] Stage passes selector bindings to executors
- [x] Stage does not pass bindings when selector yields nothing
- [x] Stage works without a selector (backward compatibility)
- [x] All 97 existing tests pass