### PR TITLE
fix(pipeline): clear graph and truncate file at most once per writer instance

### DIFF
--- a/packages/pipeline/test/writer/fileWriter.test.ts
+++ b/packages/pipeline/test/writer/fileWriter.test.ts
@@ -45,14 +45,14 @@ describe('FileWriter', () => {
           quad(
             namedNode('http://example.com/subject'),
             namedNode('http://example.com/predicate'),
-            literal('object')
-          )
-        )
+            literal('object'),
+          ),
+        ),
       );
 
       const files = await readFile(
         join(tempDir, 'example.com_dataset_1.ttl'),
-        'utf-8'
+        'utf-8',
       );
       expect(files).toContain('<http://example.com/subject>');
       expect(files).toContain('<http://example.com/predicate>');
@@ -73,14 +73,14 @@ describe('FileWriter', () => {
           quad(
             namedNode('http://example.com/subject'),
             namedNode('http://example.com/predicate'),
-            literal('object')
-          )
-        )
+            literal('object'),
+          ),
+        ),
       );
 
       const content = await readFile(
         join(tempDir, 'example.com_dataset_1.nt'),
-        'utf-8'
+        'utf-8',
       );
       expect(content).toContain('<http://example.com/subject>');
     });
@@ -93,8 +93,48 @@ describe('FileWriter', () => {
       await writer.write(dataset, quadsOf());
 
       await expect(
-        readFile(join(tempDir, 'example.com_dataset_1.ttl'))
+        readFile(join(tempDir, 'example.com_dataset_1.ttl')),
       ).rejects.toThrow();
+    });
+
+    it('appends quads from a second write to the same dataset (n-triples)', async () => {
+      const writer = new FileWriter({
+        outputDir: tempDir,
+        format: 'n-triples',
+      });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/s1'),
+            namedNode('http://example.com/p'),
+            literal('first'),
+          ),
+        ),
+      );
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/s2'),
+            namedNode('http://example.com/p'),
+            literal('second'),
+          ),
+        ),
+      );
+
+      const content = await readFile(
+        join(tempDir, 'example.com_dataset_1.nt'),
+        'utf-8',
+      );
+      expect(content).toContain('<http://example.com/s1>');
+      expect(content).toContain('<http://example.com/s2>');
+      expect(content).toContain('"first"');
+      expect(content).toContain('"second"');
     });
 
     it('creates nested output directories', async () => {
@@ -109,14 +149,14 @@ describe('FileWriter', () => {
           quad(
             namedNode('http://example.com/s'),
             namedNode('http://example.com/p'),
-            literal('o')
-          )
-        )
+            literal('o'),
+          ),
+        ),
       );
 
       const content = await readFile(
         join(nestedDir, 'example.com_dataset_1.ttl'),
-        'utf-8'
+        'utf-8',
       );
       expect(content).toBeTruthy();
     });

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 91.08,
-          lines: 93.64,
-          branches: 88.74,
-          statements: 92.85,
+          lines: 93.72,
+          branches: 88.93,
+          statements: 92.94,
         },
       },
     },


### PR DESCRIPTION
## Summary

- `SparqlUpdateWriter`: add `clearedGraphs: Set<string>`. `CLEAR GRAPH` now fires only on the *first* `write()` call per dataset per writer instance. Subsequent calls from later pipeline stages append to the same named graph rather than wiping it.
- `FileWriter`: add `writtenFiles: Set<string>`. First write creates/truncates the file; subsequent writes for the same dataset append. Includes a JSDoc note that Turtle format repeats prefix declarations on each append — use `'n-triples'` or `'n-quads'` in multi-stage pipelines.
- New tests covering both behaviours.

## Test plan

- [x] `npx nx test pipeline` — all 146 tests pass
- [x] `npx nx typecheck pipeline` — no errors
- [x] `npx nx lint pipeline` — no errors (existing warnings only)