### PR TITLE
refactor(pipeline-void): replace Analyzer classes with Stage factories and streaming transformers

### DIFF
--- a/packages/pipeline-void/package.json
+++ b/packages/pipeline-void/package.json
@@ -27,7 +27,6 @@
     "@lde/dataset": "0.6.8",
     "@lde/pipeline": "0.6.15",
     "@rdfjs/types": "^2.0.1",
-    "fetch-sparql-endpoint": "^6.0.0",
     "n3": "^1.17.0",
     "tslib": "^2.3.0"
   }

--- a/packages/pipeline-void/src/index.ts
+++ b/packages/pipeline-void/src/index.ts
@@ -1,11 +1,4 @@
-export { Stage } from '@lde/pipeline';
-export {
-  type Analyzer,
-  BaseAnalyzer,
-  Success,
-  Failure,
-  NotSupported,
-} from '@lde/pipeline/analyzer';
+export { Stage, NotSupported } from '@lde/pipeline';
 export * from './sparqlQueryAnalyzer.js';
 export * from './perClassAnalyzer.js';
 export * from './vocabularyAnalyzer.js';

--- a/packages/pipeline-void/src/queries/class-partition.rq
+++ b/packages/pipeline-void/src/queries/class-partition.rq
@@ -6,7 +6,6 @@ CONSTRUCT {
     ?classPartition void:class ?type ;
         void:entities ?entities .
 }
