### PR TITLE
fix(pipeline): fix race condition in tee that skips quads for slow consumers

### DIFF
--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -47,28 +47,44 @@ export interface PipelineOptions {
 
 /**
  * Split an async iterable into `count` branches that can be consumed
- * independently. Backpressure is enforced by the slowest consumer —
+ * independently. Backpressure is enforced by the slowest consumer –
  * the source only advances once every branch has consumed the current item.
  */
 function tee<T>(source: AsyncIterable<T>, count: number): AsyncIterable<T>[] {
   const iterator = source[Symbol.asyncIterator]();
   let current: Promise<IteratorResult<T>> | undefined;
-  let consumed = 0;
+  const consumed = new Array<boolean>(count).fill(false);
+  const waiting: (() => void)[] = [];
 
-  function advance(): Promise<IteratorResult<T>> {
-    if (!current || consumed >= count) {
-      consumed = 0;
+  function advance(branch: number): Promise<IteratorResult<T>> {
+    // First branch to request a new round fetches from the source.
+    if (!current || consumed.every(Boolean)) {
+      consumed.fill(false);
       current = iterator.next();
     }
-    consumed++;
+
+    // This branch already consumed the current item – wait for the next round.
+    if (consumed[branch]) {
+      return new Promise<void>(resolve => waiting.push(resolve)).then(() =>
+        advance(branch),
+      );
+    }
+
+    consumed[branch] = true;
+
+    // All branches consumed – wake up any that are waiting for the next round.
+    if (consumed.every(Boolean)) {
+      for (const resolve of waiting.splice(0)) resolve();
+    }
+
     return current;
   }
 
-  return Array.from({ length: count }, () => ({
+  return Array.from({length: count}, (_, index) => ({
     [Symbol.asyncIterator](): AsyncIterator<T> {
       return {
         async next() {
-          return advance();
+          return advance(index);
         },
       };
     },

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -184,7 +184,7 @@ describe('Pipeline', () => {
       );
     });
 
-    it('fans out to multiple writers', async () => {
+    it('fans out to multiple writers at different speeds', async () => {
       const quadsA: Quad[] = [];
       const quadsB: Quad[] = [];
       const writerA: Writer = {
@@ -192,59 +192,6 @@ describe('Pipeline', () => {
           for await (const quad of quads) quadsA.push(quad);
         },
         flush: vi.fn().mockResolvedValue(undefined),
-      };
-      const writerB: Writer = {
-        async write(_dataset, quads) {
-          for await (const quad of quads) quadsB.push(quad);
-        },
-        flush: vi.fn().mockResolvedValue(undefined),
-      };
-
-      const testQuads = [
-        DataFactory.quad(
-          DataFactory.namedNode('http://s1'),
-          DataFactory.namedNode('http://p1'),
-          DataFactory.namedNode('http://o1'),
-        ),
-        DataFactory.quad(
-          DataFactory.namedNode('http://s2'),
-          DataFactory.namedNode('http://p2'),
-          DataFactory.namedNode('http://o2'),
-        ),
-      ];
-
-      const stage = new Stage({ name: 'stage1', executors: [] });
-      vi.spyOn(stage, 'run').mockImplementation(
-        async (_dataset, _distribution, stageWriter) => {
-          await stageWriter.write(
-            _dataset,
-            (async function* () {
-              yield* testQuads;
-            })(),
-          );
-        },
-      );
-
-      const pipeline = new Pipeline({
-        datasetSelector: makeDatasetSelector(dataset),
-        stages: [stage],
-        writers: [writerA, writerB],
-        distributionResolver: makeResolver(makeResolvedDistribution()),
-      });
-
-      await pipeline.run();
-
-      expect(quadsA).toEqual(testQuads);
-      expect(quadsB).toEqual(testQuads);
-    });
-
-    it('fans out correctly when writers consume at different speeds', async () => {
-      const quadsA: Quad[] = [];
-      const quadsB: Quad[] = [];
-      const writerA: Writer = {
-        async write(_dataset, quads) {
-          for await (const quad of quads) quadsA.push(quad);
-        },
       };
       const writerB: Writer = {
         async write(_dataset, quads) {
@@ -254,6 +201,7 @@ describe('Pipeline', () => {
             quadsB.push(quad);
           }
         },
+        flush: vi.fn().mockResolvedValue(undefined),
       };
 
       const testQuads = [

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -238,6 +238,67 @@ describe('Pipeline', () => {
       expect(quadsB).toEqual(testQuads);
     });
 
+    it('fans out correctly when writers consume at different speeds', async () => {
+      const quadsA: Quad[] = [];
+      const quadsB: Quad[] = [];
+      const writerA: Writer = {
+        async write(_dataset, quads) {
+          for await (const quad of quads) quadsA.push(quad);
+        },
+      };
+      const writerB: Writer = {
+        async write(_dataset, quads) {
+          for await (const quad of quads) {
+            // Simulate a slow consumer (e.g. HTTP-based SparqlUpdateWriter).
+            await new Promise(resolve => setTimeout(resolve, 50));
+            quadsB.push(quad);
+          }
+        },
+      };
+
+      const testQuads = [
+        DataFactory.quad(
+          DataFactory.namedNode('http://s1'),
+          DataFactory.namedNode('http://p1'),
+          DataFactory.namedNode('http://o1'),
+        ),
+        DataFactory.quad(
+          DataFactory.namedNode('http://s2'),
+          DataFactory.namedNode('http://p2'),
+          DataFactory.namedNode('http://o2'),
+        ),
+        DataFactory.quad(
+          DataFactory.namedNode('http://s3'),
+          DataFactory.namedNode('http://p3'),
+          DataFactory.namedNode('http://o3'),
+        ),
+      ];
+
+      const stage = new Stage({name: 'stage1', executors: []});
+      vi.spyOn(stage, 'run').mockImplementation(
+        async (_dataset, _distribution, stageWriter) => {
+          await stageWriter.write(
+            _dataset,
+            (async function* () {
+              yield* testQuads;
+            })(),
+          );
+        },
+      );
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [stage],
+        writers: [writerA, writerB],
+        distributionResolver: makeResolver(makeResolvedDistribution()),
+      });
+
+      await pipeline.run();
+
+      expect(quadsA).toEqual(testQuads);
+      expect(quadsB).toEqual(testQuads);
+    });
+
     it('calls flush on writer after all stages complete for a dataset', async () => {
       const stage1 = makeStage('stage1');
       const stage2 = makeStage('stage2');

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 93.57,
-          lines: 93.74,
-          branches: 88.01,
-          statements: 93.15,
+          functions: 93.66,
+          lines: 93.79,
+          branches: 88.14,
+          statements: 93.22,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Fix race condition in `tee()` where a fast writer (e.g. `FileWriter`) could lap a slow writer (e.g. `SparqlUpdateWriter`), causing the slow writer to skip quads
- The root cause was a shared `consumed` counter with no per-branch tracking – any branch could increment it, letting one branch advance the source past items another branch hadn't seen
- Replace with per-branch consumption flags and a barrier: fast branches wait until all branches have consumed the current item before the source advances
- Strengthen the existing fan-out test to use differently-paced writers, covering the race condition
