### PR TITLE
build: ignore ESLint packages in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,6 @@ updates:
     schedule:
       interval: 'weekly'
     groups:
-      eslint:
-        patterns:
-          - '@typescript-eslint/*'
-          - 'eslint'
-          - 'eslint-plugin-svelte'
       fastify:
         patterns:
           - '@fastify/*'
@@ -27,3 +22,8 @@ updates:
       # Upgrade Nx manually with `nx migrate latest`
       - dependency-name: '@nx/*'
       - dependency-name: 'nx'
+      # ESLint major versions are tied to Nx; upgrade together with Nx
+      - dependency-name: '@eslint/*'
+      - dependency-name: '@typescript-eslint/*'
+      - dependency-name: 'eslint'
+      - dependency-name: 'eslint-plugin-svelte'


### PR DESCRIPTION
## Summary

- Move ESLint packages (`eslint`, `@eslint/*`, `@typescript-eslint/*`, `eslint-plugin-svelte`) from grouped updates to the Dependabot ignore list
- ESLint major versions are constrained by Nx's `@nx/eslint` peer dependencies (currently `^8.0.0 || ^9.0.0`), so they must be upgraded together with Nx via `nx migrate latest`
- This prevents Dependabot from opening PRs for ESLint upgrades that can't be merged without an Nx upgrade (e.g. #99, #130)