### PR TITLE
feat(pipeline): show dataset selection duration in console reporter

### DIFF
--- a/packages/pipeline-console-reporter/src/consoleReporter.ts
+++ b/packages/pipeline-console-reporter/src/consoleReporter.ts
@@ -21,10 +21,10 @@ export class ConsoleReporter implements ProgressReporter {
     }).start();
   }
 
-  datasetsSelected(count: number): void {
+  datasetsSelected(count: number, duration: number): void {
     this.datasetTotal = count;
     if (this.stageSpinner) {
-      this.stageSpinner.text = `Selected datasets: found ${chalk.bold(count)} datasets`;
+      this.stageSpinner.text = `Selected datasets: found ${chalk.bold(count)} datasets in ${chalk.bold(prettyMilliseconds(duration))}`;
     }
   }
 

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -127,7 +127,9 @@ export class Pipeline {
 
     this.reporter?.pipelineStart?.(this.name);
 
+    const selectStart = Date.now();
     const datasets = await this.datasetSelector.select();
+    this.reporter?.datasetsSelected?.(datasets.total, Date.now() - selectStart);
     for await (const dataset of datasets) {
       await this.processDataset(dataset);
     }

--- a/packages/pipeline/src/progressReporter.ts
+++ b/packages/pipeline/src/progressReporter.ts
@@ -10,7 +10,7 @@ export interface DistributionAnalysisResult {
 
 export interface ProgressReporter {
   pipelineStart?(name: string): void;
-  datasetsSelected?(count: number): void;
+  datasetsSelected?(count: number, duration: number): void;
   datasetStart?(dataset: Dataset): void;
   distributionsAnalyzed?(
     dataset: Dataset,

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 91.74,
-          lines: 94.07,
+          lines: 94.09,
           branches: 89.38,
-          statements: 93.37,
+          statements: 93.39,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Add `duration` parameter to `ProgressReporter.datasetsSelected()` interface
- Measure selection time in `Pipeline.run()` and call `datasetsSelected()` with count and duration
- Display duration in `ConsoleReporter` using `prettyMilliseconds()` (e.g. "Selected datasets: found **3** datasets in **1.2s**")

## Test plan

- [x] `npx nx run-many -t typecheck -p pipeline pipeline-console-reporter` passes
- [x] `npx nx run-many -t test -p pipeline pipeline-console-reporter` passes (161 + 1 tests)
- [x] `npx nx run-many -t lint -p pipeline pipeline-console-reporter` passes