### PR TITLE
fix(sparql-qlever): update QLever CLI binaries to new names

### DIFF
--- a/packages/sparql-qlever/src/importer.ts
+++ b/packages/sparql-qlever/src/importer.ts
@@ -120,7 +120,7 @@ export class Importer implements ImporterInterface {
     const indexTask = await this.taskRunner.run(
       `(zcat '${basename(file)}' 2>/dev/null || cat '${basename(
         file,
-      )}') | IndexBuilderMain -i ${
+      )}') | qlever-index -i ${
         this.indexName
       } -s ${settingsFile} -F ${format} -f -`,
     );

--- a/packages/sparql-qlever/src/server.ts
+++ b/packages/sparql-qlever/src/server.ts
@@ -17,7 +17,7 @@ export class Server<Task> implements SparqlServer {
     // TODO prevent double starts.
 
     this.task = await this.taskRunner.run(
-      `ServerMain --index-basename ${this.indexName} --memory-max-size 6G --port ${this.port}`
+      `qlever-server --index-basename ${this.indexName} --memory-max-size 6G --port ${this.port}`,
     );
   }
 

--- a/packages/sparql-qlever/vite.config.ts
+++ b/packages/sparql-qlever/vite.config.ts
@@ -8,7 +8,7 @@ export default mergeConfig(
     cacheDir: '../../node_modules/.vite/packages/sparql-monitor',
     test: {
       env: {
-        QLEVER_IMAGE: 'adfreiburg/qlever:commit-9352d06',
+        QLEVER_IMAGE: 'adfreiburg/qlever:commit-a14e0a0',
       },
       coverage: {
         thresholds: {


### PR DESCRIPTION
## Summary

- Rename `IndexBuilderMain` to `qlever-index` and `ServerMain` to `qlever-server` to match QLever's current binary names
- Bump the QLever Docker image from `commit-9352d06` to `commit-a14e0a0`