### PR TITLE
ci(release): fix git push race condition when multiple PRs merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write # needed for provenance data generation and NPM trusted publishing OIDC
@@ -33,6 +37,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Pull latest main (a previous release run may have pushed)
+        run: git pull --rebase origin main
 
       - run: npx nx release --skip-publish
         env:


### PR DESCRIPTION
## Summary

When multiple commits land on main in quick succession, each push triggers a separate release workflow run. The first run to finish pushes a `chore(release): publish` commit, but subsequent runs fail with `non-fast-forward` because their local main is behind the remote.

This PR fixes the race condition with two changes:

- **Add a `concurrency` group** (`cancel-in-progress: false`) to serialise release runs. Only one runs at a time; stale intermediate pushes are dropped while the latest push always gets a chance to run.
- **Pull latest main** (`git pull --rebase`) before running `nx release`, so queued runs see the latest tags and version state — preventing non-fast-forward push failures.

## Test plan

- [x] Review the diff
- [ ] Verify the next time multiple PRs merge to main: only one release run should execute at a time and subsequent queued runs should succeed or correctly no-op