### PR TITLE
build(deps): bump ldkit to 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21320,6 +21320,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.2.0.tgz",
       "integrity": "sha512-3Vf3FOUB/i7tdlghovHsgjoZbdqIgB0m01UGwpxCBHI/swbxcqhQzmKFjU9T3gNxurmsdqafF8Unoh9ZCwNuRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*",
@@ -25366,6 +25367,7 @@
       "version": "3.1.12",
       "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.12.tgz",
       "integrity": "sha512-zg/sdKKtYI0845wKPSuSgunyU1o/+7tRzMw85lHsf4p/0UbA6+65MXAyEtv1nkaqSqrq/bXm7+bqXas+Xo5dpQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": ">=1.0.0"
@@ -31321,6 +31323,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -32833,12 +32836,12 @@
       }
     },
     "node_modules/ldkit": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/ldkit/-/ldkit-2.5.2.tgz",
-      "integrity": "sha512-hK0/b6/rkBiIUJG5j0/21Xi3jvpKwgfP5sGicCN1NEPFJlkmzpmeWxfjoU8bDBhPOunKX1p88XmMK3OrnkGdPw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/ldkit/-/ldkit-2.6.0.tgz",
+      "integrity": "sha512-VY4Y3NQIj5zAQdinwNW2ZAo5Q3hXKVm/BmuPNNspqcLs53nso3s4e3cFXLwsJD1DEfpf1cMEYbhMC/CXvbyE+Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^4",
+        "@comunica/types": "^5",
         "@rdfjs/types": "^2",
         "@shexjs/parser": "1.0.0-alpha.28",
         "@types/n3": "^1",
@@ -32853,6 +32856,23 @@
       },
       "bin": {
         "ldkit": "esm/cli.js"
+      }
+    },
+    "node_modules/ldkit/node_modules/@comunica/types": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-5.1.3.tgz",
+      "integrity": "sha512-EbA9yYlx+49zGfmMYnQdbNfdZoUwovjKLXD4ZlpM2TDbo3MUdweyqLcDS00GB+PE5bVzFQf1I2sneEWVfzx3mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/utils-algebra": "^5.1.3",
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.10.0",
+        "lru-cache": "^11.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
       }
     },
     "node_modules/ldkit/node_modules/@types/node": {
@@ -32886,6 +32906,15 @@
       },
       "bin": {
         "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/ldkit/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/ldkit/node_modules/rdf-data-factory": {
@@ -33620,6 +33649,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/luxon": {
@@ -33867,6 +33897,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/minimatch": {
@@ -33889,6 +33920,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -36064,6 +36096,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz",
       "integrity": "sha512-6uIhsXTVp2AtO6f41PdnRV5xZsa0zVZQDTBdn0br+DZuFf5M/YD+T6m8hKDUnALI6nFL/IujTMLgEs20MlNidQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*",
@@ -36493,6 +36526,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
       "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*",
@@ -36529,6 +36563,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
       "integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*",
@@ -37462,6 +37497,7 @@
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.3.8.tgz",
       "integrity": "sha512-Xo1/5icRtVk2N38BrY9NXN8N/ZPjULlns7sDHv0nlcGOsOediBLWVy8LmV+Q90RHvb3atZZbrFy3VqrM4iXciA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*",
@@ -40141,7 +40177,7 @@
       "version": "0.6.17",
       "dependencies": {
         "@lde/dataset": "0.6.10",
-        "ldkit": "^2.5.2",
+        "ldkit": "^2.6.0",
         "n3": "^1.26.0",
         "sparqljs": "^3.7.3",
         "tslib": "^2.3.0"

--- a/packages/dataset-registry-client/package.json
+++ b/packages/dataset-registry-client/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@lde/dataset": "0.6.10",
-    "ldkit": "^2.5.2",
+    "ldkit": "^2.6.0",
     "n3": "^1.26.0",
     "sparqljs": "^3.7.3",
     "tslib": "^2.3.0"


### PR DESCRIPTION
Bumps `ldkit` from 2.5.2 to 2.6.0 in `@lde/dataset-registry-client`.

ldkit 2.6.0 updates its `@comunica/types` dependency from `^4` to `^5` (via [karelklima/ldkit#168](https://github.com/karelklima/ldkit/pull/168)), aligning it with the Comunica v5 packages already used in this workspace.