### PR TITLE
fix(sparql-qlever): wait for SPARQL endpoint to be ready after server start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34734,7 +34734,7 @@
         "c12": "^3.0.2",
         "commander": "^14.0.3",
         "cron": "^4.1.0",
-        "drizzle-kit": "^1.0.0-beta.15-9485290",
+        "drizzle-kit": "1.0.0-beta.15-9485290",
         "drizzle-orm": "1.0.0-beta.15-9485290",
         "fetch-sparql-endpoint": "^7.1.0",
         "postgres": "^3.4.5",
@@ -34756,15 +34756,16 @@
     },
     "packages/sparql-qlever": {
       "name": "@lde/sparql-qlever",
-      "version": "0.8.0",
+      "version": "0.8.2",
       "dependencies": {
         "@lde/dataset": "0.7.0",
         "@lde/distribution-downloader": "0.5.0",
         "@lde/sparql-importer": "0.3.0",
         "@lde/sparql-server": "0.4.10",
         "@lde/task-runner": "0.2.10",
-        "@lde/task-runner-docker": "0.2.10",
+        "@lde/task-runner-docker": "0.2.11",
         "@lde/task-runner-native": "0.2.11",
+        "@lde/wait-for-sparql": "0.2.11",
         "tslib": "^2.3.0"
       }
     },
@@ -34784,7 +34785,7 @@
     },
     "packages/task-runner-docker": {
       "name": "@lde/task-runner-docker",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@lde/task-runner": "0.2.10",
         "dockerode": "^4.0.7",

--- a/packages/sparql-qlever/package.json
+++ b/packages/sparql-qlever/package.json
@@ -30,6 +30,7 @@
     "@lde/task-runner": "0.2.10",
     "@lde/task-runner-docker": "0.2.11",
     "@lde/task-runner-native": "0.2.11",
+    "@lde/wait-for-sparql": "0.2.11",
     "tslib": "^2.3.0"
   }
 }

--- a/packages/sparql-qlever/src/server.ts
+++ b/packages/sparql-qlever/src/server.ts
@@ -1,5 +1,6 @@
 import { SparqlServer } from '@lde/sparql-server';
 import { TaskRunner } from '@lde/task-runner';
+import { waitForSparqlEndpointAvailable } from '@lde/wait-for-sparql';
 
 export class Server<Task> implements SparqlServer {
   private readonly taskRunner: TaskRunner<Task>;
@@ -19,6 +20,7 @@ export class Server<Task> implements SparqlServer {
     this.task = await this.taskRunner.run(
       `qlever-server --index-basename ${this.indexName} --memory-max-size 6G --port ${this.port}`,
     );
+    await waitForSparqlEndpointAvailable(this.queryEndpoint.toString());
   }
 
   public async stop(): Promise<void> {

--- a/packages/sparql-qlever/test/server.test.ts
+++ b/packages/sparql-qlever/test/server.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Server } from '../src/server.js';
 import { DockerTaskRunner } from '@lde/task-runner-docker';
-import { waitForSparqlEndpointAvailable } from '@lde/wait-for-sparql';
 import { resolve } from 'node:path';
 
 describe('Server', () => {
@@ -22,9 +21,9 @@ describe('Server', () => {
       });
 
       await server.start();
-      const endpoint = server.queryEndpoint.toString();
-      expect(endpoint).toEqual(`http://localhost:${port}/sparql`);
-      await waitForSparqlEndpointAvailable(endpoint);
+      expect(server.queryEndpoint.toString()).toEqual(
+        `http://localhost:${port}/sparql`,
+      );
       await server.stop();
     }, 20_000);
   });


### PR DESCRIPTION
## Summary

`Server.start()` spawns the QLever process but returns immediately, before the server is accepting connections. This causes early SPARQL queries to fail with `TypeError: fetch failed` (ECONNREFUSED).

- Add `waitForSparqlEndpointAvailable()` call in `Server.start()` so it only resolves once the endpoint is reachable (retries with exponential backoff)
- Promote `@lde/wait-for-sparql` from a test-only to a production dependency of `@lde/sparql-qlever`
- Remove the now-redundant `waitForSparqlEndpointAvailable` call from the server test