### PR TITLE
Add flush() to Writer and Turtle prefix support to FileWriter

### DIFF
--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -60,6 +60,10 @@ class FanOutWriter implements Writer {
       );
     }
   }
+
+  async flush(dataset: Dataset): Promise<void> {
+    for (const w of this.writers) await w.flush?.(dataset);
+  }
 }
 
 class TransformWriter implements Writer {
@@ -70,6 +74,10 @@ class TransformWriter implements Writer {
 
   async write(dataset: Dataset, quads: AsyncIterable<Quad>): Promise<void> {
     await this.inner.write(dataset, this.transform(quads, dataset));
+  }
+
+  async flush(dataset: Dataset): Promise<void> {
+    await this.inner.flush?.(dataset);
   }
 }
 
@@ -168,6 +176,7 @@ export class Pipeline {
       await this.distributionResolver.cleanup?.();
     }
 
+    await this.writer.flush?.(dataset);
     this.reporter?.datasetComplete?.(dataset);
   }
 

--- a/packages/pipeline/src/writer/fileWriter.ts
+++ b/packages/pipeline/src/writer/fileWriter.ts
@@ -1,6 +1,6 @@
 import { Dataset } from '@lde/dataset';
 import type { Quad } from '@rdfjs/types';
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, type WriteStream } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import filenamifyUrl from 'filenamify-url';
@@ -22,6 +22,11 @@ export interface FileWriterOptions {
    * @default '-'
    */
   replacementCharacter?: string;
+  /**
+   * Turtle prefix declarations. Keys are prefix names, values are namespace IRIs.
+   * Only used when format is 'turtle'.
+   */
+  prefixes?: Record<string, string>;
 }
 
 /**
@@ -29,13 +34,9 @@ export interface FileWriterOptions {
  *
  * Files are named based on the dataset IRI using filenamify-url.
  *
- * The first {@link write} call for a given dataset creates (or overwrites) the file.
- * Subsequent calls for the same dataset append to it, so that multiple pipeline stages
- * can each contribute quads to a single output file.
- *
- * **Note:** With `format: 'turtle'` each append will repeat the prefix declarations
- * at the start of each chunk. The default `format: 'n-triples'` produces clean
- * line-oriented output without repeated headers.
+ * A single N3Writer is kept open per dataset across all {@link write} calls,
+ * so Turtle prefix declarations are written once and triples can be grouped
+ * by subject. Call {@link flush} after all stages complete to finalize the file.
  */
 const formatMap: Record<string, string> = {
   turtle: 'Turtle',
@@ -47,12 +48,17 @@ export class FileWriter implements Writer {
   private readonly outputDir: string;
   readonly format: 'turtle' | 'n-triples' | 'n-quads';
   private readonly replacementCharacter: string;
-  private readonly writtenFiles = new Set<string>();
+  private readonly prefixes?: Record<string, string>;
+  private readonly activeWriters = new Map<
+    string,
+    { n3Writer: N3Writer; stream: WriteStream }
+  >();
 
   constructor(options: FileWriterOptions) {
     this.outputDir = options.outputDir;
     this.format = options.format ?? 'n-triples';
     this.replacementCharacter = options.replacementCharacter ?? '-';
+    this.prefixes = options.prefixes;
   }
 
   async write(dataset: Dataset, quads: AsyncIterable<Quad>): Promise<void> {
@@ -61,22 +67,22 @@ export class FileWriter implements Writer {
     const first = await iterator.next();
     if (first.done) return;
 
-    const filePath = join(this.outputDir, this.getFilename(dataset));
-    await mkdir(dirname(filePath), { recursive: true });
+    const { n3Writer } = await this.getOrCreateWriter(dataset);
 
-    const flags = this.writtenFiles.has(filePath) ? 'a' : 'w';
-    this.writtenFiles.add(filePath);
-
-    const stream = createWriteStream(filePath, { flags });
-    const writer = new N3Writer(stream, { format: formatMap[this.format] });
-
-    writer.addQuad(first.value);
+    n3Writer.addQuad(first.value);
     for await (const quad of { [Symbol.asyncIterator]: () => iterator }) {
-      writer.addQuad(quad);
+      n3Writer.addQuad(quad);
     }
+  }
 
+  async flush(dataset: Dataset): Promise<void> {
+    const key = this.getFilePath(dataset);
+    const entry = this.activeWriters.get(key);
+    if (!entry) return;
+
+    this.activeWriters.delete(key);
     await new Promise<void>((resolve, reject) => {
-      writer.end((error) => {
+      entry.n3Writer.end((error) => {
         if (error) reject(error);
         else resolve();
       });
@@ -84,7 +90,7 @@ export class FileWriter implements Writer {
   }
 
   getOutputPath(dataset: Dataset): string {
-    return join(this.outputDir, this.getFilename(dataset));
+    return this.getFilePath(dataset);
   }
 
   getFilename(dataset: Dataset): string {
@@ -93,6 +99,30 @@ export class FileWriter implements Writer {
       replacement: this.replacementCharacter,
     });
     return `${baseName}.${extension}`;
+  }
+
+  private getFilePath(dataset: Dataset): string {
+    return join(this.outputDir, this.getFilename(dataset));
+  }
+
+  private async getOrCreateWriter(
+    dataset: Dataset,
+  ): Promise<{ n3Writer: N3Writer; stream: WriteStream }> {
+    const key = this.getFilePath(dataset);
+    const existing = this.activeWriters.get(key);
+    if (existing) return existing;
+
+    await mkdir(dirname(key), { recursive: true });
+
+    const stream = createWriteStream(key, { flags: 'w' });
+    const n3Writer = new N3Writer(stream, {
+      format: formatMap[this.format],
+      prefixes: this.prefixes,
+    });
+
+    const entry = { n3Writer, stream };
+    this.activeWriters.set(key, entry);
+    return entry;
   }
 
   private getExtension(): string {

--- a/packages/pipeline/src/writer/writer.ts
+++ b/packages/pipeline/src/writer/writer.ts
@@ -12,4 +12,13 @@ export interface Writer {
    * @param quads The RDF quads to write
    */
   write(dataset: Dataset, quads: AsyncIterable<Quad>): Promise<void>;
+
+  /**
+   * Finalize writing for a dataset. Called after all stages complete.
+   *
+   * Writers that buffer output across multiple {@link write} calls (e.g. to
+   * share Turtle prefix declarations) should implement this to flush remaining
+   * data and release resources.
+   */
+  flush?(dataset: Dataset): Promise<void>;
 }

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -48,8 +48,14 @@ function makeResolvedDistribution(): ResolvedDistribution {
   return new ResolvedDistribution(sparqlDistribution, []);
 }
 
-function makeWriter(): Writer & { write: ReturnType<typeof vi.fn> } {
-  return { write: vi.fn().mockResolvedValue(undefined) };
+function makeWriter(): Writer & {
+  write: ReturnType<typeof vi.fn>;
+  flush: ReturnType<typeof vi.fn>;
+} {
+  return {
+    write: vi.fn().mockResolvedValue(undefined),
+    flush: vi.fn().mockResolvedValue(undefined),
+  };
 }
 
 type RequiredReporter = Required<ProgressReporter> & {
@@ -182,6 +188,42 @@ describe('Pipeline', () => {
         .calls[0][2];
       expect(usedWriter).not.toBe(writer);
       expect(usedWriter).not.toBe(writer2);
+    });
+
+    it('calls flush on writer after all stages complete for a dataset', async () => {
+      const stage1 = makeStage('stage1');
+      const stage2 = makeStage('stage2');
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [stage1, stage2],
+        writers: writer,
+        distributionResolver: makeResolver(makeResolvedDistribution()),
+      });
+
+      await pipeline.run();
+
+      expect(writer.flush).toHaveBeenCalledWith(dataset);
+      expect(writer.flush).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls flush once per dataset', async () => {
+      const dataset1 = makeDataset('http://example.org/dataset/1');
+      const dataset2 = makeDataset('http://example.org/dataset/2');
+      const stage = makeStage('stage1');
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset1, dataset2),
+        stages: [stage],
+        writers: writer,
+        distributionResolver: makeResolver(makeResolvedDistribution()),
+      });
+
+      await pipeline.run();
+
+      expect(writer.flush).toHaveBeenCalledTimes(2);
+      expect(writer.flush).toHaveBeenCalledWith(dataset1);
+      expect(writer.flush).toHaveBeenCalledWith(dataset2);
     });
 
     it('skips stage returning NotSupported', async () => {

--- a/packages/pipeline/test/writer/fileWriter.test.ts
+++ b/packages/pipeline/test/writer/fileWriter.test.ts
@@ -49,6 +49,7 @@ describe('FileWriter', () => {
           ),
         ),
       );
+      await writer.flush(dataset);
 
       const files = await readFile(
         join(tempDir, 'example.com-dataset-1.nt'),
@@ -77,6 +78,7 @@ describe('FileWriter', () => {
           ),
         ),
       );
+      await writer.flush(dataset);
 
       const content = await readFile(
         join(tempDir, 'example.com-dataset-1.nt'),
@@ -91,13 +93,14 @@ describe('FileWriter', () => {
       const dataset = createDataset('http://example.com/dataset/1');
 
       await writer.write(dataset, quadsOf());
+      await writer.flush(dataset);
 
       await expect(
         readFile(join(tempDir, 'example.com-dataset-1.nt')),
       ).rejects.toThrow();
     });
 
-    it('appends quads from a second write to the same dataset (n-triples)', async () => {
+    it('combines quads from multiple write calls into a single file', async () => {
       const writer = new FileWriter({
         outputDir: tempDir,
         format: 'n-triples',
@@ -127,6 +130,8 @@ describe('FileWriter', () => {
         ),
       );
 
+      await writer.flush(dataset);
+
       const content = await readFile(
         join(tempDir, 'example.com-dataset-1.nt'),
         'utf-8',
@@ -155,6 +160,7 @@ describe('FileWriter', () => {
           ),
         ),
       );
+      await writer.flush(dataset);
 
       const content = await readFile(
         join(tempDir, 'example.com_dataset_1.nt'),
@@ -179,12 +185,134 @@ describe('FileWriter', () => {
           ),
         ),
       );
+      await writer.flush(dataset);
 
       const content = await readFile(
         join(nestedDir, 'example.com-dataset-1.nt'),
         'utf-8',
       );
       expect(content).toBeTruthy();
+    });
+  });
+
+  describe('flush', () => {
+    it('is a no-op when no write was made for the dataset', async () => {
+      const writer = new FileWriter({ outputDir: tempDir });
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      // Should not throw.
+      await writer.flush(dataset);
+    });
+  });
+
+  describe('Turtle prefixes', () => {
+    it('writes prefix declarations and compacts IRIs', async () => {
+      const writer = new FileWriter({
+        outputDir: tempDir,
+        format: 'turtle',
+        prefixes: {
+          ex: 'http://example.com/',
+        },
+      });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/subject'),
+            namedNode('http://example.com/predicate'),
+            literal('object'),
+          ),
+        ),
+      );
+      await writer.flush(dataset);
+
+      const content = await readFile(
+        join(tempDir, 'example.com-dataset-1.ttl'),
+        'utf-8',
+      );
+      expect(content).toContain('@prefix ex: <http://example.com/>');
+      expect(content).toContain('ex:subject');
+      expect(content).toContain('ex:predicate');
+    });
+
+    it('writes a single prefix block across multiple write calls', async () => {
+      const writer = new FileWriter({
+        outputDir: tempDir,
+        format: 'turtle',
+        prefixes: {
+          ex: 'http://example.com/',
+        },
+      });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/s1'),
+            namedNode('http://example.com/p'),
+            literal('first'),
+          ),
+        ),
+      );
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/s2'),
+            namedNode('http://example.com/p'),
+            literal('second'),
+          ),
+        ),
+      );
+
+      await writer.flush(dataset);
+
+      const content = await readFile(
+        join(tempDir, 'example.com-dataset-1.ttl'),
+        'utf-8',
+      );
+
+      // Prefix block should appear exactly once.
+      const prefixCount = content.split('@prefix').length - 1;
+      expect(prefixCount).toBe(1);
+
+      // Both triples should be present.
+      expect(content).toContain('"first"');
+      expect(content).toContain('"second"');
+    });
+
+    it('writes full IRIs when no prefixes are provided', async () => {
+      const writer = new FileWriter({
+        outputDir: tempDir,
+        format: 'turtle',
+      });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/subject'),
+            namedNode('http://example.com/predicate'),
+            literal('object'),
+          ),
+        ),
+      );
+      await writer.flush(dataset);
+
+      const content = await readFile(
+        join(tempDir, 'example.com-dataset-1.ttl'),
+        'utf-8',
+      );
+      expect(content).toContain('<http://example.com/subject>');
+      expect(content).not.toContain('@prefix');
     });
   });
 });

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 91.34,
-          lines: 93.72,
-          branches: 88.88,
-          statements: 92.97,
+          functions: 91.74,
+          lines: 94.07,
+          branches: 89.38,
+          statements: 93.37,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Add optional `flush(dataset)` method to the `Writer` interface — called after all pipeline stages complete for a dataset, allowing writers to finalize buffered output
- Rewrite `FileWriter` to keep a single `N3Writer` open per dataset across all `write()` calls instead of creating a new one each time. This means Turtle prefix declarations are written once and triples can be grouped by subject
- Add `prefixes` option to `FileWriterOptions`, passed through to N3Writer for compact Turtle output
- Propagate `flush()` through `FanOutWriter` and `TransformWriter`; call it in `Pipeline.processDataset()` after stages complete
- `SparqlUpdateWriter` doesn't need `flush()` — it's optional on the interface

## Test plan

- [x] FileWriter: multiple `write()` calls produce a single prefix block in Turtle
- [x] FileWriter: prefixes compact IRIs in output
- [x] FileWriter: no prefixes = full IRIs, backward compatible
- [x] FileWriter: `flush()` without prior `write()` is a no-op
- [x] Pipeline: `flush()` called once per dataset after all stages
- [x] All 161 pipeline tests pass
- [x] Lint and typecheck clean across all 17 packages