-#namedGraph#
 WHERE {
     {
         SELECT (COUNT(?type) AS ?entities) ?type {

--- a/packages/pipeline-void/src/queries/class-properties-objects.rq
+++ b/packages/pipeline-void/src/queries/class-properties-objects.rq
@@ -3,7 +3,6 @@ PREFIX void: <http://rdfs.org/ns/void#>
 CONSTRUCT {
     ?propertyPartition void:distinctObjects ?objects .
 }
-#namedGraph#
 WHERE {
     # Object counts only. Subject counts in class-properties-subjects.rq.
     {

--- a/packages/pipeline-void/src/queries/class-properties-subjects.rq
+++ b/packages/pipeline-void/src/queries/class-properties-subjects.rq
@@ -8,7 +8,6 @@ CONSTRUCT {
     ?propertyPartition void:property ?p ;
         void:entities ?subjects .
 }
-#namedGraph#
 WHERE {
     # Subject counts only. Object counts in class-properties-objects.rq.
     {

--- a/packages/pipeline-void/src/queries/datatypes.rq
+++ b/packages/pipeline-void/src/queries/datatypes.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
   ?dataset void-ext:datatypes ?count ;
     void-ext:datatype ?datatype .
 }
-#namedGraph#
 WHERE {
   {
     # Count distinct datatypes

--- a/packages/pipeline-void/src/queries/entity-properties.rq
+++ b/packages/pipeline-void/src/queries/entity-properties.rq
@@ -8,7 +8,6 @@ CONSTRUCT {
         void:entities ?subjects ;
         void:distinctObjects ?objects .
 }
-#namedGraph#
 WHERE {
     {
         SELECT (COUNT(DISTINCT ?s) AS ?subjects) (COUNT(DISTINCT ?o) as ?objects) ?p {

--- a/packages/pipeline-void/src/queries/licenses.rq
+++ b/packages/pipeline-void/src/queries/licenses.rq
@@ -11,7 +11,6 @@ CONSTRUCT {
         dcterms:license ?license ;
         void:triples ?count .
 }
-#namedGraph#
 WHERE {
     {
         SELECT (IRI(?l) AS ?license) (COUNT(*) AS ?count) {

--- a/packages/pipeline-void/src/queries/object-literals.rq
+++ b/packages/pipeline-void/src/queries/object-literals.rq
@@ -5,7 +5,6 @@ CONSTRUCT {
     ?dataset a void:Dataset ;
         void-ext:distinctLiterals ?distinctLiterals .
 }
-#namedGraph#
 WHERE {
     SELECT (COUNT(DISTINCT ?o) AS ?distinctLiterals) {
         #subjectFilter#

--- a/packages/pipeline-void/src/queries/object-uri-space.rq
+++ b/packages/pipeline-void/src/queries/object-uri-space.rq
@@ -6,7 +6,6 @@ CONSTRUCT {
         void:objectsTarget ?prefix ;
         void:triples ?count .
 }
-#namedGraph#
 WHERE {
     {
         SELECT ?prefix (SUM(?ocount) AS ?count) {

--- a/packages/pipeline-void/src/queries/object-uris.rq
+++ b/packages/pipeline-void/src/queries/object-uris.rq
@@ -5,7 +5,6 @@ CONSTRUCT {
     ?dataset a void:Dataset ;
         void-ext:distinctIRIReferenceObjects ?distinctIRIReferenceObjects .
 }
-#namedGraph#
 WHERE {
     SELECT (COUNT(DISTINCT ?o) AS ?distinctIRIReferenceObjects) {
         #subjectFilter#

--- a/packages/pipeline-void/src/queries/properties.rq
+++ b/packages/pipeline-void/src/queries/properties.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
     ?dataset a void:Dataset ;
         void:properties ?count .
 }
-#namedGraph#
 WHERE {
     SELECT (COUNT(DISTINCT ?p) as ?count) {
         #subjectFilter#

--- a/packages/pipeline-void/src/queries/subject-uri-space.rq
+++ b/packages/pipeline-void/src/queries/subject-uri-space.rq
@@ -6,7 +6,6 @@ CONSTRUCT {
     ?subset void:uriSpace ?uriSpace ;
         void:entities ?count .
 }
-#namedGraph#
 WHERE {
     {
         # Pre-group distinct subjects before computing namespace to avoid regex on every triple.

--- a/packages/pipeline-void/src/queries/subjects.rq
+++ b/packages/pipeline-void/src/queries/subjects.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
     ?dataset a void:Dataset ;
         void:distinctSubjects ?count .
 }
-#namedGraph#
 WHERE {
     SELECT (COUNT(DISTINCT ?s) as ?count) {
         #subjectFilter#

--- a/packages/pipeline-void/src/queries/triples.rq
+++ b/packages/pipeline-void/src/queries/triples.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
     ?dataset a void:Dataset ;
         void:triples ?count .
 }
-#namedGraph#
 WHERE {
     SELECT (COUNT(*) as ?count) {
         #subjectFilter#

--- a/packages/pipeline-void/test/sparqlQueryAnalyzer.test.ts
+++ b/packages/pipeline-void/test/sparqlQueryAnalyzer.test.ts
@@ -1,135 +1,40 @@
-import {
-  SparqlQueryAnalyzer,
-  Success,
-  Failure,
-  NotSupported,
-} from '../src/index.js';
-import { Dataset, Distribution } from '@lde/dataset';
-import { describe, it, expect, vi } from 'vitest';
-import { Readable } from 'node:stream';
-import { DataFactory } from 'n3';
+import { createQueryStage, Stage } from '../src/index.js';
+import { Distribution } from '@lde/dataset';
+import { describe, it, expect } from 'vitest';
 
-const { namedNode, literal, quad } = DataFactory;
+describe('createQueryStage', () => {
+  const distribution = Distribution.sparql(
+    new URL('http://example.com/sparql')
+  );
 
-describe('SparqlQueryAnalyzer', () => {
-  function createDataset(sparqlEndpoint?: string): Dataset {
-    const distributions: Distribution[] = [];
-    if (sparqlEndpoint) {
-      distributions.push(Distribution.sparql(new URL(sparqlEndpoint)));
-    }
-    return new Dataset({
-      iri: new URL('http://example.com/dataset/1'),
-      distributions,
-    });
-  }
+  it('returns a Stage with the query filename as name', async () => {
+    const stage = await createQueryStage('triples.rq', distribution);
 
-  describe('execute', () => {
-    it('returns NotSupported when no SPARQL distribution', async () => {
-      const analyzer = new SparqlQueryAnalyzer(
-        'test',
-        'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o } LIMIT 1'
-      );
-
-      const result = await analyzer.execute(createDataset());
-
-      expect(result).toBeInstanceOf(NotSupported);
-      expect((result as NotSupported).message).toBe(
-        'No SPARQL distribution available'
-      );
-    });
-
-    it('executes query and returns Success with data', async () => {
-      const mockFetcher = {
-        fetchTriples: vi.fn().mockImplementation(() => {
-          const stream = new Readable({
-            objectMode: true,
-            read() {
-              /* no-op */
-            },
-          });
-          stream.push(
-            quad(
-              namedNode('http://example.com/s'),
-              namedNode('http://example.com/p'),
-              literal('o')
-            )
-          );
-          stream.push(null);
-          return Promise.resolve(stream);
-        }),
-      };
-
-      const analyzer = new SparqlQueryAnalyzer(
-        'test',
-        'CONSTRUCT { ?dataset a <http://rdfs.org/ns/void#Dataset> } WHERE { ?s ?p ?o } LIMIT 1',
-        { fetcher: mockFetcher as never }
-      );
-
-      const result = await analyzer.execute(
-        createDataset('http://example.com/sparql')
-      );
-
-      expect(result).toBeInstanceOf(Success);
-      expect([...(result as Success).data]).toHaveLength(1);
-    });
-
-    it('substitutes template variables in query', async () => {
-      let executedQuery = '';
-      const mockFetcher = {
-        fetchTriples: vi.fn().mockImplementation((_endpoint, query) => {
-          executedQuery = query;
-          const stream = new Readable({
-            objectMode: true,
-            read() {
-              /* no-op */
-            },
-          });
-          stream.push(null);
-          return Promise.resolve(stream);
-        }),
-      };
-
-      const analyzer = new SparqlQueryAnalyzer(
-        'test',
-        'CONSTRUCT { ?dataset a <http://rdfs.org/ns/void#Dataset> } #namedGraph# WHERE { #subjectFilter# ?s ?p ?o }',
-        { fetcher: mockFetcher as never }
-      );
-
-      const dataset = createDataset('http://example.com/sparql');
-
-      await analyzer.execute(dataset);
-
-      expect(executedQuery).toContain('<http://example.com/dataset/1>');
-      expect(executedQuery).not.toContain('?dataset');
-    });
-
-    it('returns Failure on error', async () => {
-      const mockFetcher = {
-        fetchTriples: vi.fn().mockRejectedValue(new Error('Query timeout')),
-      };
-
-      const analyzer = new SparqlQueryAnalyzer(
-        'test',
-        'CONSTRUCT {} WHERE {}',
-        {
-          fetcher: mockFetcher as never,
-        }
-      );
-
-      const result = await analyzer.execute(
-        createDataset('http://example.com/sparql')
-      );
-
-      expect(result).toBeInstanceOf(Failure);
-      expect((result as Failure).message).toBe('Query timeout');
-    });
+    expect(stage).toBeInstanceOf(Stage);
+    expect(stage.name).toBe('triples.rq');
   });
 
-  describe('fromFile', () => {
-    it('loads query from file', async () => {
-      const analyzer = await SparqlQueryAnalyzer.fromFile('triples.rq');
+  it('creates a stage for any query file', async () => {
+    const stage = await createQueryStage('properties.rq', distribution);
 
-      expect(analyzer.name).toBe('triples.rq');
-    });
+    expect(stage).toBeInstanceOf(Stage);
+    expect(stage.name).toBe('properties.rq');
+  });
+
+  it('accepts a distribution with subjectFilter', async () => {
+    const dist = Distribution.sparql(new URL('http://example.com/sparql'));
+    dist.subjectFilter = 'FILTER(?s = <http://example.com/s>)';
+
+    const stage = await createQueryStage('triples.rq', dist);
+
+    expect(stage).toBeInstanceOf(Stage);
+  });
+
+  it('accepts a distribution without subjectFilter', async () => {
+    const dist = Distribution.sparql(new URL('http://example.com/sparql'));
+
+    const stage = await createQueryStage('triples.rq', dist);
+
+    expect(stage).toBeInstanceOf(Stage);
   });
 });

--- a/packages/pipeline-void/vite.config.ts
+++ b/packages/pipeline-void/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 88.88,
+          branches: 100,
           statements: 100,
         },
       },


### PR DESCRIPTION
## Summary

- Replace `SparqlQueryAnalyzer` class with `createQueryStage` factory that returns a `Stage`
- Replace `VocabularyAnalyzer` decorator class with `withVocabularies` async generator transformer
- Convert `withProvenance` from `Store`-based function to streaming async generator
- Remove `#namedGraph#` template line from 13 query files (the executor handles `FROM` via AST with `withDefaultGraph`)
- Remove `Analyzer`/`BaseAnalyzer`/`Success`/`Failure` re-exports from `index.ts`
- Remove `fetch-sparql-endpoint` direct dependency (provided transitively via `@lde/pipeline`)

## Test plan

- [x] `npx nx test pipeline-void` — 24 tests pass, 100% coverage
- [x] `npx nx lint pipeline-void` — clean (pre-existing warning only)
- [x] `npx nx typecheck pipeline-void` — passes
- [x] `npx nx build pipeline-void` — builds cleanly