### PR TITLE
fix(pipeline-console-reporter): underline dataset URL in header

### DIFF
--- a/packages/pipeline-console-reporter/src/consoleReporter.ts
+++ b/packages/pipeline-console-reporter/src/consoleReporter.ts
@@ -37,7 +37,9 @@ export class ConsoleReporter implements ProgressReporter {
       ? ` ${chalk.dim(`[${this.datasetIndex}/${this.datasetTotal}]`)}`
       : '';
     console.info();
-    console.info(`Dataset ${chalk.bold(dataset.iri.toString())}${counter}`);
+    console.info(
+      `Dataset ${chalk.bold.underline(dataset.iri.toString())}${counter}`,
+    );
   }
 
   distributionsAnalyzed(


### PR DESCRIPTION
## Summary

- Underline the dataset URL in the console reporter header so it's visually recognizable as a clickable link in terminals that support it

## Test plan

- [x] `npx nx typecheck pipeline-console-reporter` passes
- [x] Visual confirmation: dataset URLs now appear underlined in terminal output