### PR TITLE
refactor(pipeline-void): replace PerClassAnalyzer with Stage-based factories

### DIFF
--- a/packages/pipeline-void/README.md
+++ b/packages/pipeline-void/README.md
@@ -5,7 +5,16 @@ VOiD (Vocabulary of Interlinked Datasets) statistical analysis for RDF datasets.
 ## Analyzers
 
 - **SparqlQueryAnalyzer** — Execute SPARQL CONSTRUCT queries with template substitution
-- **PerClassAnalyzer** — Two-phase analyzer that iterates over classes to avoid timeouts
+
+## Per-class stages
+
+Factory functions that create `Stage` instances for per-class analysis.
+Each stage first selects classes from the endpoint, then runs a CONSTRUCT query
+with `?class` bound via VALUES:
+
+- `createDatatypeStage` — per-class datatype partitions
+- `createLanguageStage` — per-class language tags
+- `createObjectClassStage` — per-class object class partitions
 
 ## SPARQL Queries
 
@@ -33,14 +42,30 @@ Generic VOiD analysis queries included:
 ## Usage
 
 ```typescript
-import { SparqlQueryAnalyzer } from '@lde/pipeline-void';
+import {
+  SparqlQueryAnalyzer,
+  Success,
+  createDatatypeStage,
+} from '@lde/pipeline-void';
+import { Distribution } from '@lde/dataset';
 
-// Load a query from file
+// Simple CONSTRUCT query analyzer
 const analyzer = await SparqlQueryAnalyzer.fromFile('triples.rq');
-
-// Execute against a dataset
 const result = await analyzer.execute(dataset);
 if (result instanceof Success) {
   // result.data contains the VOiD statistics as RDF
 }
+
+// Per-class stage (streaming)
+const distribution = Distribution.sparql(new URL('http://example.com/sparql'));
+const stage = await createDatatypeStage(distribution);
+const quads = await stage.run(dataset, distribution);
+```
+
+## Validation
+
+```sh
+npx nx test pipeline-void
+npx nx lint pipeline-void
+npx nx typecheck pipeline-void
 ```

--- a/packages/pipeline-void/src/index.ts
+++ b/packages/pipeline-void/src/index.ts
@@ -1,3 +1,4 @@
+export { Stage } from '@lde/pipeline';
 export {
   type Analyzer,
   BaseAnalyzer,

--- a/packages/pipeline-void/src/perClassAnalyzer.ts
+++ b/packages/pipeline-void/src/perClassAnalyzer.ts
@@ -1,176 +1,73 @@
-import { Dataset, Distribution } from '@lde/dataset';
+import { Distribution } from '@lde/dataset';
 import {
+  Stage,
+  SparqlSelector,
   SparqlConstructExecutor,
-  substituteQueryTemplates,
   readQueryFile,
-  collect,
 } from '@lde/pipeline';
-import { Store } from 'n3';
-import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  BaseAnalyzer,
-  Success,
-  Failure,
-  NotSupported,
-} from '@lde/pipeline/analyzer';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export interface PerClassAnalyzerOptions {
-  /**
-   * Timeout for SPARQL queries in milliseconds.
-   * @default 300000 (5 minutes)
-   */
-  timeout?: number;
-  /**
-   * Custom SparqlEndpointFetcher instance.
-   */
-  fetcher?: SparqlEndpointFetcher;
-  /**
-   * Maximum number of classes to analyze.
-   * @default 1000
-   */
-  maxClasses?: number;
-}
-
 /**
- * Two-phase analyzer that first retrieves classes, then runs a query for each class.
+ * Create a Stage that first selects classes from the endpoint,
+ * then runs a per-class CONSTRUCT query with `?class` bound via VALUES.
  *
- * This approach prevents timeouts and OOM errors on large datasets by splitting
- * the analysis into smaller queries per class.
- *
- * Supports legacy template substitution:
- * - `#subjectFilter#` — replaced with the dataset's subject filter (if any)
- * - `#namedGraph#` — replaced with `FROM <graph>` clause if the distribution has a named graph
- * - `?dataset` — replaced with the dataset IRI
- * - `<#class#>` — replaced with the current class IRI
+ * Replaces the legacy `PerClassAnalyzer` two-phase loop with streaming.
  */
