### PR TITLE
Replace +gzip media types with dcat:compressFormat

### DIFF
--- a/packages/dataset-registry-client/src/client.ts
+++ b/packages/dataset-registry-client/src/client.ts
@@ -7,7 +7,7 @@ import { Paginator } from './paginator.js';
 export class Client {
   constructor(
     private readonly sparqlEndpoint: URL,
-    private readonly schema = DatasetSchema
+    private readonly schema = DatasetSchema,
   ) {}
 
   public query(criteria: object): Promise<Paginator<Dataset>>;
@@ -55,9 +55,10 @@ export class Client {
                 const distribution = new Distribution(
                   new URL(d.accessURL),
                   d.mediaType ?? undefined,
-                  d.conformsTo ? new URL(d.conformsTo) : undefined
+                  d.conformsTo ? new URL(d.conformsTo) : undefined,
                 );
                 distribution.byteSize = d.byteSize ?? undefined;
+                distribution.compressFormat = d.compressFormat ?? undefined;
                 distribution.lastModified = d.modified ?? undefined;
 
                 return distribution;
@@ -72,11 +73,11 @@ export class Client {
                     name: dataset.publisher.name,
                   }
                 : undefined,
-            })
+            }),
         );
       },
       total,
-      pageSize
+      pageSize,
     );
   }
 }

