### PR TITLE
chore: normalize package.json fields to prevent npm publish warnings

### DIFF
--- a/packages/dataset-registry-client/package.json
+++ b/packages/dataset-registry-client/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/dataset-registry-client",
   "version": "0.7.0",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/dataset-registry-client"
   },
   "type": "module",

--- a/packages/dataset/package.json
+++ b/packages/dataset/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/dataset",
   "version": "0.7.0",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/dataset"
   },
   "type": "module",

--- a/packages/distribution-downloader/package.json
+++ b/packages/distribution-downloader/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/distribution-downloader",
   "version": "0.5.0",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/distribution-downloader"
   },
   "type": "module",

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -9,15 +9,15 @@
     "generator"
   ],
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/docgen"
   },
   "type": "module",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "development": "./src/index.ts",
       "types": "./dist/index.d.ts",
+      "development": "./src/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     }
@@ -26,7 +26,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "docgen": "./dist/cli.js"
+    "docgen": "dist/cli.js"
   },
   "files": [
     "dist",

--- a/packages/fastify-rdf/package.json
+++ b/packages/fastify-rdf/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.12",
   "description": "Fastify plugin for serving RDF data with content negotiation",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/fastify-rdf"
   },
   "type": "module",

--- a/packages/local-sparql-endpoint/package.json
+++ b/packages/local-sparql-endpoint/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/local-sparql-endpoint",
   "version": "0.2.12",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/local-sparql-endpoint"
   },
   "type": "module",

--- a/packages/pipeline-console-reporter/package.json
+++ b/packages/pipeline-console-reporter/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Console progress reporter for @lde/pipeline",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/pipeline-console-reporter"
   },
   "type": "module",

--- a/packages/pipeline-void/package.json
+++ b/packages/pipeline-void/package.json
@@ -3,7 +3,7 @@
   "version": "0.10.0",
   "description": "VOiD (Vocabulary of Interlinked Datasets) statistical analysis for RDF datasets",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/pipeline-void"
   },
   "type": "module",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/pipeline",
   "version": "0.13.0",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/pipeline"
   },
   "type": "module",

--- a/packages/sparql-importer/package.json
+++ b/packages/sparql-importer/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/sparql-importer",
   "version": "0.3.0",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/sparql-importer"
   },
   "type": "module",

--- a/packages/sparql-monitor/package.json
+++ b/packages/sparql-monitor/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.13",
   "description": "Monitor SPARQL endpoints with periodic checks",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/sparql-monitor"
   },
   "type": "module",
@@ -20,7 +20,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "sparql-monitor": "./dist/cli.js"
+    "sparql-monitor": "dist/cli.js"
   },
   "files": [
     "dist",

--- a/packages/sparql-qlever/package.json
+++ b/packages/sparql-qlever/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/sparql-qlever",
   "version": "0.8.3",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/sparql-qlever"
   },
   "type": "module",

--- a/packages/sparql-server/package.json
+++ b/packages/sparql-server/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/sparql-server",
   "version": "0.4.10",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/sparql-server"
   },
   "type": "module",

--- a/packages/task-runner-docker/package.json
+++ b/packages/task-runner-docker/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/task-runner-docker",
   "version": "0.2.11",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/task-runner-docker"
   },
   "type": "module",

--- a/packages/task-runner-native/package.json
+++ b/packages/task-runner-native/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/task-runner-native",
   "version": "0.2.11",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/task-runner-native"
   },
   "type": "module",

--- a/packages/task-runner/package.json
+++ b/packages/task-runner/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/task-runner",
   "version": "0.2.10",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/task-runner"
   },
   "type": "module",

--- a/packages/wait-for-sparql/package.json
+++ b/packages/wait-for-sparql/package.json
@@ -2,7 +2,7 @@
   "name": "@lde/wait-for-sparql",
   "version": "0.2.11",
   "repository": {
-    "url": "https://github.com/ldengine/lde",
+    "url": "git+https://github.com/ldengine/lde.git",
     "directory": "packages/wait-for-sparql"
   },
   "type": "module",


### PR DESCRIPTION
## Summary

- Run `npm pkg fix` on all 17 packages to eliminate warnings during `npm publish`
- Normalize `repository.url` from `https://github.com/ldengine/lde` to `git+https://github.com/ldengine/lde.git`
- Normalize `bin` paths in `docgen` and `sparql-monitor` (remove leading `./`)