### PR TITLE
refactor(pipeline): rename selector types for clarity

### DIFF
--- a/packages/pipeline-void/src/perClassAnalyzer.ts
+++ b/packages/pipeline-void/src/perClassAnalyzer.ts
@@ -1,6 +1,6 @@
 import {
   Stage,
-  SparqlSelector,
+  SparqlItemSelector,
   SparqlConstructExecutor,
   readQueryFile,
 } from '@lde/pipeline';
@@ -25,7 +25,7 @@ async function createPerClassStage(queryFilename: string): Promise<Stage> {
 
   return new Stage({
     name: queryFilename,
-    selector: (distribution) => {
+    itemSelector: (distribution) => {
       const subjectFilter = distribution.subjectFilter ?? '';
       const fromClause = distribution.namedGraph
         ? `FROM <${distribution.namedGraph}>`
@@ -37,7 +37,7 @@ async function createPerClassStage(queryFilename: string): Promise<Stage> {
         'LIMIT 1000',
       ].join('\n');
 
-      return new SparqlSelector({
+      return new SparqlItemSelector({
         query: selectorQuery,
         endpoint: distribution.accessUrl!,
         pageSize: 1000,

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -2,7 +2,7 @@ import { createReadStream } from 'node:fs';
 import { Dataset, Distribution } from '@lde/dataset';
 import type { Quad } from '@rdfjs/types';
 import { StreamParser } from 'n3';
-import type { Selector } from './selector.js';
+import type { DatasetSelector } from './selector.js';
 import { Stage } from './stage.js';
 import type { Writer } from './writer/writer.js';
 import { FileWriter } from './writer/fileWriter.js';
@@ -16,7 +16,7 @@ import type { ProgressReporter } from './progressReporter.js';
 
 export interface PipelineOptions {
   name: string;
-  selector: Selector;
+  datasetSelector: DatasetSelector;
   stages: Stage[];
   writer: Writer;
   distributionResolver: DistributionResolver;
@@ -45,12 +45,12 @@ export class Pipeline {
   }
 
   async run(): Promise<void> {
-    const { selector, reporter, name } = this.options;
+    const { datasetSelector, reporter, name } = this.options;
     const start = Date.now();
 
     reporter?.pipelineStart(name);
 
-    const datasets = await selector.select();
+    const datasets = await datasetSelector.select();
     for await (const dataset of datasets) {
       await this.processDataset(dataset);
     }

--- a/packages/pipeline/src/selector.ts
+++ b/packages/pipeline/src/selector.ts
@@ -4,11 +4,11 @@ import { Client, Paginator } from '@lde/dataset-registry-client';
 /**
  * Select {@link Dataset}s for processing in a pipeline.
  */
-export interface Selector {
+export interface DatasetSelector {
   select(): Promise<Paginator<Dataset>>;
 }
 
-export class ManualDatasetSelection implements Selector {
+export class ManualDatasetSelection implements DatasetSelector {
   constructor(private readonly datasets: Dataset[]) {}
 
   async select(): Promise<Paginator<Dataset>> {
@@ -31,7 +31,7 @@ export class ManualDatasetSelection implements Selector {
  * @param string options.query Optional custom SPARQL query to select datasets.
  * @param object options.criteria Optional search criteria to select datasets.
  */
-export class RegistrySelector implements Selector {
+export class RegistrySelector implements DatasetSelector {
   private readonly registry: Client;
   private readonly query?: string;
   private readonly criteria?: object;

--- a/packages/pipeline/src/sparql/index.ts
+++ b/packages/pipeline/src/sparql/index.ts
@@ -8,7 +8,10 @@ export {
   type QuadStream,
   type VariableBindings,
 } from './executor.js';
-export { SparqlSelector, type SparqlSelectorOptions } from './selector.js';
+export {
+  SparqlItemSelector,
+  type SparqlItemSelectorOptions,
+} from './selector.js';
 
 export { injectValues } from './values.js';
 

--- a/packages/pipeline/src/sparql/selector.ts
+++ b/packages/pipeline/src/sparql/selector.ts
@@ -7,13 +7,13 @@ import {
   type Variable,
   type VariableTerm,
 } from 'sparqljs';
-import type { StageSelector } from '../stage.js';
+import type { ItemSelector } from '../stage.js';
 import type { VariableBindings } from './executor.js';
 
 const parser = new Parser();
 const generator = new Generator();
 
-export interface SparqlSelectorOptions {
+export interface SparqlItemSelectorOptions {
   /** SELECT query projecting at least one named variable. A LIMIT in the query sets the default page size. */
   query: string;
   /** SPARQL endpoint URL. */
@@ -25,7 +25,7 @@ export interface SparqlSelectorOptions {
 }
 
 /**
- * {@link StageSelector} that pages through SPARQL SELECT results,
+ * {@link ItemSelector} that pages through SPARQL SELECT results,
  * yielding all projected variable bindings (NamedNode values only) per row.
  *
  * Pagination is an internal detail — consumers iterate binding rows directly.
@@ -33,13 +33,13 @@ export interface SparqlSelectorOptions {
  * (can be overridden by the `pageSize` option). Pagination continues
  * until a page returns fewer results than the page size.
  */
-export class SparqlSelector implements StageSelector {
+export class SparqlItemSelector implements ItemSelector {
   private readonly parsed: SelectQuery;
   private readonly endpoint: URL;
   private readonly pageSize: number;
   private readonly fetcher: SparqlEndpointFetcher;
 
-  constructor(options: SparqlSelectorOptions) {
+  constructor(options: SparqlItemSelectorOptions) {
     const parsed = parser.parse(options.query);
     if (parsed.type !== 'query' || parsed.queryType !== 'SELECT') {
       throw new Error('Query must be a SELECT query');

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -11,7 +11,7 @@ import {
 import type { Writer } from '../src/writer/writer.js';
 import type { ProgressReporter } from '../src/progressReporter.js';
 import type { StageOutputResolver } from '../src/stageOutputResolver.js';
-import type { Selector } from '../src/selector.js';
+import type { DatasetSelector } from '../src/selector.js';
 import { Paginator } from '@lde/dataset-registry-client';
 
 function makeDataset(iri = 'http://example.org/dataset'): Dataset {
@@ -25,7 +25,7 @@ const sparqlDistribution = Distribution.sparql(
   new URL('http://example.org/sparql')
 );
 
-function makeSelector(...datasets: Dataset[]): Selector {
+function makeDatasetSelector(...datasets: Dataset[]): DatasetSelector {
   return {
     select: async () => new Paginator(async () => datasets, datasets.length),
   };
@@ -103,7 +103,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [stage1, stage2],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -131,7 +131,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [stage],
         writer,
         distributionResolver: makeResolver(
@@ -159,7 +159,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [stage1, stage2],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -189,7 +189,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [parent],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -233,7 +233,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [parent],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -264,7 +264,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [parent],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -286,7 +286,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [parent],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -309,7 +309,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [failingParent],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -330,7 +330,7 @@ describe('Pipeline', () => {
         () =>
           new Pipeline({
             name: 'test',
-            selector: makeSelector(dataset),
+            datasetSelector: makeDatasetSelector(dataset),
             stages: [parent],
             writer,
             distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -349,7 +349,7 @@ describe('Pipeline', () => {
         () =>
           new Pipeline({
             name: 'test',
-            selector: makeSelector(dataset),
+            datasetSelector: makeDatasetSelector(dataset),
             stages: [parent],
             writer,
             distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -369,7 +369,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [flatStage, chainedParent],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -400,7 +400,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'my-pipeline',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [stage],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -445,7 +445,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [parent],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -471,7 +471,7 @@ describe('Pipeline', () => {
     it('works without reporter', async () => {
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset),
+        datasetSelector: makeDatasetSelector(dataset),
         stages: [makeStage('stage1')],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),
@@ -490,7 +490,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset1, dataset2),
+        datasetSelector: makeDatasetSelector(dataset1, dataset2),
         stages: [stage],
         writer,
         distributionResolver: resolver,
@@ -521,7 +521,7 @@ describe('Pipeline', () => {
 
       const pipeline = new Pipeline({
         name: 'test',
-        selector: makeSelector(dataset1, dataset2),
+        datasetSelector: makeDatasetSelector(dataset1, dataset2),
         stages: [failingStage],
         writer,
         distributionResolver: makeResolver(makeResolvedDistribution()),

--- a/packages/pipeline/test/sparql/selector.test.ts
+++ b/packages/pipeline/test/sparql/selector.test.ts
@@ -1,5 +1,5 @@
-import { SparqlSelector } from '../../src/sparql/selector.js';
-import type { StageSelector } from '../../src/stage.js';
+import { SparqlItemSelector } from '../../src/sparql/selector.js';
+import type { ItemSelector } from '../../src/stage.js';
 import type { VariableBindings } from '../../src/sparql/executor.js';
 import { describe, it, expect, vi } from 'vitest';
 import { Readable } from 'node:stream';
@@ -23,7 +23,7 @@ function bindingsStream(
   return Promise.resolve(stream);
 }
 
-describe('SparqlSelector', () => {
+describe('SparqlItemSelector', () => {
   const endpoint = new URL('http://example.com/sparql');
   const query = 'SELECT ?uri WHERE { ?uri a <http://example.com/Class> }';
 
@@ -39,7 +39,7 @@ describe('SparqlSelector', () => {
         ),
     };
 
-    const selector = new SparqlSelector({
+    const selector = new SparqlItemSelector({
       query,
       endpoint,
       pageSize: 10,
@@ -73,7 +73,7 @@ describe('SparqlSelector', () => {
         }),
     };
 
-    const selector = new SparqlSelector({
+    const selector = new SparqlItemSelector({
       query,
       endpoint,
       pageSize: 2,
@@ -104,7 +104,7 @@ describe('SparqlSelector', () => {
       fetchBindings: vi.fn().mockImplementation(() => bindingsStream([])),
     };
 
-    const selector = new SparqlSelector({
+    const selector = new SparqlItemSelector({
       query,
       endpoint,
       fetcher: mockFetcher as never,
@@ -129,7 +129,7 @@ describe('SparqlSelector', () => {
         }),
     };
 
-    const selector = new SparqlSelector({
+    const selector = new SparqlItemSelector({
       query,
       endpoint,
       pageSize: 50,
@@ -157,7 +157,7 @@ describe('SparqlSelector', () => {
         ),
     };
 
-    const selector = new SparqlSelector({
+    const selector = new SparqlItemSelector({
       query,
       endpoint,
       pageSize: 10,
@@ -185,7 +185,7 @@ describe('SparqlSelector', () => {
         }),
     };
 
-    const selector = new SparqlSelector({
+    const selector = new SparqlItemSelector({
       query,
       endpoint,
       fetcher: mockFetcher as never,
@@ -209,7 +209,7 @@ describe('SparqlSelector', () => {
         }),
     };
 
-    const selector = new SparqlSelector({
+    const selector = new SparqlItemSelector({
       query: 'SELECT ?class WHERE { ?s a ?class } LIMIT 25',
       endpoint,
       fetcher: mockFetcher as never,
@@ -234,7 +234,7 @@ describe('SparqlSelector', () => {
         }),
     };
 
-    const selector = new SparqlSelector({
+    const selector = new SparqlItemSelector({
       query: 'SELECT ?class WHERE { ?s a ?class } LIMIT 25',
       endpoint,
       pageSize: 5,
@@ -261,7 +261,7 @@ describe('SparqlSelector', () => {
       ),
     };
 
-    const selector = new SparqlSelector({
+    const selector = new SparqlItemSelector({
       query: 'SELECT ?class ?property WHERE { ?s a ?class ; ?property ?o }',
       endpoint,
       fetcher: mockFetcher as never,
@@ -288,7 +288,7 @@ describe('SparqlSelector', () => {
       ),
     };
 
-    const selector = new SparqlSelector({
+    const selector = new SparqlItemSelector({
       query:
         'SELECT ?class ?label WHERE { ?s a ?class ; <http://www.w3.org/2000/01/rdf-schema#label> ?label }',
       endpoint,
@@ -309,7 +309,7 @@ describe('SparqlSelector', () => {
   it('throws on non-SELECT queries', () => {
     expect(
       () =>
-        new SparqlSelector({
+        new SparqlItemSelector({
           query: 'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }',
           endpoint,
         })
@@ -319,14 +319,14 @@ describe('SparqlSelector', () => {
   it('throws on SELECT * queries', () => {
     expect(
       () =>
-        new SparqlSelector({
+        new SparqlItemSelector({
           query: 'SELECT * WHERE { ?s ?p ?o }',
           endpoint,
         })
     ).toThrow('SELECT * is not supported');
   });
 
-  it('is assignable to StageSelector', async () => {
+  it('is assignable to ItemSelector', async () => {
     const mockFetcher = {
       fetchBindings: vi
         .fn()
@@ -335,8 +335,8 @@ describe('SparqlSelector', () => {
         ),
     };
 
-    // Verify SparqlSelector satisfies StageSelector.
-    const selector: StageSelector = new SparqlSelector({
+    // Verify SparqlItemSelector satisfies ItemSelector.
+    const selector: ItemSelector = new SparqlItemSelector({
       query,
       endpoint,
       fetcher: mockFetcher as never,


### PR DESCRIPTION
## Summary

- `Selector` → `DatasetSelector` (pipeline-level, selects datasets to process)
- `StageSelector` → `ItemSelector` (stage-level, selects items for executors)
- `SparqlSelector` → `SparqlItemSelector`
- Rename `selector` property on `StageOptions` to `itemSelector`

The old names were confusing because `Selector` and `StageSelector` sounded related but served completely different purposes. The new names make the distinction clear: `DatasetSelector` selects which datasets to process, while `ItemSelector` selects items (bindings) within a stage for executors to act on.

## Test plan

- [x] All pipeline tests pass
- [x] All pipeline-void tests pass
- [x] Lint and typecheck pass