### PR TITLE
fix(sparql-qlever): update QLever CLI binaries to new names

### DIFF
--- a/packages/sparql-qlever/src/server.ts
+++ b/packages/sparql-qlever/src/server.ts
@@ -2,7 +2,7 @@ import { SparqlServer } from '@lde/sparql-server';
 import { TaskRunner } from '@lde/task-runner';
 
 export class Server<Task> implements SparqlServer {
-  private taskRunner: TaskRunner<Task>;
+  private readonly taskRunner: TaskRunner<Task>;
   private readonly indexName: string;
   private task?: Task;
   private readonly port: number;


### PR DESCRIPTION
## Summary

- Make `taskRunner` field `readonly` for consistency with other fields in `Server`
- Triggers a patch release for `@lde/sparql-qlever`, since #170 was merged with `build:` instead of `fix:`