### PR TITLE
fix(pipeline): don't mark empty distributions as valid

### DIFF
--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 95.06,
-          lines: 94.53,
-          branches: 90.09,
-          statements: 93.77,
+          functions: 95.23,
+          lines: 94.79,
+          branches: 90.13,
+          statements: 94.06,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Extend `probeDataDump()` to validate response body content for small files (≤ 10 KB), detecting empty distributions that return HTTP 200 but contain no useful data
- Add `failureReason` field to `DataDumpProbeResult` with N3-based validation for Turtle, N-Triples, and N-Quads
- Emit `failureReason` as `schema:error` literal in probe reports

Fix #112