### PR TITLE
feat(fastify-rdf): add reply.sendHydraError() for Hydra error responses

### DIFF
--- a/packages/fastify-rdf/README.md
+++ b/packages/fastify-rdf/README.md
@@ -92,6 +92,35 @@ await app.register(fastifyRdf, { parseRdf: true });
 
 Routes without per-route or plugin-level `parseRdf` get JSON fallback for `application/ld+json` (parsed as plain JSON) and 415 Unsupported Media Type for other RDF content types.
 
+### Hydra Error Responses with `reply.sendHydraError()`
+
+Send [Hydra](https://www.hydra-cg.com/spec/latest/core/) error responses with content negotiation. This maps `error.message` to `hydra:title` and `error.cause` (when it is a string) to `hydra:description`:
+
+```typescript
+app.get('/resource', async (request, reply) => {
+  const error = new Error('Not Found', {
+    cause: 'The requested dataset was not found',
+  }) as Error & { statusCode: number };
+  error.statusCode = 404;
+  return reply.sendHydraError(error);
+});
+```
+
+The status code is taken from `error.statusCode` (standard in Fastify and http-errors), defaulting to 500.
+
+For `Accept: application/ld+json`, the response is compact JSON-LD — no `jsonld` dependency needed:
+
+```json
+{
+  "@context": "http://www.w3.org/ns/hydra/core#",
+  "@type": "Error",
+  "title": "Not Found",
+  "description": "The requested dataset was not found"
+}
+```
+
+For all other RDF formats (Turtle, N-Triples, etc.), the error is serialised through the standard RDF pipeline.
+
 ### Custom Default Content Type
 
 By default, the plugin uses `text/turtle` when no `Accept` header is provided. You can change this:

--- a/packages/fastify-rdf/src/hydra-error.ts
+++ b/packages/fastify-rdf/src/hydra-error.ts
@@ -1,0 +1,47 @@
+import { DataFactory, Store } from 'n3';
+
+const { namedNode, blankNode, literal } = DataFactory;
+
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const HYDRA_ERROR = namedNode('http://www.w3.org/ns/hydra/core#Error');
+const HYDRA_TITLE = namedNode('http://www.w3.org/ns/hydra/core#title');
+const HYDRA_DESCRIPTION = namedNode(
+  'http://www.w3.org/ns/hydra/core#description',
+);
+
+/**
+ * Serialize a Hydra error as compact JSON-LD without needing the `jsonld` dependency.
+ */
+export function serializeHydraErrorAsJsonLd(
+  title: string,
+  description?: string,
+): string {
+  const obj: Record<string, string> = {
+    '@context': 'http://www.w3.org/ns/hydra/core#',
+    '@type': 'Error',
+    title,
+  };
+  if (description !== undefined) {
+    obj['description'] = description;
+  }
+  return JSON.stringify(obj);
+}
+
+/**
+ * Create an N3 Store with Hydra error triples.
+ */
+export function createHydraErrorDataset(
+  title: string,
+  description?: string,
+): Store {
+  const store = new Store();
+  const subject = blankNode();
+  store.add(DataFactory.quad(subject, RDF_TYPE, HYDRA_ERROR));
+  store.add(DataFactory.quad(subject, HYDRA_TITLE, literal(title)));
+  if (description !== undefined) {
+    store.add(
+      DataFactory.quad(subject, HYDRA_DESCRIPTION, literal(description)),
+    );
+  }
+  return store;
+}

--- a/packages/fastify-rdf/src/index.ts
+++ b/packages/fastify-rdf/src/index.ts
@@ -4,4 +4,5 @@ export {
   type FastifyRdfOptions,
   type RdfData,
 } from './types.js';
+export { createHydraErrorDataset } from './hydra-error.js';
 export { fastifyRdf as default } from './plugin.js';

--- a/packages/fastify-rdf/src/plugin.ts
+++ b/packages/fastify-rdf/src/plugin.ts
@@ -11,6 +11,10 @@ import {
   type FastifyRdfOptions,
   type RdfData,
 } from './types.js';
+import {
+  serializeHydraErrorAsJsonLd,
+  createHydraErrorDataset,
+} from './hydra-error.js';
 
 /**
  * Collect a readable stream into a string.
@@ -205,6 +209,31 @@ async function fastifyRdfPlugin(
       },
     );
   }
+
+  server.decorateReply(
+    'sendHydraError',
+    async function (
+      this: FastifyReply,
+      error: Error & { statusCode?: number },
+    ): Promise<FastifyReply> {
+      this.status(error.statusCode ?? 500);
+      const title = error.message;
+      const description =
+        typeof error.cause === 'string' ? error.cause : undefined;
+      const contentType = negotiateContentType(
+        this.request,
+        supportedContentTypes,
+        defaultContentType,
+      );
+      if (contentType === 'application/ld+json') {
+        this.type('application/ld+json');
+        return this.send(serializeHydraErrorAsJsonLd(title, description));
+      }
+      const dataset = createHydraErrorDataset(title, description);
+      this.type(contentType);
+      return this.send(await serializeRdfToString(dataset, contentType));
+    },
+  );
 
   await registerRdfParsers(server, options.parseRdf ?? false);
 }

--- a/packages/fastify-rdf/src/types.ts
+++ b/packages/fastify-rdf/src/types.ts
@@ -44,6 +44,15 @@ declare module 'fastify' {
      * @returns The data (when overrideSend is enabled) or Promise<FastifyReply>
      */
     sendRdf(data: RdfData): RdfData | Promise<FastifyReply>;
+
+    /**
+     * Send a Hydra error response with content negotiation.
+     * Uses `error.message` as `hydra:title` and `error.cause` (if a string) as `hydra:description`.
+     * Status code defaults to `error.statusCode` or 500.
+     */
+    sendHydraError(
+      error: Error & { statusCode?: number },
+    ): Promise<FastifyReply>;
   }
 
   interface FastifyContextConfig {

--- a/packages/fastify-rdf/test/hydra-error.test.ts
+++ b/packages/fastify-rdf/test/hydra-error.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { DataFactory } from 'n3';
+import {
+  serializeHydraErrorAsJsonLd,
+  createHydraErrorDataset,
+} from '../src/hydra-error.js';
+
+const { namedNode } = DataFactory;
+
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const HYDRA_ERROR = namedNode('http://www.w3.org/ns/hydra/core#Error');
+const HYDRA_TITLE = namedNode('http://www.w3.org/ns/hydra/core#title');
+const HYDRA_DESCRIPTION = namedNode(
+  'http://www.w3.org/ns/hydra/core#description',
+);
+
+describe('serializeHydraErrorAsJsonLd', () => {
+  it('should produce @context, @type, and title', () => {
+    const json = JSON.parse(serializeHydraErrorAsJsonLd('Not Found'));
+    expect(json['@context']).toBe('http://www.w3.org/ns/hydra/core#');
+    expect(json['@type']).toBe('Error');
+    expect(json['title']).toBe('Not Found');
+  });
+
+  it('should include description when provided', () => {
+    const json = JSON.parse(
+      serializeHydraErrorAsJsonLd('Not Found', 'The resource was not found'),
+    );
+    expect(json['description']).toBe('The resource was not found');
+  });
+
+  it('should omit description when not provided', () => {
+    const json = JSON.parse(serializeHydraErrorAsJsonLd('Not Found'));
+    expect(json).not.toHaveProperty('description');
+  });
+
+  it('should omit @id', () => {
+    const json = JSON.parse(serializeHydraErrorAsJsonLd('Not Found'));
+    expect(json).not.toHaveProperty('@id');
+  });
+});
+
+describe('createHydraErrorDataset', () => {
+  it('should produce rdf:type hydra:Error triple', () => {
+    const dataset = createHydraErrorDataset('Not Found');
+    const types = [...dataset.match(null, RDF_TYPE, HYDRA_ERROR)];
+    expect(types).toHaveLength(1);
+  });
+
+  it('should produce hydra:title triple', () => {
+    const dataset = createHydraErrorDataset('Not Found');
+    const titles = [...dataset.match(null, HYDRA_TITLE, null)];
+    expect(titles).toHaveLength(1);
+    expect(titles[0].object.value).toBe('Not Found');
+  });
+
+  it('should produce hydra:description triple when provided', () => {
+    const dataset = createHydraErrorDataset(
+      'Not Found',
+      'The resource was not found',
+    );
+    const descriptions = [...dataset.match(null, HYDRA_DESCRIPTION, null)];
+    expect(descriptions).toHaveLength(1);
+    expect(descriptions[0].object.value).toBe('The resource was not found');
+  });
+
+  it('should omit hydra:description when not provided', () => {
+    const dataset = createHydraErrorDataset('Not Found');
+    const descriptions = [...dataset.match(null, HYDRA_DESCRIPTION, null)];
+    expect(descriptions).toHaveLength(0);
+  });
+
+  it('should use a blank node subject', () => {
+    const dataset = createHydraErrorDataset('Not Found');
+    const quads = [...dataset];
+    for (const quad of quads) {
+      expect(quad.subject.termType).toBe('BlankNode');
+    }
+  });
+});

--- a/packages/fastify-rdf/test/plugin.test.ts
+++ b/packages/fastify-rdf/test/plugin.test.ts
@@ -349,6 +349,174 @@ describe('fastifyRdf plugin', () => {
     });
   });
 