--- a/packages/dataset-registry-client/src/dcat.ts
+++ b/packages/dataset-registry-client/src/dcat.ts
@@ -7,6 +7,7 @@ export const dcat = createNamespace({
     'Dataset',
     'Distribution',
     'accessURL',
+    'compressFormat',
     'keyword',
     'mediaType',
     'byteSize',

--- a/packages/dataset-registry-client/src/schema.ts
+++ b/packages/dataset-registry-client/src/schema.ts
@@ -57,6 +57,10 @@ export const DatasetSchema = {
         '@type': xsd.nonNegativeInteger,
         '@optional': true,
       },
+      compressFormat: {
+        '@id': dcat.compressFormat,
+        '@optional': true,
+      },
       conformsTo: {
         '@id': dcterms.conformsTo,
         '@optional': true,

--- a/packages/dataset-registry-client/test/fixtures/registry.ttl
+++ b/packages/dataset-registry-client/test/fixtures/registry.ttl
@@ -12,13 +12,13 @@
   dcat:distribution [
     a dcat:Distribution ;
     dcat:accessURL <http://foo.org/sparql2> ;
-    dcat:mediaType "application/sparql-query" ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/sparql-query> ;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
     dct:modified "2022-12-03T10:26"^^xsd:dateTime ;
   ] , [
     a dcat:Distribution ;
     dcat:accessURL <http://foo.org/files/foo.ttl.gz> ;
-    dcat:mediaType "text/turtle" ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     dcat:byteSize "87654321" ;
   ] .
 
@@ -31,7 +31,7 @@
   ] , [
     a dcat:Distribution ;
     dcat:accessURL <http://bar.org/files/bar.ttl.gz> ;
-    dcat:mediaType "text/turtle" ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     dcat:byteSize "87654321" ;
   ] .
 

--- a/packages/dataset/src/dataset.ts
+++ b/packages/dataset/src/dataset.ts
@@ -44,18 +44,14 @@ export class Dataset {
 
   public getDownloadDistributions(): Distribution[] {
     return [
-      ...this.distributions.filter((distribution) =>
-        distribution.mimeType?.endsWith('+gzip'),
-      ),
-      ...this.distributions.filter((distribution) =>
-        distribution.accessUrl?.toString().endsWith('.nt.gz'),
+      // Prefer compressed distributions.
+      ...this.distributions.filter(
+        (distribution) => distribution.compressFormat !== undefined,
       ),
       ...this.distributions.filter(
         (distribution) =>
-          undefined !== distribution.mimeType &&
-          ['application/n-triples', 'text/turtle'].includes(
-            distribution.mimeType,
-          ),
+          distribution.compressFormat === undefined &&
+          distribution.mimeType !== undefined,
       ),
     ];
   }

--- a/packages/dataset/src/distribution.ts
+++ b/packages/dataset/src/distribution.ts
@@ -1,16 +1,37 @@
 const SPARQL_URI = 'https://www.w3.org/TR/sparql11-protocol/';
 
+export const IANA_MEDIA_TYPE_PREFIX =
+  'https://www.iana.org/assignments/media-types/';
+
 export class Distribution {
   public byteSize?: number;
+  public compressFormat?: string;
   public lastModified?: Date;
   public namedGraph?: string;
   public subjectFilter?: string;
 
+  /**
+   * Plain content type derived from {@link mediaType}, e.g. `application/n-triples`.
+   * Use this for HTTP headers, format matching, etc.
+   */
+  public readonly mimeType?: string;
+
+  /**
+   * @param accessUrl  Distribution access URL.
+   * @param mediaType  IANA media type URI per DCAT-AP 3.0
+   *   (e.g. `https://www.iana.org/assignments/media-types/application/n-triples`),
+   *   or a plain content type for convenience.
+   * @param conformsTo Specification the distribution conforms to.
+   */
   constructor(
     public readonly accessUrl: URL,
-    public readonly mimeType?: string,
+    public readonly mediaType?: string,
     public readonly conformsTo?: URL,
-  ) {}
+  ) {
+    this.mimeType = mediaType?.startsWith(IANA_MEDIA_TYPE_PREFIX)
+      ? mediaType.slice(IANA_MEDIA_TYPE_PREFIX.length)
+      : mediaType;
+  }
 
   public isSparql() {
     return (
@@ -24,7 +45,7 @@ export class Distribution {
   public static sparql(endpoint: URL, namedGraph?: string) {
     const distribution = new this(
       endpoint,
-      'application/sparql-query',
+      IANA_MEDIA_TYPE_PREFIX + 'application/sparql-query',
       new URL(SPARQL_URI),
     );
     distribution.namedGraph = namedGraph;

--- a/packages/dataset/src/mediaType.ts
+++ b/packages/dataset/src/mediaType.ts
@@ -1,16 +1,16 @@
+import { IANA_MEDIA_TYPE_PREFIX } from './distribution.js';
+
+const iana = (type: string) => IANA_MEDIA_TYPE_PREFIX + type;
+
 export const sparqlMediaTypes = [
-  'application/sparql-query',
-  'application/sparql-results+json',
-  'application/sparql-results+xml',
+  iana('application/sparql-query'),
+  iana('application/sparql-results+json'),
+  iana('application/sparql-results+xml'),
 ];
 
 export const rdfMediaTypes = [
-  'application/ld+json',
-  'application/ld+json+gzip',
-  'application/n-quads',
-  'application/n-quads+gzip',
-  'application/n-triples',
-  'application/n-triples+gzip',
-  'text/turtle',
-  'text/turtle+gzip',
+  iana('application/ld+json'),
+  iana('application/n-quads'),
+  iana('application/n-triples'),
+  iana('text/turtle'),
 ];

--- a/packages/sparql-qlever/src/importer.ts
+++ b/packages/sparql-qlever/src/importer.ts
@@ -94,13 +94,10 @@ export class Importer implements ImporterInterface {
   private fileFormatFromMimeType(mimeType: string): fileFormat {
     switch (mimeType) {
       case 'application/n-triples':
-      case 'application/n-triples+gzip':
         return 'nt';
       case 'application/n-quads':
-      case 'application/n-quads+gzip':
         return 'nq';
       case 'text/turtle':
-      case 'text/turtle+gzip':
         return 'ttl';
       default:
         throw new Error(`Unsupported media type: ${mimeType}`);

--- a/packages/sparql-qlever/vite.config.ts
+++ b/packages/sparql-qlever/vite.config.ts
@@ -12,12 +12,12 @@ export default mergeConfig(
       },
       coverage: {
         thresholds: {
-          lines: 76.92,
+          lines: 77.5,
           functions: 100,
-          branches: 43.47,
-          statements: 76.92,
+          branches: 45.45,
+          statements: 77.5,
         },
       },
     },
-  })
+  }),
 );


### PR DESCRIPTION
## Summary

- Remove non-standard `+gzip` suffixed media types (e.g. `application/n-triples+gzip`) from `rdfMediaTypes` — these were a custom convention not recognised by IANA.
- Add `compressFormat` property to `Distribution`, following DCAT-AP 3.0's `dcat:compressFormat` for modelling compression separately from media type.
- Simplify `getDownloadDistributions()` to prefer compressed distributions via `compressFormat` instead of fragile mime type suffix checks and `.nt.gz` URL heuristics. Also fixes a deduplication bug in the old implementation.
- Remove `+gzip` switch cases from QLever importer's `fileFormatFromMimeType()`.
- Wire up `dcat:compressFormat` in the registry client: namespace, ldkit schema, and Distribution mapping.
- Use full IANA media type URIs consistently in media type lists and test fixtures.
