### PR TITLE
ci: use npm ci in nx-migrate to avoid flaky cache EEXIST

### DIFF
--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.check.outputs.up_to_date == 'false'
-        run: npm install
+        run: npm ci
 
       - name: Run nx migrate
         if: steps.check.outputs.up_to_date == 'false'


### PR DESCRIPTION
The nightly Nx migrate job failed with `npm error EEXIST` in `/home/runner/.npm/_cacache/tmp` during `npm install`. Switching the initial install to `npm ci` gives a deterministic install from the lockfile and is less prone to the concurrent-cache-write race. The second install after `nx migrate` stays as `npm install` since that step modifies `package.json`.

Failed run: https://github.com/ldelements/lde/actions/runs/24386478975