+  describe('reply.sendHydraError', () => {
+    it('should return compact JSON-LD Hydra error for Accept: application/ld+json', async () => {
+      await app.register(fastifyRdf);
+      app.get('/error', async (_request, reply) => {
+        const error = new Error('Not Found') as Error & { statusCode: number };
+        error.statusCode = 404;
+        return reply.sendHydraError(error);
+      });
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/error',
+        headers: { accept: 'application/ld+json' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.headers['content-type']).toContain('application/ld+json');
+      const json = response.json();
+      expect(json['@context']).toBe('http://www.w3.org/ns/hydra/core#');
+      expect(json['@type']).toBe('Error');
+      expect(json['title']).toBe('Not Found');
+    });
+
+    it('should include description from string error.cause', async () => {
+      await app.register(fastifyRdf);
+      app.get('/error', async (_request, reply) => {
+        const error = new Error('Not Found', {
+          cause: 'The dataset was not found',
+        }) as Error & { statusCode: number };
+        error.statusCode = 404;
+        return reply.sendHydraError(error);
+      });
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/error',
+        headers: { accept: 'application/ld+json' },
+      });
+
+      const json = response.json();
+      expect(json['description']).toBe('The dataset was not found');
+    });
+
+    it('should omit description when cause is not a string', async () => {
+      await app.register(fastifyRdf);
+      app.get('/error', async (_request, reply) => {
+        const error = new Error('Internal error', {
+          cause: new Error('underlying'),
+        }) as Error & { statusCode: number };
+        error.statusCode = 500;
+        return reply.sendHydraError(error);
+      });
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/error',
+        headers: { accept: 'application/ld+json' },
+      });
+
+      const json = response.json();
+      expect(json).not.toHaveProperty('description');
+    });
+
+    it('should default to status 500 when statusCode is absent', async () => {
+      await app.register(fastifyRdf);
+      app.get('/error', async (_request, reply) => {
+        return reply.sendHydraError(new Error('Something broke'));
+      });
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/error',
+        headers: { accept: 'application/ld+json' },
+      });
+
+      expect(response.statusCode).toBe(500);
+    });
+
+    it('should serialise as Turtle for Accept: text/turtle', async () => {
+      await app.register(fastifyRdf);
+      app.get('/error', async (_request, reply) => {
+        const error = new Error('Not Found') as Error & { statusCode: number };
+        error.statusCode = 404;
+        return reply.sendHydraError(error);
+      });
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/error',
+        headers: { accept: 'text/turtle' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.headers['content-type']).toContain('text/turtle');
+      expect(response.body).toContain('http://www.w3.org/ns/hydra/core#Error');
+      expect(response.body).toContain('Not Found');
+    });
+
+    it('should serialise as N-Triples for Accept: application/n-triples', async () => {
+      await app.register(fastifyRdf);
+      app.get('/error', async (_request, reply) => {
+        const error = new Error('Not Found') as Error & { statusCode: number };
+        error.statusCode = 404;
+        return reply.sendHydraError(error);
+      });
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/error',
+        headers: { accept: 'application/n-triples' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.headers['content-type']).toContain(
+        'application/n-triples',
+      );
+      expect(response.body).toContain(
+        '<http://www.w3.org/ns/hydra/core#Error>',
+      );
+    });
+
+    it('should work correctly under overrideSend mode', async () => {
+      await app.register(fastifyRdf, { overrideSend: true });
+      app.get('/error', async (_request, reply) => {
+        const error = new Error('Not Found') as Error & { statusCode: number };
+        error.statusCode = 404;
+        return reply.sendHydraError(error);
+      });
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/error',
+        headers: { accept: 'application/ld+json' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      const json = response.json();
+      expect(json['@type']).toBe('Error');
+      expect(json['title']).toBe('Not Found');
+    });
+
+    it('should use default content type when no Accept header', async () => {
+      await app.register(fastifyRdf);
+      app.get('/error', async (_request, reply) => {
+        const error = new Error('Not Found') as Error & { statusCode: number };
+        error.statusCode = 404;
+        return reply.sendHydraError(error);
+      });
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/error',
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.headers['content-type']).toContain('text/turtle');
+      expect(response.body).toContain('Not Found');
+    });
+  });
+
   describe('overrideSend option', () => {
     it('should serialize DatasetCore returned from handler', async () => {
       await app.register(fastifyRdf, { overrideSend: true });

--- a/packages/fastify-rdf/vite.config.ts
+++ b/packages/fastify-rdf/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 93.33,
-          lines: 96.92,
-          branches: 93.93,
-          statements: 97.01,
+          functions: 94.44,
+          lines: 97.82,
+          branches: 95.34,
+          statements: 97.87,
         },
       },
     },


### PR DESCRIPTION
## Summary

Add `reply.sendHydraError(error)` to `@lde/fastify-rdf` for sending [Hydra](https://www.hydra-cg.com/spec/latest/core/) error responses with content negotiation.

- Maps `error.message` to `hydra:title` and string `error.cause` to `hydra:description`
- Status code from `error.statusCode`, defaulting to 500
- For `application/ld+json`: returns compact JSON-LD directly — no `jsonld` dependency needed
- For all other RDF formats: builds an N3 Store and serialises through the existing pipeline
- Exports `createHydraErrorDataset` for consumer test assertions

Fix #186

## Test plan

- [x] `npx nx test fastify-rdf` — 36 tests pass (9 hydra-error unit + 27 plugin integration)
- [x] `npx nx lint fastify-rdf` — clean
- [x] `npx nx typecheck fastify-rdf` — clean
- [x] `npx nx build fastify-rdf` — clean