### PR TITLE
refactor(pipeline): extract import logic into ImportResolver decorator

### DIFF
--- a/packages/pipeline/src/distribution/importResolver.ts
+++ b/packages/pipeline/src/distribution/importResolver.ts
@@ -1,0 +1,70 @@
+import { Distribution } from '@lde/dataset';
+import type { Importer } from '@lde/sparql-importer';
+import { ImportFailed, ImportSuccessful } from '@lde/sparql-importer';
+import type { SparqlServer } from '@lde/sparql-server';
+import {
+  type DistributionResolver,
+  NoDistributionAvailable,
+  ResolvedDistribution,
+} from './resolver.js';
+
+export interface ImportResolverOptions {
+  importer: Importer;
+  server?: SparqlServer;
+}
+
+/**
+ * A {@link DistributionResolver} decorator that adds import-as-fallback logic.
+ *
+ * Delegates to an inner resolver first. If the inner resolver returns
+ * {@link NoDistributionAvailable}, tries importing the dataset and optionally
+ * starts a SPARQL server.
+ */
+export class ImportResolver implements DistributionResolver {
+  constructor(
+    private readonly inner: DistributionResolver,
+    private readonly options: ImportResolverOptions,
+  ) {}
+
+  async resolve(
+    ...args: Parameters<DistributionResolver['resolve']>
+  ): Promise<ResolvedDistribution | NoDistributionAvailable> {
+    const result = await this.inner.resolve(...args);
+    if (result instanceof ResolvedDistribution) return result;
+
+    const [dataset] = args;
+    const importResult = await this.options.importer.import(dataset);
+
+    if (importResult instanceof ImportSuccessful) {
+      if (this.options.server) {
+        await this.options.server.start();
+        return new ResolvedDistribution(
+          Distribution.sparql(
+            this.options.server.queryEndpoint,
+            importResult.identifier,
+          ),
+          result.probeResults,
+        );
+      }
+
+      return new ResolvedDistribution(
+        Distribution.sparql(
+          importResult.distribution.accessUrl,
+          importResult.identifier,
+        ),
+        result.probeResults,
+      );
+    }
+
+    return new NoDistributionAvailable(
+      dataset,
+      'No SPARQL endpoint or importable data dump available',
+      result.probeResults,
+      importResult instanceof ImportFailed ? importResult : undefined,
+    );
+  }
+
+  async cleanup(): Promise<void> {
+    await this.options.server?.stop();
+  }
+}

