### PR TITLE
feat(pipeline): isolate errors per stage in processDataset()

### DIFF
--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -132,14 +132,19 @@ export class Pipeline {
 
     try {
       for (const stage of this.stages) {
-        if (stage.stages.length > 0) {
-          await this.runChain(dataset, resolved.distribution, stage);
-        } else {
-          await this.runStage(dataset, resolved.distribution, stage);
+        try {
+          if (stage.stages.length > 0) {
+            await this.runChain(dataset, resolved.distribution, stage);
+          } else {
+            await this.runStage(dataset, resolved.distribution, stage);
+          }
+        } catch (error) {
+          this.reporter?.stageFailed(
+            stage.name,
+            error instanceof Error ? error : new Error(String(error)),
+          );
         }
       }
-    } catch {
-      // Stage error for this dataset; continue to next dataset.
     } finally {
       await this.distributionResolver.cleanup?.();
     }

--- a/packages/pipeline/src/progressReporter.ts
+++ b/packages/pipeline/src/progressReporter.ts
@@ -12,8 +12,9 @@ export interface ProgressReporter {
       elementsProcessed: number;
       quadsGenerated: number;
       duration: number;
-    }
+    },
   ): void;
+  stageFailed(stage: string, error: Error): void;
   stageSkipped(stage: string, reason: string): void;
   datasetComplete(dataset: string): void;
   datasetSkipped(dataset: string, reason: string): void;

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -56,6 +56,7 @@ function makeReporter(): ProgressReporter & {
     stageStart: vi.fn<ProgressReporter['stageStart']>(),
     stageProgress: vi.fn<ProgressReporter['stageProgress']>(),
     stageComplete: vi.fn<ProgressReporter['stageComplete']>(),
+    stageFailed: vi.fn<ProgressReporter['stageFailed']>(),
     stageSkipped: vi.fn<ProgressReporter['stageSkipped']>(),
     datasetComplete: vi.fn<ProgressReporter['datasetComplete']>(),
     datasetSkipped: vi.fn<ProgressReporter['datasetSkipped']>(),
@@ -531,6 +532,69 @@ describe('Pipeline', () => {
       // Both datasets should be attempted.
       expect(failingStage.run).toHaveBeenCalledTimes(2);
       expect(reporter.datasetComplete).toHaveBeenCalledTimes(2);
+      expect(reporter.stageFailed).toHaveBeenCalledWith(
+        'failing',
+        expect.any(Error),
+      );
+    });
+
+    it('continues to next stage when a stage throws', async () => {
+      const failingStage = makeStage('failing');
+      vi.spyOn(failingStage, 'run').mockRejectedValue(
+        new Error('Stage failed'),
+      );
+      const okStage = makeStage('ok');
+      const reporter = makeReporter();
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [failingStage, okStage],
+        writers: writer,
+        distributionResolver: makeResolver(makeResolvedDistribution()),
+        reporter,
+      });
+
+      await pipeline.run();
+
+      expect(okStage.run).toHaveBeenCalledTimes(1);
+      expect(reporter.stageFailed).toHaveBeenCalledWith(
+        'failing',
+        expect.any(Error),
+      );
+      expect(reporter.datasetComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues to next top-level stage when a chain throws', async () => {
+      const stageOutputResolver = makeStageOutputResolver();
+
+      const child = makeStage('child');
+      const chainedParent = makeStage('chained', undefined, [child]);
+      vi.spyOn(chainedParent, 'run').mockRejectedValue(
+        new Error('Chain failed'),
+      );
+
+      const flatStage = makeStage('flat');
+      const reporter = makeReporter();
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [chainedParent, flatStage],
+        writers: writer,
+        distributionResolver: makeResolver(makeResolvedDistribution()),
+        chaining: {
+          stageOutputResolver,
+          outputDir: '/tmp/test',
+        },
+        reporter,
+      });
+
+      await pipeline.run();
+
+      expect(flatStage.run).toHaveBeenCalledTimes(1);
+      expect(reporter.stageFailed).toHaveBeenCalledWith(
+        'chained',
+        expect.any(Error),
+      );
     });
   });
 

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 91.08,
-          lines: 93.53,
-          branches: 88.51,
-          statements: 92.75,
+          lines: 93.56,
+          branches: 88.18,
+          statements: 92.78,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Move the try/catch in `processDataset()` inside the stage loop so each top-level stage is independently wrapped. A failure in one stage no longer prevents remaining stages from running.
- Add `stageFailed(stage, error)` to the `ProgressReporter` interface so consumers can observe and report stage-level failures.
- Chain stages (parent + children) still abort on failure, which is correct since children depend on parent output.
- Outer try/finally preserved for `distributionResolver.cleanup()` (runs once per dataset regardless of errors).

## Test plan

- [x] Add test: flat stage failure doesn't skip subsequent stages (`stageFailed` called, next stage still runs)
- [x] Add test: chained stage failure doesn't skip subsequent top-level stages
- [x] Strengthen existing "continues to next dataset" test with `stageFailed` assertion
- [x] All 149 existing tests pass
- [x] Lint and typecheck pass