### PR TITLE
feat(pipeline): batch selector bindings to executor

### DIFF
--- a/packages/pipeline/src/batch.ts
+++ b/packages/pipeline/src/batch.ts
@@ -1,0 +1,20 @@
+/**
+ * Groups items from an async iterable into arrays of at most `size` items.
+ * Yields partial final batches.
+ */
+export async function* batch<T>(
+  iterable: AsyncIterable<T>,
+  size: number
+): AsyncIterable<T[]> {
+  let buffer: T[] = [];
+  for await (const item of iterable) {
+    buffer.push(item);
+    if (buffer.length === size) {
+      yield buffer;
+      buffer = [];
+    }
+  }
+  if (buffer.length > 0) {
+    yield buffer;
+  }
+}

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -1,3 +1,4 @@
+export * from './batch.js';
 export * from './pipeline.js';
 export * from './selector.js';
 export * from './stage.js';

--- a/packages/pipeline/test/batch.test.ts
+++ b/packages/pipeline/test/batch.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { batch } from '../src/batch.js';
+
+async function* fromArray<T>(items: T[]): AsyncIterable<T> {
+  yield* items;
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const item of iterable) {
+    result.push(item);
+  }
+  return result;
+}
+
+describe('batch', () => {
+  it('batches items into groups of the specified size', async () => {
+    const result = await collect(batch(fromArray([1, 2, 3, 4]), 2));
+    expect(result).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it('yields a partial final batch when items do not divide evenly', async () => {
+    const result = await collect(batch(fromArray([1, 2, 3, 4, 5]), 2));
+    expect(result).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it('yields nothing for an empty iterable', async () => {
+    const result = await collect(batch(fromArray([]), 3));
+    expect(result).toEqual([]);
+  });
+
+  it('yields single-item batches when size is 1', async () => {
+    const result = await collect(batch(fromArray([1, 2, 3]), 1));
+    expect(result).toEqual([[1], [2], [3]]);
+  });
+});

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 91.76,
-          lines: 92.3,
-          branches: 83.05,
-          statements: 92.42,
+          functions: 91.86,
+          lines: 92.58,
+          branches: 83.24,
+          statements: 92.69,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Add generic `batch()` async iterable utility that groups items into arrays of at most `size` items
- Add `batchSize` option to `StageOptions` (default: 10) to limit VALUES clause size per executor call
- Replace `collectBindings()` with batched execution: iterate batches from selector, call executor per batch, merge quad streams
- Empty selector now returns `NotSupported` instead of executing with no bindings

This is Phase 2 migration item 4 from the design doc: "Create batching utility for VALUES clause injection". Sequential execution for now; concurrent `Promise.race` model is a separate task.

## Test plan

- [x] `batch()` unit tests: even splits, partial final batches, empty iterables, size-1 batches
- [x] Stage tests updated: single batch, multi-batch, custom batchSize, empty selector
- [x] All 110 pipeline tests pass
- [x] Lint and typecheck clean