--- a/packages/pipeline/src/distribution/index.ts
+++ b/packages/pipeline/src/distribution/index.ts
@@ -9,6 +9,11 @@ export {
 export { probeResultsToQuads } from './report.js';
 
 export {
+  ImportResolver,
+  type ImportResolverOptions,
+} from './importResolver.js';
+
+export {
   ResolvedDistribution,
   NoDistributionAvailable,
   SparqlDistributionResolver,

--- a/packages/pipeline/test/distribution/importResolver.test.ts
+++ b/packages/pipeline/test/distribution/importResolver.test.ts
@@ -1,0 +1,218 @@
+import {
+  ImportResolver,
+  ResolvedDistribution,
+  NoDistributionAvailable,
+  DataDumpProbeResult,
+  type DistributionResolver,
+} from '../../src/distribution/index.js';
+import { Dataset, Distribution } from '@lde/dataset';
+import { ImportSuccessful, ImportFailed } from '@lde/sparql-importer';
+import type { SparqlServer } from '@lde/sparql-server';
+import { describe, it, expect, vi } from 'vitest';
+
+const dataDumpProbeResult = new DataDumpProbeResult(
+  'http://example.org/data.nt',
+  new Response('', {
+    status: 200,
+    headers: {
+      'Content-Length': '1000',
+      'Content-Type': 'application/n-triples',
+    },
+  }),
+);
+
+function makeDataset(): Dataset {
+  return new Dataset({
+    iri: new URL('http://example.org/dataset'),
+    distributions: [
+      new Distribution(
+        new URL('http://example.org/data.nt'),
+        'application/n-triples',
+      ),
+    ],
+  });
+}
+
+function makeInnerResolver(
+  result: ResolvedDistribution | NoDistributionAvailable,
+): DistributionResolver {
+  return { resolve: vi.fn().mockResolvedValue(result) };
+}
+
+function makeServer(): SparqlServer & {
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+} {
+  return {
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    queryEndpoint: new URL('http://localhost:7001/sparql'),
+  };
+}
+
+describe('ImportResolver', () => {
+  it('returns inner result when it is a ResolvedDistribution', async () => {
+    const distribution = Distribution.sparql(
+      new URL('http://example.org/sparql'),
+    );
+    const resolved = new ResolvedDistribution(distribution, []);
+    const inner = makeInnerResolver(resolved);
+    const mockImporter = { import: vi.fn() };
+
+    const resolver = new ImportResolver(inner, { importer: mockImporter });
+    const result = await resolver.resolve(makeDataset());
+
+    expect(result).toBe(resolved);
+    expect(mockImporter.import).not.toHaveBeenCalled();
+  });
+
+  it('falls back to import when inner resolver returns NoDistributionAvailable', async () => {
+    const dataset = makeDataset();
+    const inner = makeInnerResolver(
+      new NoDistributionAvailable(dataset, 'No endpoint', [
+        dataDumpProbeResult,
+      ]),
+    );
+
+    const mockImporter = {
+      import: vi
+        .fn()
+        .mockResolvedValue(
+          new ImportSuccessful(
+            Distribution.sparql(new URL('http://localhost:7878/sparql')),
+            'test-graph',
+          ),
+        ),
+    };
+
+    const resolver = new ImportResolver(inner, { importer: mockImporter });
+    const result = await resolver.resolve(dataset);
+
+    expect(result).toBeInstanceOf(ResolvedDistribution);
+    expect(mockImporter.import).toHaveBeenCalledWith(dataset);
+    const resolved = result as ResolvedDistribution;
+    expect(resolved.distribution.accessUrl.toString()).toBe(
+      'http://localhost:7878/sparql',
+    );
+    expect(resolved.probeResults).toHaveLength(1);
+    expect(resolved.probeResults[0]).toBeInstanceOf(DataDumpProbeResult);
+  });
+
+  it('returns NoDistributionAvailable with importFailed when import fails', async () => {
+    const dataset = makeDataset();
+    const inner = makeInnerResolver(
+      new NoDistributionAvailable(dataset, 'No endpoint', [
+        dataDumpProbeResult,
+      ]),
+    );
+
+    const mockImporter = {
+      import: vi
+        .fn()
+        .mockResolvedValue(
+          new ImportFailed(
+            new Distribution(
+              new URL('http://example.org/data.nt'),
+              'application/n-triples',
+            ),
+            'Parse error',
+          ),
+        ),
+    };
+
+    const resolver = new ImportResolver(inner, { importer: mockImporter });
+    const result = await resolver.resolve(dataset);
+
+    expect(result).toBeInstanceOf(NoDistributionAvailable);
+    const noDistribution = result as NoDistributionAvailable;
+    expect(noDistribution.importFailed).toBeInstanceOf(ImportFailed);
+    expect(noDistribution.importFailed!.error).toBe('Parse error');
+    expect(noDistribution.probeResults).toHaveLength(1);
+  });
+
+  describe('server integration', () => {
+    it('starts server after import and uses its endpoint', async () => {
+      const dataset = makeDataset();
+      const inner = makeInnerResolver(
+        new NoDistributionAvailable(dataset, 'No endpoint', [
+          dataDumpProbeResult,
+        ]),
+      );
+
+      const mockImporter = {
+        import: vi
+          .fn()
+          .mockResolvedValue(
+            new ImportSuccessful(
+              Distribution.sparql(new URL('http://localhost:7878/sparql')),
+              'test-graph',
+            ),
+          ),
+      };
+
+      const server = makeServer();
+
+      const resolver = new ImportResolver(inner, {
+        importer: mockImporter,
+        server,
+      });
+      const result = await resolver.resolve(dataset);
+
+      expect(result).toBeInstanceOf(ResolvedDistribution);
+      expect(server.start).toHaveBeenCalled();
+      const resolved = result as ResolvedDistribution;
+      expect(resolved.distribution.accessUrl.toString()).toBe(
+        'http://localhost:7001/sparql',
+      );
+    });
+
+    it('does not start server when inner resolver succeeds', async () => {
+      const distribution = Distribution.sparql(
+        new URL('http://example.org/sparql'),
+      );
+      const resolved = new ResolvedDistribution(distribution, []);
+      const inner = makeInnerResolver(resolved);
+      const mockImporter = { import: vi.fn() };
+      const server = makeServer();
+
+      const resolver = new ImportResolver(inner, {
+        importer: mockImporter,
+        server,
+      });
+      await resolver.resolve(makeDataset());
+
+      expect(server.start).not.toHaveBeenCalled();
+    });
+
+    it('cleanup stops server', async () => {
+      const server = makeServer();
+      const resolver = new ImportResolver(
+        makeInnerResolver(
+          new ResolvedDistribution(
+            Distribution.sparql(new URL('http://example.org/sparql')),
+            [],
+          ),
+        ),
+        { importer: { import: vi.fn() }, server },
+      );
+
+      await resolver.cleanup();
+
+      expect(server.stop).toHaveBeenCalled();
+    });
+
+    it('cleanup is a no-op when no server', async () => {
+      const resolver = new ImportResolver(
+        makeInnerResolver(
+          new ResolvedDistribution(
+            Distribution.sparql(new URL('http://example.org/sparql')),
+            [],
+          ),
+        ),
+        { importer: { import: vi.fn() } },
+      );
+
+      await expect(resolver.cleanup()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/pipeline/test/distribution/resolver.test.ts
+++ b/packages/pipeline/test/distribution/resolver.test.ts
@@ -7,8 +7,6 @@ import {
   NetworkError,
 } from '../../src/distribution/index.js';
 import { Dataset, Distribution } from '@lde/dataset';
-import { ImportSuccessful, ImportFailed } from '@lde/sparql-importer';
-import type { SparqlServer } from '@lde/sparql-server';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 describe('SparqlDistributionResolver', () => {
@@ -46,96 +44,7 @@ describe('SparqlDistributionResolver', () => {
     expect(resolved.probeResults[0]).toBeInstanceOf(SparqlProbeResult);
   });
 
-  it('uses importer when no SPARQL endpoint is available', async () => {
-    vi.mocked(fetch).mockResolvedValue(
-      new Response('', {
-        status: 200,
-        headers: { 'Content-Length': '1000' },
-      }),
-    );
-
-    const mockImporter = {
-      import: vi
-        .fn()
-        .mockResolvedValue(
-          new ImportSuccessful(
-            Distribution.sparql(new URL('http://localhost:7878/sparql')),
-            'test-graph',
-          ),
-        ),
-    };
-
-    const resolver = new SparqlDistributionResolver({
-      importer: mockImporter,
-    });
-    const dataset = new Dataset({
-      iri: new URL('http://example.org/dataset'),
-      distributions: [
-        new Distribution(
-          new URL('http://example.org/data.nt'),
-          'application/n-triples',
-        ),
-      ],
-    });
-
-    const result = await resolver.resolve(dataset);
-
-    expect(result).toBeInstanceOf(ResolvedDistribution);
-    expect(mockImporter.import).toHaveBeenCalledWith(dataset);
-    const resolved = result as ResolvedDistribution;
-    expect(resolved.distribution.accessUrl.toString()).toBe(
-      'http://localhost:7878/sparql',
-    );
-    expect(resolved.probeResults).toHaveLength(1);
-    expect(resolved.probeResults[0]).toBeInstanceOf(DataDumpProbeResult);
-  });
-
-  it('returns NoDistributionAvailable when importer fails', async () => {
-    vi.mocked(fetch).mockResolvedValue(
-      new Response('', {
-        status: 200,
-        headers: { 'Content-Length': '1000' },
-      }),
-    );
-
-    const mockImporter = {
-      import: vi
-        .fn()
-        .mockResolvedValue(
-          new ImportFailed(
-            new Distribution(
-              new URL('http://example.org/data.nt'),
-              'application/n-triples',
-            ),
-            'Parse error',
-          ),
-        ),
-    };
-
-    const resolver = new SparqlDistributionResolver({
-      importer: mockImporter,
-    });
-    const dataset = new Dataset({
-      iri: new URL('http://example.org/dataset'),
-      distributions: [
-        new Distribution(
-          new URL('http://example.org/data.nt'),
-          'application/n-triples',
-        ),
-      ],
-    });
-
-    const result = await resolver.resolve(dataset);
-
-    expect(result).toBeInstanceOf(NoDistributionAvailable);
-    const noDistribution = result as NoDistributionAvailable;
-    expect(noDistribution.probeResults).toHaveLength(1);
-    expect(noDistribution.probeResults[0]).toBeInstanceOf(DataDumpProbeResult);
-    expect(noDistribution.importFailed).toBeInstanceOf(ImportFailed);
-    expect(noDistribution.importFailed!.error).toBe('Parse error');
-  });
-
-  it('returns NoDistributionAvailable when no endpoint and no importer', async () => {
+  it('returns NoDistributionAvailable when no endpoint', async () => {
     vi.mocked(fetch).mockResolvedValue(
       new Response('', {
         status: 200,
@@ -184,32 +93,17 @@ describe('SparqlDistributionResolver', () => {
 
   it('does not mutate dataset.distributions', async () => {
     vi.mocked(fetch).mockResolvedValue(
-      new Response('', {
+      new Response('{}', {
         status: 200,
-        headers: { 'Content-Length': '1000' },
+        headers: { 'Content-Type': 'application/sparql-results+json' },
       }),
     );
 
-    const mockImporter = {
-      import: vi
-        .fn()
-        .mockResolvedValue(
-          new ImportSuccessful(
-            Distribution.sparql(new URL('http://localhost:7878/sparql')),
-          ),
-        ),
-    };
-
-    const resolver = new SparqlDistributionResolver({
-      importer: mockImporter,
-    });
+    const resolver = new SparqlDistributionResolver();
     const dataset = new Dataset({
       iri: new URL('http://example.org/dataset'),
       distributions: [
-        new Distribution(
-          new URL('http://example.org/data.nt'),
-          'application/n-triples',
-        ),
+        Distribution.sparql(new URL('http://example.org/sparql')),
       ],
     });
 
@@ -218,132 +112,5 @@ describe('SparqlDistributionResolver', () => {
     await resolver.resolve(dataset);
 
     expect(dataset.distributions.length).toBe(originalLength);
-  });
-
-  describe('server integration', () => {
-    function makeServer(): SparqlServer & {
-      start: ReturnType<typeof vi.fn>;
-      stop: ReturnType<typeof vi.fn>;
-    } {
-      return {
-        start: vi.fn().mockResolvedValue(undefined),
-        stop: vi.fn().mockResolvedValue(undefined),
-        queryEndpoint: new URL('http://localhost:7001/sparql'),
-      };
-    }
-
-    it('starts server after import and uses its endpoint', async () => {
-      vi.mocked(fetch).mockResolvedValue(
-        new Response('', {
-          status: 200,
-          headers: { 'Content-Length': '1000' },
-        }),
-      );
-
-      const mockImporter = {
-        import: vi
-          .fn()
-          .mockResolvedValue(
-            new ImportSuccessful(
-              Distribution.sparql(new URL('http://localhost:7878/sparql')),
-              'test-graph',
-            ),
-          ),
-      };
-
-      const server = makeServer();
-
-      const resolver = new SparqlDistributionResolver({
-        importer: mockImporter,
-        server,
-      });
-      const dataset = new Dataset({
-        iri: new URL('http://example.org/dataset'),
-        distributions: [
-          new Distribution(
-            new URL('http://example.org/data.nt'),
-            'application/n-triples',
-          ),
-        ],
-      });
-
-      const result = await resolver.resolve(dataset);
-
-      expect(result).toBeInstanceOf(ResolvedDistribution);
-      expect(server.start).toHaveBeenCalled();
-      const resolved = result as ResolvedDistribution;
-      expect(resolved.distribution.accessUrl.toString()).toBe(
-        'http://localhost:7001/sparql',
-      );
-    });
-
-    it('does not start server when SPARQL endpoint is already available', async () => {
-      vi.mocked(fetch).mockResolvedValue(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Content-Type': 'application/sparql-results+json' },
-        }),
-      );
-
-      const server = makeServer();
-
-      const resolver = new SparqlDistributionResolver({ server });
-      const dataset = new Dataset({
-        iri: new URL('http://example.org/dataset'),
-        distributions: [
-          Distribution.sparql(new URL('http://example.org/sparql')),
-        ],
-      });
-
-      await resolver.resolve(dataset);
-
-      expect(server.start).not.toHaveBeenCalled();
-    });
-
-    it('cleanup stops a started server', async () => {
-      vi.mocked(fetch).mockResolvedValue(
-        new Response('', {
-          status: 200,
-          headers: { 'Content-Length': '1000' },
-        }),
-      );
-
-      const mockImporter = {
-        import: vi
-          .fn()
-          .mockResolvedValue(
-            new ImportSuccessful(
-              Distribution.sparql(new URL('http://localhost:7878/sparql')),
-            ),
-          ),
-      };
-
-      const server = makeServer();
-
-      const resolver = new SparqlDistributionResolver({
-        importer: mockImporter,
-        server,
-      });
-      const dataset = new Dataset({
-        iri: new URL('http://example.org/dataset'),
-        distributions: [
-          new Distribution(
-            new URL('http://example.org/data.nt'),
-            'application/n-triples',
-          ),
-        ],
-      });
-
-      await resolver.resolve(dataset);
-      await resolver.cleanup();
-
-      expect(server.stop).toHaveBeenCalled();
-    });
-
-    it('cleanup is a no-op when no server is configured', async () => {
-      const resolver = new SparqlDistributionResolver();
-
-      await expect(resolver.cleanup()).resolves.toBeUndefined();
-    });
   });
 });

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,8 +11,8 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 95.6,
-          lines: 95,
+          functions: 95.69,
+          lines: 94.98,
           branches: 90.3,
           statements: 94.3,
         },


### PR DESCRIPTION
## Summary

- Slim down `SparqlDistributionResolver` to probe-only: it now just probes existing SPARQL distributions and returns the first valid one, with no import/server/cleanup logic
- Add `ImportResolver` decorator that wraps any `DistributionResolver` and adds import-as-fallback: when the inner resolver returns `NoDistributionAvailable`, it tries importing the dataset and optionally starts a SPARQL server
- This separates two concerns that were mixed: **probing** existing endpoints (always needed) vs **importing** data dumps as fallback (only needed for DKG-style workflows)
- Uses the same decorator/composition pattern as `TransformWriter` and `FanOutWriter`

## Changes

- `SparqlDistributionResolver` — removed `importer`/`server` fields, import fallback, and `cleanup()` method
- New `ImportResolver` class in `importResolver.ts` — decorator implementing `DistributionResolver`
- Import/server tests moved from `resolver.test.ts` to new `importResolver.test.ts`
- Coverage thresholds adjusted for new code distribution

## Test plan

- [x] `nx test pipeline` — 135 tests pass
- [x] `nx typecheck pipeline` — clean
- [x] `nx lint pipeline` — clean
- [x] DKG `npm run compile` — clean (updated separately)