### PR TITLE
fix(release): move useCommitScope to correct config level

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -62,11 +62,12 @@
   },
   "release": {
     "projectsRelationship": "independent",
+    "conventionalCommits": {
+      "useCommitScope": false
+    },
     "version": {
       "preVersionCommand": "npx nx run-many -t build",
-      "conventionalCommits": {
-        "useCommitScope": false
-      },
+      "conventionalCommits": true,
       "fallbackCurrentVersionResolver": "disk",
       "versionActionsOptions": {
         "skipLockFileUpdate": true


### PR DESCRIPTION
## Summary

- `release.version.conventionalCommits` is a boolean shorthand; the object form with `useCommitScope` belongs at `release.conventionalCommits`
- The original fix in #106 put it under `version`, where the schema expects a boolean — the object was truthy so conventional commits stayed enabled, but `useCommitScope: false` was silently ignored
- As a result, `feat(pipeline)` commits still produced **patch** instead of **minor** bumps (scope `"pipeline"` doesn't match project name `"@lde/pipeline"`)

## Test plan

- [x] Verify IDE no longer shows type error on `nx.json`
- [ ] Do a dry-run release (`npx nx release --dry-run`) with a `feat` commit and confirm it produces a minor bump