### PR TITLE
feat(pipeline): add SparqlServer support to distribution resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39598,11 +39598,12 @@
     },
     "packages/pipeline": {
       "name": "@lde/pipeline",
-      "version": "0.6.27",
+      "version": "0.6.30",
       "dependencies": {
         "@lde/dataset": "0.6.9",
         "@lde/dataset-registry-client": "0.6.16",
         "@lde/sparql-importer": "0.2.9",
+        "@lde/sparql-server": "0.4.9",
         "@rdfjs/types": "^2.0.1",
         "fetch-sparql-endpoint": "^7.1.0",
         "filenamify-url": "^3.0.0",
@@ -39616,10 +39617,10 @@
     },
     "packages/pipeline-void": {
       "name": "@lde/pipeline-void",
-      "version": "0.2.29",
+      "version": "0.2.35",
       "dependencies": {
         "@lde/dataset": "0.6.9",
-        "@lde/pipeline": "0.6.27",
+        "@lde/pipeline": "0.6.30",
         "@rdfjs/types": "^2.0.1",
         "@zazuko/prefixes": "^2.6.1",
         "n3": "^1.17.0",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -26,6 +26,7 @@
     "@lde/dataset": "0.6.9",
     "@lde/dataset-registry-client": "0.6.16",
     "@lde/sparql-importer": "0.2.9",
+    "@lde/sparql-server": "0.4.9",
     "@rdfjs/types": "^2.0.1",
     "fetch-sparql-endpoint": "^7.1.0",
     "filenamify-url": "^3.0.0",

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -109,6 +109,8 @@ export class Pipeline {
       }
     } catch {
       // Stage error for this dataset; continue to next dataset.
+    } finally {
+      await this.distributionResolver.cleanup?.();
     }
 
     this.reporter?.datasetComplete(datasetIri);

--- a/packages/pipeline/tsconfig.lib.json
+++ b/packages/pipeline/tsconfig.lib.json
@@ -14,6 +14,9 @@
       "path": "../local-sparql-endpoint/tsconfig.lib.json"
     },
     {
+      "path": "../sparql-server/tsconfig.lib.json"
+    },
+    {
       "path": "../sparql-importer/tsconfig.lib.json"
     },
     {

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 95.23,
-          lines: 94.79,
-          branches: 90.13,
-          statements: 94.06,
+          functions: 95.29,
+          lines: 94.87,
+          branches: 90.22,
+          statements: 94.15,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Add optional `server: SparqlServer` to `SparqlDistributionResolverOptions` — when import succeeds, start the server and resolve to its query endpoint instead of the importer's endpoint
- Add optional `cleanup()` method to `DistributionResolver` interface — `SparqlDistributionResolver` implements it by stopping the server
- Call `resolver.cleanup?.()` in `Pipeline.processDataset()` finally block, ensuring servers are stopped after each dataset (even on error)

These changes enable the DKG → LDE migration pattern: import → start server → query → stop server.

## Test plan

- [x] Resolver starts server after successful import and uses its endpoint
- [x] Resolver does not start server when a SPARQL endpoint is already available
- [x] `cleanup()` stops a started server
- [x] `cleanup()` is a no-op when no server was started
- [x] Pipeline calls `resolver.cleanup()` after processing a dataset
- [x] Pipeline calls `resolver.cleanup()` even when a stage throws
- [x] Pipeline works when resolver has no `cleanup` method