### PR TITLE
fix(release): disable useCommitScope to prevent spurious patch releases

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -64,7 +64,9 @@
     "projectsRelationship": "independent",
     "version": {
       "preVersionCommand": "npx nx run-many -t build",
-      "conventionalCommits": true,
+      "conventionalCommits": {
+        "useCommitScope": false
+      },
       "fallbackCurrentVersionResolver": "disk",
       "versionActionsOptions": {
         "skipLockFileUpdate": true


### PR DESCRIPTION
## Summary

- Disable `useCommitScope` in Nx release conventional commits configuration
- With the default `useCommitScope: true`, commits whose scope doesn't match an Nx project name (e.g. `build(deps)`, `feat(pipeline)` vs `@lde/pipeline`) are forced to produce a `patch` bump — regardless of the commit type's `semverBump` setting
- This caused [16 patch releases](https://github.com/ldengine/lde/actions/runs/21982045432) from 8 Dependabot `build(deps)` commits that should have produced no version bump (`build` type has `semverBump: 'none'`)
- With `useCommitScope: false`, Nx relies on file-based affected analysis and respects each type's `semverBump` configuration

## Test plan

- [ ] Verify `npx nx release --dry-run` no longer produces patch bumps for `build(deps)` commits