### PR TITLE
feat(sparql-qlever): add createQlever factory function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39598,7 +39598,7 @@
     },
     "packages/pipeline": {
       "name": "@lde/pipeline",
-      "version": "0.6.32",
+      "version": "0.7.0",
       "dependencies": {
         "@lde/dataset": "0.6.10",
         "@lde/dataset-registry-client": "0.6.17",
@@ -39617,10 +39617,10 @@
     },
     "packages/pipeline-void": {
       "name": "@lde/pipeline-void",
-      "version": "0.2.37",
+      "version": "0.3.0",
       "dependencies": {
         "@lde/dataset": "0.6.10",
-        "@lde/pipeline": "0.6.32",
+        "@lde/pipeline": "0.7.0",
         "@rdfjs/types": "^2.0.1",
         "@zazuko/prefixes": "^2.6.1",
         "n3": "^1.17.0",
@@ -39673,6 +39673,8 @@
         "@lde/sparql-importer": "0.0.9",
         "@lde/sparql-server": "0.2.2",
         "@lde/task-runner": "0.0.5",
+        "@lde/task-runner-docker": "0.2.10",
+        "@lde/task-runner-native": "0.2.11",
         "tslib": "^2.3.0"
       }
     },

--- a/packages/sparql-qlever/package.json
+++ b/packages/sparql-qlever/package.json
@@ -28,6 +28,8 @@
     "@lde/sparql-importer": "0.0.9",
     "@lde/sparql-server": "0.2.2",
     "@lde/task-runner": "0.0.5",
+    "@lde/task-runner-docker": "0.2.10",
+    "@lde/task-runner-native": "0.2.11",
     "tslib": "^2.3.0"
   }
 }

--- a/packages/sparql-qlever/src/createQlever.ts
+++ b/packages/sparql-qlever/src/createQlever.ts
@@ -1,0 +1,39 @@
+import { DockerTaskRunner } from '@lde/task-runner-docker';
+import { NativeTaskRunner } from '@lde/task-runner-native';
+import { TaskRunner } from '@lde/task-runner';
+import { Importer } from './importer.js';
+import { Server } from './server.js';
+
+export type QleverOptions = {
+  indexName?: string;
+  port?: number;
+} & (
+  | {
+      mode: 'docker';
+      image: string;
+      containerName?: string;
+      mountDir?: string;
+    }
+  | { mode: 'native'; cwd?: string }
+);
+
+export function createQlever(options: QleverOptions) {
+  const taskRunner: TaskRunner<unknown> =
+    options.mode === 'docker'
+      ? new DockerTaskRunner({
+          image: options.image,
+          containerName: options.containerName,
+          mountDir: options.mountDir,
+          port: options.port,
+        })
+      : new NativeTaskRunner({ cwd: options.cwd });
+
+  return {
+    importer: new Importer({ taskRunner, indexName: options.indexName }),
+    server: new Server({
+      taskRunner,
+      indexName: options.indexName ?? 'data',
+      port: options.port,
+    }),
+  };
+}

--- a/packages/sparql-qlever/src/index.ts
+++ b/packages/sparql-qlever/src/index.ts
@@ -1,2 +1,3 @@
+export * from './createQlever.js';
 export * from './importer.js';
 export * from './server.js';

--- a/packages/sparql-qlever/tsconfig.lib.json
+++ b/packages/sparql-qlever/tsconfig.lib.json
@@ -14,6 +14,9 @@
       "path": "../wait-for-sparql/tsconfig.lib.json"
     },
     {
+      "path": "../task-runner-native/tsconfig.lib.json"
+    },
+    {
       "path": "../task-runner-docker/tsconfig.lib.json"
     }
   ],


### PR DESCRIPTION
## Summary

- Add a `createQlever()` factory function to `@lde/sparql-qlever` that accepts a discriminated union (`mode: 'docker' | 'native'`) and returns `{ importer, server }`
- Internalizes `TaskRunner` wiring so consumers (like DKG) don't need `@lde/task-runner-docker`/`@lde/task-runner-native` as direct dependencies
- Adds `@lde/task-runner-docker` and `@lde/task-runner-native` as dependencies of `@lde/sparql-qlever`

## Test plan

- [x] `nx lint sparql-qlever` passes
- [x] `nx typecheck sparql-qlever` passes
- [x] `nx test sparql-qlever` passes
- [x] `nx build sparql-qlever` passes