### PR TITLE
chore(release): enable updateDependents and fix stale @lde deps in sparql-qlever

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -68,6 +68,7 @@
     "version": {
       "preVersionCommand": "npx nx run-many -t build",
       "conventionalCommits": true,
+      "updateDependents": "auto",
       "fallbackCurrentVersionResolver": "disk",
       "versionActionsOptions": {
         "skipLockFileUpdate": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -40302,47 +40302,12 @@
       "version": "0.7.0",
       "dependencies": {
         "@lde/dataset": "0.6.10",
-        "@lde/distribution-downloader": "0.2.7",
-        "@lde/sparql-importer": "0.0.9",
-        "@lde/sparql-server": "0.2.2",
-        "@lde/task-runner": "0.0.5",
+        "@lde/distribution-downloader": "0.4.11",
+        "@lde/sparql-importer": "0.2.10",
+        "@lde/sparql-server": "0.4.10",
+        "@lde/task-runner": "0.2.10",
         "@lde/task-runner-docker": "0.2.10",
         "@lde/task-runner-native": "0.2.11",
-        "tslib": "^2.3.0"
-      }
-    },
-    "packages/sparql-qlever/node_modules/@lde/distribution-downloader": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@lde/distribution-downloader/-/distribution-downloader-0.2.7.tgz",
-      "integrity": "sha512-azG9bTxzbjSb3U3j2PYgBs9DbOQcGFmIyYSVLuaylkjsPDKmz4p76ZxrDe7jUTRvbh/rCCyI6PBPVxjqjMhm0Q==",
-      "dependencies": {
-        "@lde/dataset": "0.4.2",
-        "filenamify-url": "3.1.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "packages/sparql-qlever/node_modules/@lde/sparql-importer": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@lde/sparql-importer/-/sparql-importer-0.0.9.tgz",
-      "integrity": "sha512-PyUK+1rNlK92R8TAooV1hIqlCXEFms72nbIUlCWDhwOObdOQWBJrkv2Xf3K3CBNaE7Mg1Z4yCzEug3iZeNreNw==",
-      "dependencies": {
-        "@lde/dataset": "0.4.2",
-        "tslib": "^2.3.0"
-      }
-    },
-    "packages/sparql-qlever/node_modules/@lde/sparql-server": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@lde/sparql-server/-/sparql-server-0.2.2.tgz",
-      "integrity": "sha512-zT7EkGgsFthXtfRCxJ36tVzb4ug8raPUY9RnQ9plT7dYvFex2ByOXtgLHBLZxeB3Xf50k2Q7OUinFoK8AR07FQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "packages/sparql-qlever/node_modules/@lde/task-runner": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@lde/task-runner/-/task-runner-0.0.5.tgz",
-      "integrity": "sha512-seHQFnEa6ckGOhY9TE2fHQFB+NZPRzs3Zx5TChXA1zvWkkVHXSKN9srvqQPcHHgdWcf60mpTMPnhBMe/cSu4Tg==",
-      "dependencies": {
         "tslib": "^2.3.0"
       }
     },

--- a/packages/sparql-qlever/package.json
+++ b/packages/sparql-qlever/package.json
@@ -24,10 +24,10 @@
   ],
   "dependencies": {
     "@lde/dataset": "0.6.10",
-    "@lde/distribution-downloader": "0.2.7",
-    "@lde/sparql-importer": "0.0.9",
-    "@lde/sparql-server": "0.2.2",
-    "@lde/task-runner": "0.0.5",
+    "@lde/distribution-downloader": "0.4.11",
+    "@lde/sparql-importer": "0.2.10",
+    "@lde/sparql-server": "0.4.10",
+    "@lde/task-runner": "0.2.10",
     "@lde/task-runner-docker": "0.2.10",
     "@lde/task-runner-native": "0.2.11",
     "tslib": "^2.3.0"

--- a/packages/sparql-qlever/tsconfig.lib.json
+++ b/packages/sparql-qlever/tsconfig.lib.json
@@ -20,6 +20,18 @@
       "path": "../task-runner-docker/tsconfig.lib.json"
     },
     {
+      "path": "../task-runner/tsconfig.lib.json"
+    },
+    {
+      "path": "../sparql-server/tsconfig.lib.json"
+    },
+    {
+      "path": "../sparql-importer/tsconfig.lib.json"
+    },
+    {
+      "path": "../distribution-downloader/tsconfig.lib.json"
+    },
+    {
       "path": "../dataset/tsconfig.lib.json"
     }
   ],


### PR DESCRIPTION
## Summary

- Enables `updateDependents: 'auto'` in the Nx release config so dependent packages' `package.json` references are updated automatically when a dependency is bumped. The package graph is shallow (max cascade depth 4) so the impact is modest.
- Bumps five stale `@lde/*` dependencies in `@lde/sparql-qlever` to current workspace versions — these drifted because `updateDependents` was not configured:
  - `@lde/dataset` 0.4.2 → 0.6.10
  - `@lde/distribution-downloader` 0.2.7 → 0.4.11
  - `@lde/sparql-importer` 0.0.9 → 0.2.10
  - `@lde/sparql-server` 0.2.2 → 0.4.10
  - `@lde/task-runner` 0.0.5 → 0.2.10
- Adds missing `tsconfig` project references (via `nx sync`)

Unblocks #137.