-export class PerClassAnalyzer extends BaseAnalyzer {
-  private readonly fetcher: SparqlEndpointFetcher;
-  private readonly query: string;
-  private readonly maxClasses: number;
+async function createPerClassStage(
+  queryFilename: string,
+  distribution: Distribution
+): Promise<Stage> {
+  const rawQuery = await readQueryFile(
+    resolve(__dirname, 'queries', queryFilename)
+  );
 
-  constructor(
-    public readonly name: string,
-    query: string,
-    options?: PerClassAnalyzerOptions
-  ) {
-    super();
-    this.query = query;
-    this.fetcher =
-      options?.fetcher ??
-      new SparqlEndpointFetcher({
-        timeout: options?.timeout ?? 300_000,
-      });
-    this.maxClasses = options?.maxClasses ?? 1000;
-  }
+  // Pre-process #subjectFilter# before the query is parsed as SPARQL.
+  const subjectFilter = distribution.subjectFilter ?? '';
+  const query = rawQuery.replace('#subjectFilter#', subjectFilter);
 
-  /**
-   * Create an analyzer from a query file in the queries directory.
-   *
-   * @param filename Query filename (e.g., 'class-property-datatypes.rq')
-   * @param options Optional analyzer options
-   */
-  public static async fromFile(
-    filename: string,
-    options?: PerClassAnalyzerOptions
-  ): Promise<PerClassAnalyzer> {
-    const query = await readQueryFile(resolve(__dirname, 'queries', filename));
-    return new PerClassAnalyzer(filename, query, options);
-  }
+  // Build the selector SELECT query (same substitution for subjectFilter).
+  const fromClause = distribution.namedGraph
+    ? `FROM <${distribution.namedGraph}>`
+    : '';
+  const selectorQuery = [
+    'SELECT DISTINCT ?class',
+    fromClause,
+    `WHERE { ${subjectFilter} ?s a ?class . }`,
+    'LIMIT 1000',
+  ].join('\n');
 
-  public async execute(
-    dataset: Dataset
-  ): Promise<Success | Failure | NotSupported> {
-    const sparqlDistribution = dataset.getSparqlDistribution();
-    if (sparqlDistribution === null) {
-      return new NotSupported('No SPARQL distribution available');
-    }
+  const selector = new SparqlSelector({
+    query: selectorQuery,
+    endpoint: distribution.accessUrl!,
+    pageSize: 1000,
+  });
 
-    const store = new Store();
+  const executor = new SparqlConstructExecutor({ query });
 
-    try {
-      // Phase 1: Get all classes.
-      const classes = await this.getClasses(sparqlDistribution, dataset);
-
-      // Phase 2: Run query for each class.
-      for (const classIri of classes) {
-        const substituted = substituteQueryTemplates(
-          this.query.replaceAll('<#class#>', `<${classIri}>`),
-          sparqlDistribution,
-          dataset
-        );
-        const executor = new SparqlConstructExecutor({
-          query: substituted,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          fetcher: this.fetcher as any,
-        });
-        const stream = await executor.execute(dataset, sparqlDistribution);
-        store.addQuads([...(await collect(stream))]);
-      }
-    } catch (e) {
-      const accessUrl = sparqlDistribution.accessUrl;
-      return new Failure(
-        accessUrl ?? new URL('unknown://'),
-        e instanceof Error ? e.message : undefined
-      );
-    }
-
-    return new Success(store);
-  }
-
-  private async getClasses(
-    distribution: Distribution,
-    dataset: Dataset
-  ): Promise<string[]> {
-    const classQuery = substituteQueryTemplates(
-      `SELECT DISTINCT ?class
-       #namedGraph#
-       WHERE {
-         #subjectFilter#
-         ?s a ?class .
-       }
-       LIMIT ${this.maxClasses}`,
-      distribution,
-      dataset
-    );
-
-    const bindings = await this.fetcher.fetchBindings(
-      distribution.accessUrl!.toString(),
-      classQuery
-    );
-    const classes: string[] = [];
-    for await (const binding of bindings) {
-      // Bindings are Record<string, RDF.Term>.
-      const bindingRecord = binding as unknown as Record<
-        string,
-        { termType: string; value: string }
-      >;
-      const classValue = bindingRecord['class'];
-      if (classValue && classValue.termType === 'NamedNode') {
-        classes.push(classValue.value);
-      }
-    }
-    return classes;
-  }
+  return new Stage({
+    name: queryFilename,
+    selector,
+    executors: executor,
+  });
 }
 
-export function createDatatypeAnalyzer(
-  options?: PerClassAnalyzerOptions
-): Promise<PerClassAnalyzer> {
-  return PerClassAnalyzer.fromFile('class-property-datatypes.rq', options);
+export function createDatatypeStage(
+  distribution: Distribution
+): Promise<Stage> {
+  return createPerClassStage('class-property-datatypes.rq', distribution);
 }
 
-export function createLanguageAnalyzer(
-  options?: PerClassAnalyzerOptions
-): Promise<PerClassAnalyzer> {
-  return PerClassAnalyzer.fromFile('class-property-languages.rq', options);
+export function createLanguageStage(
+  distribution: Distribution
+): Promise<Stage> {
+  return createPerClassStage('class-property-languages.rq', distribution);
 }
 
-export function createObjectClassAnalyzer(
-  options?: PerClassAnalyzerOptions
-): Promise<PerClassAnalyzer> {
-  return PerClassAnalyzer.fromFile('class-property-object-classes.rq', options);
+export function createObjectClassStage(
+  distribution: Distribution
+): Promise<Stage> {
+  return createPerClassStage('class-property-object-classes.rq', distribution);
 }

--- a/packages/pipeline-void/src/queries/class-property-datatypes.rq
+++ b/packages/pipeline-void/src/queries/class-property-datatypes.rq
@@ -7,14 +7,13 @@ CONSTRUCT {
       void-ext:datatype ?dt ;
       void:triples ?count .
 }
-#namedGraph#
 WHERE {
   {
     SELECT ?p ?dt (COUNT(*) AS ?count) {
       {
         SELECT ?p ?o {
           #subjectFilter#
-          ?s a <#class#> ;
+          ?s a ?class ;
             ?p ?o .
           FILTER (ISLITERAL(?o))
         }
@@ -23,7 +22,7 @@ WHERE {
     }
     GROUP BY ?p ?dt
   }
-  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(<#class#>), STR(?p))))) AS ?propertyPartition)
-  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#datatype-", MD5(CONCAT(STR(<#class#>), STR(?p), STR(?dt))))) AS ?datatypePartition)
+  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(?class), STR(?p))))) AS ?propertyPartition)
+  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#datatype-", MD5(CONCAT(STR(?class), STR(?p), STR(?dt))))) AS ?datatypePartition)
 }
 LIMIT 100000

--- a/packages/pipeline-void/src/queries/class-property-languages.rq
+++ b/packages/pipeline-void/src/queries/class-property-languages.rq
@@ -7,7 +7,6 @@ CONSTRUCT {
     void-ext:language ?lang ;
     void:triples ?count .
 }
-#namedGraph#
 WHERE {
   {
     SELECT ?p ?lang (COUNT(*) AS ?count) {
@@ -15,7 +14,7 @@ WHERE {
         # Pre-filter to distinct literals to minimize LANG calls
         SELECT DISTINCT ?p ?o {
           #subjectFilter#
-          ?s a <#class#> ;
+          ?s a ?class ;
             ?p ?o .
           FILTER(ISLITERAL(?o))
         }
@@ -25,7 +24,7 @@ WHERE {
     }
     GROUP BY ?p ?lang
   }
-  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(<#class#>), STR(?p))))) AS ?propertyPartition)
-  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#language-", MD5(CONCAT(STR(<#class#>), STR(?p), ?lang)))) AS ?languagePartition)
+  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(?class), STR(?p))))) AS ?propertyPartition)
+  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#language-", MD5(CONCAT(STR(?class), STR(?p), ?lang)))) AS ?languagePartition)
 }
 LIMIT 100000

