### PR TITLE
chore: auto-apply Nx sync changes

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -79,6 +79,9 @@
       "automaticFromRef": true
     }
   },
+  "sync": {
+    "applyChanges": true
+  },
   "generators": {
     "@nx/js:library": {
       "bundler": "tsc",


### PR DESCRIPTION
## Summary

- Set `sync.applyChanges` to `true` in `nx.json` so Nx automatically applies identified sync changes when running tasks, removing the manual `nx sync` step.