### PR TITLE
feat(pipeline): make FileWriter replacement character configurable

### DIFF
--- a/packages/pipeline/src/writer/fileWriter.ts
+++ b/packages/pipeline/src/writer/fileWriter.ts
@@ -17,6 +17,11 @@ export interface FileWriterOptions {
    * @default 'n-triples'
    */
   format?: 'turtle' | 'n-triples' | 'n-quads';
+  /**
+   * Character used to replace URL-unsafe characters in filenames.
+   * @default '-'
+   */
+  replacementCharacter?: string;
 }
 
 /**
@@ -41,11 +46,13 @@ const formatMap: Record<string, string> = {
 export class FileWriter implements Writer {
   private readonly outputDir: string;
   readonly format: 'turtle' | 'n-triples' | 'n-quads';
+  private readonly replacementCharacter: string;
   private readonly writtenFiles = new Set<string>();
 
   constructor(options: FileWriterOptions) {
     this.outputDir = options.outputDir;
     this.format = options.format ?? 'n-triples';
+    this.replacementCharacter = options.replacementCharacter ?? '-';
   }
 
   async write(dataset: Dataset, quads: AsyncIterable<Quad>): Promise<void> {
@@ -83,7 +90,7 @@ export class FileWriter implements Writer {
   getFilename(dataset: Dataset): string {
     const extension = this.getExtension();
     const baseName = filenamifyUrl(dataset.iri.toString(), {
-      replacement: '_',
+      replacement: this.replacementCharacter,
     });
     return `${baseName}.${extension}`;
   }

--- a/packages/pipeline/test/writer/fileWriter.test.ts
+++ b/packages/pipeline/test/writer/fileWriter.test.ts
@@ -51,7 +51,7 @@ describe('FileWriter', () => {
       );
 
       const files = await readFile(
-        join(tempDir, 'example.com_dataset_1.nt'),
+        join(tempDir, 'example.com-dataset-1.nt'),
         'utf-8',
       );
       expect(files).toContain('<http://example.com/subject>');
@@ -79,7 +79,7 @@ describe('FileWriter', () => {
       );
 
       const content = await readFile(
-        join(tempDir, 'example.com_dataset_1.nt'),
+        join(tempDir, 'example.com-dataset-1.nt'),
         'utf-8',
       );
       expect(content).toContain('<http://example.com/subject>');
@@ -93,7 +93,7 @@ describe('FileWriter', () => {
       await writer.write(dataset, quadsOf());
 
       await expect(
-        readFile(join(tempDir, 'example.com_dataset_1.nt')),
+        readFile(join(tempDir, 'example.com-dataset-1.nt')),
       ).rejects.toThrow();
     });
 
@@ -128,13 +128,39 @@ describe('FileWriter', () => {
       );
 
       const content = await readFile(
-        join(tempDir, 'example.com_dataset_1.nt'),
+        join(tempDir, 'example.com-dataset-1.nt'),
         'utf-8',
       );
       expect(content).toContain('<http://example.com/s1>');
       expect(content).toContain('<http://example.com/s2>');
       expect(content).toContain('"first"');
       expect(content).toContain('"second"');
+    });
+
+    it('uses custom replacement character in filenames', async () => {
+      const writer = new FileWriter({
+        outputDir: tempDir,
+        replacementCharacter: '_',
+      });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/s'),
+            namedNode('http://example.com/p'),
+            literal('o'),
+          ),
+        ),
+      );
+
+      const content = await readFile(
+        join(tempDir, 'example.com_dataset_1.nt'),
+        'utf-8',
+      );
+      expect(content).toBeTruthy();
     });
 
     it('creates nested output directories', async () => {
@@ -155,7 +181,7 @@ describe('FileWriter', () => {
       );
 
       const content = await readFile(
-        join(nestedDir, 'example.com_dataset_1.nt'),
+        join(nestedDir, 'example.com-dataset-1.nt'),
         'utf-8',
       );
       expect(content).toBeTruthy();

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 91.08,
-          lines: 93.52,
-          branches: 88.41,
-          statements: 92.74,
+          lines: 93.53,
+          branches: 88.51,
+          statements: 92.75,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Add `replacementCharacter` option to `FileWriterOptions`, defaulting to `'-'` (was hardcoded `'_'`)
- Produces more readable filenames, e.g. `data.beeldengeluid.nl-id-dataset-0010.nt` instead of `data.beeldengeluid.nl_id_dataset_0010.nt`
- Consumers that need the old behaviour can pass `replacementCharacter: '_'`

## Test plan

- [x] Existing FileWriter tests updated to reflect new default
- [x] New test for custom `replacementCharacter` option
- [x] All 147 pipeline tests passing
- [x] Lint and typecheck clean