--- a/packages/pipeline-void/src/queries/class-property-object-classes.rq
+++ b/packages/pipeline-void/src/queries/class-property-object-classes.rq
@@ -7,14 +7,13 @@ CONSTRUCT {
       void:class ?objectClass ;
       void:triples ?count .
 }
-#namedGraph#
 WHERE {
   {
     SELECT ?p ?objectClass (COUNT(*) AS ?count) {
       {
         SELECT ?p ?o {
           #subjectFilter#
-          ?s a <#class#> ;
+          ?s a ?class ;
             ?p ?o .
           FILTER (ISIRI(?o))
         }
@@ -23,7 +22,7 @@ WHERE {
     }
     GROUP BY ?p ?objectClass
   }
-  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(<#class#>), STR(?p))))) AS ?propertyPartition)
-  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#object-class-", MD5(CONCAT(STR(<#class#>), STR(?p), STR(?objectClass))))) AS ?objectClassPartition)
+  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(?class), STR(?p))))) AS ?propertyPartition)
+  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#object-class-", MD5(CONCAT(STR(?class), STR(?p), STR(?objectClass))))) AS ?objectClassPartition)
 }
 LIMIT 100000

--- a/packages/pipeline-void/test/datatypeAnalyzer.test.ts
+++ b/packages/pipeline-void/test/datatypeAnalyzer.test.ts
@@ -1,11 +1,16 @@
-import { createDatatypeAnalyzer, PerClassAnalyzer } from '../src/index.js';
+import { createDatatypeStage, Stage } from '../src/index.js';
+import { Distribution } from '@lde/dataset';
 import { describe, it, expect } from 'vitest';
 
