### PR TITLE
build: prevent release cascade by skipping lock file update

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -65,7 +65,10 @@
     "version": {
       "preVersionCommand": "npx nx run-many -t build",
       "conventionalCommits": true,
-      "fallbackCurrentVersionResolver": "disk"
+      "fallbackCurrentVersionResolver": "disk",
+      "versionActionsOptions": {
+        "skipLockFileUpdate": true
+      }
     },
     "changelog": {
       "projectChangelogs": {


### PR DESCRIPTION
## Summary

- Adds `skipLockFileUpdate: true` to `nx.json` release version config to prevent cascading releases of all packages when only one is modified.

**Root cause**: with independent versioning, `nx release` commits update `package-lock.json` (a workspace-root file). Packages that weren't bumped retain stale tags from their last release. When the commit range between a stale tag and HEAD includes a release commit that modifies the lock file, Nx attributes that change to *all* projects, triggering false patch bumps across the board.

**Fix**: `skipLockFileUpdate` ensures release commits only touch bumped packages' `package.json` and `CHANGELOG.md` files, so stale-tagged packages correctly report no changes.

## Test plan

- [x] Verified with dry-run: simulated release commit without lock file + stale tags → only `pipeline` and `pipeline-void` bumped; all 14 other packages reported "No changes detected"
- [ ] Merge and verify next release only bumps affected packages