### PR TITLE
feat(pipeline): add distribution analysis and selection reporting

### DIFF
--- a/packages/pipeline/src/distribution/importResolver.ts
+++ b/packages/pipeline/src/distribution/importResolver.ts
@@ -44,7 +44,11 @@ export class ImportResolver implements DistributionResolver {
       );
       distribution.subjectFilter = importResult.distribution.subjectFilter;
 
-      return new ResolvedDistribution(distribution, result.probeResults);
+      return new ResolvedDistribution(
+        distribution,
+        result.probeResults,
+        importResult.distribution,
+      );
     }
 
     return new NoDistributionAvailable(

--- a/packages/pipeline/src/distribution/resolver.ts
+++ b/packages/pipeline/src/distribution/resolver.ts
@@ -6,6 +6,7 @@ export class ResolvedDistribution {
   constructor(
     readonly distribution: Distribution,
     readonly probeResults: ProbeResultType[],
+    readonly importedFrom?: Distribution,
   ) {}
 }
 

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -12,6 +12,11 @@ import {
   NoDistributionAvailable,
 } from './distribution/resolver.js';
 import { SparqlDistributionResolver } from './distribution/index.js';
+import {
+  NetworkError,
+  SparqlProbeResult,
+  type ProbeResultType,
+} from './distribution/probe.js';
 import { NotSupported } from './sparql/executor.js';
 import type { StageOutputResolver } from './stageOutputResolver.js';
 import type { ProgressReporter } from './progressReporter.js';
@@ -125,10 +130,22 @@ export class Pipeline {
     this.reporter?.datasetStart(datasetIri);
 
     const resolved = await this.distributionResolver.resolve(dataset);
+
+    this.reporter?.distributionsAnalyzed(
+      datasetIri,
+      mapProbeResults(resolved.probeResults),
+    );
+
     if (resolved instanceof NoDistributionAvailable) {
       this.reporter?.datasetSkipped(datasetIri, resolved.message);
       return;
     }
+
+    this.reporter?.distributionSelected(datasetIri, {
+      accessUrl: resolved.distribution.accessUrl.toString(),
+      namedGraph: resolved.distribution.namedGraph,
+      importedFrom: resolved.importedFrom?.accessUrl?.toString(),
+    });
 
     try {
       for (const stage of this.stages) {
@@ -277,4 +294,32 @@ export class Pipeline {
       }
     }
   }
+}
+
+function mapProbeResults(probeResults: ProbeResultType[]): Array<{
+  accessUrl: string;
+  type: 'sparql' | 'data-dump' | 'network-error';
+  available: boolean;
+  statusCode?: number;
+  error?: string;
+}> {
+  return probeResults.map((result) => {
+    if (result instanceof NetworkError) {
+      return {
+        accessUrl: result.url,
+        type: 'network-error' as const,
+        available: false,
+        error: result.message,
+      };
+    }
+    return {
+      accessUrl: result.url,
+      type:
+        result instanceof SparqlProbeResult
+          ? ('sparql' as const)
+          : ('data-dump' as const),
+      available: result.isSuccess(),
+      statusCode: result.statusCode,
+    };
+  });
 }

--- a/packages/pipeline/src/progressReporter.ts
+++ b/packages/pipeline/src/progressReporter.ts
@@ -1,6 +1,24 @@
 export interface ProgressReporter {
   pipelineStart(name: string): void;
   datasetStart(dataset: string): void;
+  distributionsAnalyzed(
+    dataset: string,
+    results: Array<{
+      accessUrl: string;
+      type: 'sparql' | 'data-dump' | 'network-error';
+      available: boolean;
+      statusCode?: number;
+      error?: string;
+    }>,
+  ): void;
+  distributionSelected(
+    dataset: string,
+    distribution: {
+      accessUrl: string;
+      namedGraph?: string;
+      importedFrom?: string;
+    },
+  ): void;
   stageStart(stage: string): void;
   stageProgress(update: {
     elementsProcessed: number;

--- a/packages/pipeline/test/distribution/importResolver.test.ts
+++ b/packages/pipeline/test/distribution/importResolver.test.ts
@@ -106,6 +106,54 @@ describe('ImportResolver', () => {
     expect(resolved.probeResults[0]).toBeInstanceOf(DataDumpProbeResult);
   });
 
+  it('sets importedFrom on ResolvedDistribution when import succeeds', async () => {
+    const dataset = makeDataset();
+    const inner = makeInnerResolver(
+      new NoDistributionAvailable(dataset, 'No endpoint', [
+        dataDumpProbeResult,
+      ]),
+    );
+
+    const importedDistribution = Distribution.sparql(
+      new URL('http://localhost:7878/sparql'),
+    );
+    const mockImporter = {
+      import: vi
+        .fn()
+        .mockResolvedValue(
+          new ImportSuccessful(importedDistribution, 'test-graph'),
+        ),
+    };
+
+    const server = makeServer();
+    const resolver = new ImportResolver(inner, {
+      importer: mockImporter,
+      server,
+    });
+    const result = await resolver.resolve(dataset);
+
+    const resolved = result as ResolvedDistribution;
+    expect(resolved.importedFrom).toBe(importedDistribution);
+  });
+
+  it('importedFrom is undefined when inner resolver succeeds directly', async () => {
+    const distribution = Distribution.sparql(
+      new URL('http://example.org/sparql'),
+    );
+    const resolved = new ResolvedDistribution(distribution, []);
+    const inner = makeInnerResolver(resolved);
+    const mockImporter = { import: vi.fn() };
+
+    const resolver = new ImportResolver(inner, {
+      importer: mockImporter,
+      server: makeServer(),
+    });
+    const result = await resolver.resolve(makeDataset());
+
+    expect(result).toBeInstanceOf(ResolvedDistribution);
+    expect((result as ResolvedDistribution).importedFrom).toBeUndefined();
+  });
+
   it('returns NoDistributionAvailable with importFailed when import fails', async () => {
     const dataset = makeDataset();
     const inner = makeInnerResolver(

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -8,6 +8,11 @@ import {
   NoDistributionAvailable,
   type DistributionResolver,
 } from '../src/distribution/resolver.js';
+import {
+  SparqlProbeResult,
+  DataDumpProbeResult,
+  NetworkError,
+} from '../src/distribution/probe.js';
 import type { Writer } from '../src/writer/writer.js';
 import type { ProgressReporter } from '../src/progressReporter.js';
 import type { StageOutputResolver } from '../src/stageOutputResolver.js';
@@ -53,6 +58,8 @@ function makeReporter(): ProgressReporter & {
   return {
     pipelineStart: vi.fn<ProgressReporter['pipelineStart']>(),
     datasetStart: vi.fn<ProgressReporter['datasetStart']>(),
+    distributionsAnalyzed: vi.fn<ProgressReporter['distributionsAnalyzed']>(),
+    distributionSelected: vi.fn<ProgressReporter['distributionSelected']>(),
     stageStart: vi.fn<ProgressReporter['stageStart']>(),
     stageProgress: vi.fn<ProgressReporter['stageProgress']>(),
     stageComplete: vi.fn<ProgressReporter['stageComplete']>(),
@@ -413,6 +420,8 @@ describe('Pipeline', () => {
       const callOrder = [
         reporter.pipelineStart,
         reporter.datasetStart,
+        reporter.distributionsAnalyzed,
+        reporter.distributionSelected,
         reporter.stageStart,
         reporter.stageComplete,
         reporter.datasetComplete,
@@ -479,6 +488,132 @@ describe('Pipeline', () => {
       });
 
       await expect(pipeline.run()).resolves.toBeUndefined();
+    });
+
+    it('distributionsAnalyzed reports probe results correctly', async () => {
+      const reporter = makeReporter();
+      const sparqlResult = new SparqlProbeResult(
+        'http://example.org/sparql',
+        new Response('', {
+          status: 200,
+          headers: { 'Content-Type': 'application/sparql-results+json' },
+        }),
+      );
+      const dataDumpResult = new DataDumpProbeResult(
+        'http://example.org/data.nt',
+        new Response('', { status: 404 }),
+      );
+      const networkError = new NetworkError(
+        'http://example.org/down',
+        'Connection refused',
+      );
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [makeStage('stage1')],
+        writers: writer,
+        distributionResolver: makeResolver(
+          new ResolvedDistribution(sparqlDistribution, [
+            sparqlResult,
+            dataDumpResult,
+            networkError,
+          ]),
+        ),
+        reporter,
+      });
+
+      await pipeline.run();
+
+      expect(reporter.distributionsAnalyzed).toHaveBeenCalledWith(
+        dataset.iri.toString(),
+        [
+          {
+            accessUrl: 'http://example.org/sparql',
+            type: 'sparql',
+            available: true,
+            statusCode: 200,
+          },
+          {
+            accessUrl: 'http://example.org/data.nt',
+            type: 'data-dump',
+            available: false,
+            statusCode: 404,
+          },
+          {
+            accessUrl: 'http://example.org/down',
+            type: 'network-error',
+            available: false,
+            error: 'Connection refused',
+          },
+        ],
+      );
+    });
+
+    it('distributionSelected reports importedFrom when import was used', async () => {
+      const reporter = makeReporter();
+      const importedFromDistribution = new Distribution(
+        new URL('http://example.org/data.nt'),
+        'application/n-triples',
+      );
+      const resolved = new ResolvedDistribution(
+        sparqlDistribution,
+        [],
+        importedFromDistribution,
+      );
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [makeStage('stage1')],
+        writers: writer,
+        distributionResolver: makeResolver(resolved),
+        reporter,
+      });
+
+      await pipeline.run();
+
+      expect(reporter.distributionSelected).toHaveBeenCalledWith(
+        dataset.iri.toString(),
+        {
+          accessUrl: 'http://example.org/sparql',
+          namedGraph: undefined,
+          importedFrom: 'http://example.org/data.nt',
+        },
+      );
+    });
+
+    it('distributionsAnalyzed called even when dataset is skipped', async () => {
+      const reporter = makeReporter();
+      const networkError = new NetworkError(
+        'http://example.org/down',
+        'Connection refused',
+      );
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [makeStage('stage1')],
+        writers: writer,
+        distributionResolver: makeResolver(
+          new NoDistributionAvailable(dataset, 'No SPARQL endpoint', [
+            networkError,
+          ]),
+        ),
+        reporter,
+      });
+
+      await pipeline.run();
+
+      expect(reporter.distributionsAnalyzed).toHaveBeenCalledWith(
+        dataset.iri.toString(),
+        [
+          {
+            accessUrl: 'http://example.org/down',
+            type: 'network-error',
+            available: false,
+            error: 'Connection refused',
+          },
+        ],
+      );
+      expect(reporter.distributionSelected).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 91.17,
-          lines: 93.62,
-          branches: 88.7,
-          statements: 92.87,
+          functions: 91.34,
+          lines: 93.71,
+          branches: 88.88,
+          statements: 92.96,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Add `distributionsAnalyzed` and `distributionSelected` methods to `ProgressReporter`, called during dataset processing to report which distributions were probed and which one was selected
- Add `importedFrom` field to `ResolvedDistribution` so clients can see when a distribution was imported from a data dump as a fallback
- Pass `importedFrom` in `ImportResolver` when import succeeds
- Add `mapProbeResults` helper in `pipeline.ts` to convert internal probe result types to the simplified report format

Fix #161

## Test plan

- [x] `distributionsAnalyzed` reports all three probe result types (SPARQL, data dump, network error)
- [x] `distributionSelected` reports `importedFrom` when import was used
- [x] `distributionsAnalyzed` is called even when dataset is skipped (no `distributionSelected`)
- [x] `importedFrom` is set on `ResolvedDistribution` when import succeeds
- [x] `importedFrom` is `undefined` when inner resolver succeeds directly
- [x] Reporter hook call order includes new methods
- [x] All 154 pipeline tests pass
- [x] Typecheck passes across all 16 workspace packages