-describe('createDatatypeAnalyzer', () => {
-  it('creates an analyzer with the correct query file', async () => {
-    const analyzer = await createDatatypeAnalyzer();
+describe('createDatatypeStage', () => {
+  it('creates a stage with the correct query file', async () => {
+    const distribution = Distribution.sparql(
+      new URL('http://example.com/sparql')
+    );
 
-    expect(analyzer.name).toBe('class-property-datatypes.rq');
-    expect(analyzer).toBeInstanceOf(PerClassAnalyzer);
+    const stage = await createDatatypeStage(distribution);
+
+    expect(stage.name).toBe('class-property-datatypes.rq');
+    expect(stage).toBeInstanceOf(Stage);
   });
 });

--- a/packages/pipeline-void/test/languageAnalyzer.test.ts
+++ b/packages/pipeline-void/test/languageAnalyzer.test.ts
@@ -1,11 +1,16 @@
-import { createLanguageAnalyzer, PerClassAnalyzer } from '../src/index.js';
+import { createLanguageStage, Stage } from '../src/index.js';
+import { Distribution } from '@lde/dataset';
 import { describe, it, expect } from 'vitest';
 
-describe('createLanguageAnalyzer', () => {
-  it('creates an analyzer with the correct query file', async () => {
-    const analyzer = await createLanguageAnalyzer();
+describe('createLanguageStage', () => {
+  it('creates a stage with the correct query file', async () => {
+    const distribution = Distribution.sparql(
+      new URL('http://example.com/sparql')
+    );
 
-    expect(analyzer.name).toBe('class-property-languages.rq');
-    expect(analyzer).toBeInstanceOf(PerClassAnalyzer);
+    const stage = await createLanguageStage(distribution);
+
+    expect(stage.name).toBe('class-property-languages.rq');
+    expect(stage).toBeInstanceOf(Stage);
   });
 });

--- a/packages/pipeline-void/test/objectClassAnalyzer.test.ts
+++ b/packages/pipeline-void/test/objectClassAnalyzer.test.ts
@@ -1,11 +1,16 @@
-import { createObjectClassAnalyzer, PerClassAnalyzer } from '../src/index.js';
+import { createObjectClassStage, Stage } from '../src/index.js';
+import { Distribution } from '@lde/dataset';
 import { describe, it, expect } from 'vitest';
 
-describe('createObjectClassAnalyzer', () => {
-  it('creates an analyzer with the correct query file', async () => {
-    const analyzer = await createObjectClassAnalyzer();
+describe('createObjectClassStage', () => {
+  it('creates a stage with the correct query file', async () => {
+    const distribution = Distribution.sparql(
+      new URL('http://example.com/sparql')
+    );
 
-    expect(analyzer.name).toBe('class-property-object-classes.rq');
-    expect(analyzer).toBeInstanceOf(PerClassAnalyzer);
+    const stage = await createObjectClassStage(distribution);
+
+    expect(stage.name).toBe('class-property-object-classes.rq');
+    expect(stage).toBeInstanceOf(Stage);
   });
 });

--- a/packages/pipeline-void/test/perClassAnalyzer.test.ts
+++ b/packages/pipeline-void/test/perClassAnalyzer.test.ts
@@ -1,134 +1,55 @@
-import { PerClassAnalyzer, Success, NotSupported } from '../src/index.js';
-import { Dataset, Distribution } from '@lde/dataset';
-import { describe, it, expect, vi } from 'vitest';
-import { Readable } from 'node:stream';
-import { DataFactory } from 'n3';
+import {
+  createDatatypeStage,
+  createLanguageStage,
+  createObjectClassStage,
+  Stage,
+} from '../src/index.js';
+import { Distribution } from '@lde/dataset';
+import { describe, it, expect } from 'vitest';
 
-const { namedNode, literal, quad } = DataFactory;
+describe('per-class stages', () => {
+  const distribution = Distribution.sparql(
+    new URL('http://example.com/sparql')
+  );
 
-describe('PerClassAnalyzer', () => {
-  function createDataset(sparqlEndpoint?: string): Dataset {
-    const distributions: Distribution[] = [];
-    if (sparqlEndpoint) {
-      distributions.push(Distribution.sparql(new URL(sparqlEndpoint)));
-    }
-    return new Dataset({
-      iri: new URL('http://example.com/dataset/1'),
-      distributions,
-    });
-  }
+  it('createDatatypeStage returns a Stage', async () => {
+    const stage = await createDatatypeStage(distribution);
 
-  describe('execute', () => {
-    it('returns NotSupported when no SPARQL distribution', async () => {
-      const analyzer = new PerClassAnalyzer(
-        'test',
-        'CONSTRUCT { ?s ?p ?o } WHERE { ?s a <#class#> ; ?p ?o } LIMIT 1'
-      );
-
-      const result = await analyzer.execute(createDataset());
-
-      expect(result).toBeInstanceOf(NotSupported);
-    });
-
-    it('executes query for each class', async () => {
-      const mockFetcher = {
-        fetchBindings: vi.fn().mockImplementation(() => {
-          const stream = new Readable({
-            objectMode: true,
-            read() {
-              /* no-op */
-            },
-          });
-          // Return Record<string, RDF.Term> format (not Map).
-          stream.push({ class: namedNode('http://example.com/Class1') });
-          stream.push({ class: namedNode('http://example.com/Class2') });
-          stream.push(null);
-          return Promise.resolve(stream);
-        }),
-        fetchTriples: vi.fn().mockImplementation(() => {
-          const stream = new Readable({
-            objectMode: true,
-            read() {
-              /* no-op */
-            },
-          });
-          stream.push(
-            quad(
-              namedNode('http://example.com/s'),
-              namedNode('http://example.com/p'),
-              literal('o')
-            )
-          );
-          stream.push(null);
-          return Promise.resolve(stream);
-        }),
-      };
-
-      const analyzer = new PerClassAnalyzer(
-        'test',
-        'CONSTRUCT { ?s ?p ?o } WHERE { ?s a <#class#> ; ?p ?o }',
-        { fetcher: mockFetcher as never }
-      );
-
-      const result = await analyzer.execute(
-        createDataset('http://example.com/sparql')
-      );
-
-      expect(result).toBeInstanceOf(Success);
-      // Called twice, once for each class.
-      expect(mockFetcher.fetchTriples).toHaveBeenCalledTimes(2);
-    });
-
-    it('substitutes class IRI in query', async () => {
-      const queries: string[] = [];
-      const mockFetcher = {
-        fetchBindings: vi.fn().mockImplementation(() => {
-          const stream = new Readable({
-            objectMode: true,
-            read() {
-              /* no-op */
-            },
-          });
-          // Return Record<string, RDF.Term> format (not Map).
-          stream.push({ class: namedNode('http://example.com/Person') });
-          stream.push(null);
-          return Promise.resolve(stream);
-        }),
-        fetchTriples: vi
-          .fn()
-          .mockImplementation((_endpoint: string, query: string) => {
-            queries.push(query);
-            const stream = new Readable({
-              objectMode: true,
-              read() {
-                /* no-op */
-              },
-            });
-            stream.push(null);
-            return Promise.resolve(stream);
-          }),
-      };
-
-      const analyzer = new PerClassAnalyzer(
-        'test',
-        'CONSTRUCT { ?s a <#class#> } WHERE { ?s a <#class#> }',
-        { fetcher: mockFetcher as never }
-      );
-
-      await analyzer.execute(createDataset('http://example.com/sparql'));
-
-      expect(queries[0]).toContain('<http://example.com/Person>');
-      expect(queries[0]).not.toContain('<#class#>');
-    });
+    expect(stage).toBeInstanceOf(Stage);
+    expect(stage.name).toBe('class-property-datatypes.rq');
   });
 
-  describe('fromFile', () => {
-    it('loads query from file', async () => {
-      const analyzer = await PerClassAnalyzer.fromFile(
-        'class-property-datatypes.rq'
-      );
+  it('createLanguageStage returns a Stage', async () => {
+    const stage = await createLanguageStage(distribution);
 
-      expect(analyzer.name).toBe('class-property-datatypes.rq');
-    });
+    expect(stage).toBeInstanceOf(Stage);
+    expect(stage.name).toBe('class-property-languages.rq');
+  });
+
+  it('createObjectClassStage returns a Stage', async () => {
+    const stage = await createObjectClassStage(distribution);
+
+    expect(stage).toBeInstanceOf(Stage);
+    expect(stage.name).toBe('class-property-object-classes.rq');
+  });
+
+  it('accepts a distribution with subjectFilter', async () => {
+    const filtered = Distribution.sparql(new URL('http://example.com/sparql'));
+    filtered.subjectFilter = '?s <http://example.com/inDataset> ?dataset .';
+
+    const stage = await createDatatypeStage(filtered);
+
+    expect(stage).toBeInstanceOf(Stage);
+  });
+
+  it('accepts a distribution with namedGraph', async () => {
+    const graphDist = Distribution.sparql(
+      new URL('http://example.com/sparql'),
+      'http://example.com/graph'
+    );
+
+    const stage = await createDatatypeStage(graphDist);
+
+    expect(stage).toBeInstanceOf(Stage);
   });
 });

--- a/packages/pipeline-void/vite.config.ts
+++ b/packages/pipeline-void/vite.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           functions: 100,
-          lines: 97.84,
-          branches: 76.66,
-          statements: 97.84,
+          lines: 100,
+          branches: 88.88,
+          statements: 100,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Replace `PerClassAnalyzer` class with `createDatatypeStage`, `createLanguageStage`, `createObjectClassStage` factory functions that return `Stage` instances
- Compose `SparqlSelector` + `SparqlConstructExecutor` from `@lde/pipeline` instead of a custom two-phase SELECT→CONSTRUCT loop
- Replace `<#class#>` template with `?class` SPARQL variable in per-class query files, bound via VALUES clause at execution time
- Remove `#namedGraph#` from query files (executor handles `FROM` via AST with `withDefaultGraph`)
- Stream quads instead of materializing into N3 `Store`

## Test plan

- [x] `npx nx test pipeline-void` — 26 tests pass
- [x] `npx nx lint pipeline-void` — no errors
- [x] `npx nx typecheck pipeline-void` — no type errors
- [x] `npx nx build pipeline-void` — builds cleanly