### PR TITLE
fix(pipeline): propagate Last-Modified from probe to candidate distribution

### DIFF
--- a/packages/pipeline/src/distribution/importResolver.ts
+++ b/packages/pipeline/src/distribution/importResolver.ts
@@ -80,6 +80,22 @@ export class ImportResolver implements DistributionResolver {
       .getDownloadDistributions()
       .filter((d) => d.accessUrl && successfulUrls.has(d.accessUrl.toString()));
 
+    // Propagate Last-Modified from probe to candidate so the downloader can
+    // skip redundant downloads (and preserve the QLever index cache).
+    for (const candidate of candidates) {
+      if (candidate.lastModified) continue;
+      const probeResult = probeResults.find(
+        (r) => r.url === candidate.accessUrl.toString(),
+      );
+      if (
+        probeResult &&
+        !(probeResult instanceof NetworkError) &&
+        probeResult.lastModified
+      ) {
+        candidate.lastModified = probeResult.lastModified;
+      }
+    }
+
     if (candidates.length === 0) {
       return new NoDistributionAvailable(
         dataset,

--- a/packages/pipeline/test/distribution/importResolver.test.ts
+++ b/packages/pipeline/test/distribution/importResolver.test.ts
@@ -381,6 +381,101 @@ describe('ImportResolver', () => {
       expect(server.start).not.toHaveBeenCalled();
     });
 
+    it('propagates Last-Modified from probe to candidate distribution', async () => {
+      const dataset = makeDataset();
+      const lastModified = new Date('2026-01-15T10:00:00Z');
+      const probeResult = new DataDumpProbeResult(
+        'http://example.org/data.nt',
+        new Response('', {
+          status: 200,
+          headers: {
+            'Content-Length': '1000',
+            'Content-Type': 'application/n-triples',
+            'Last-Modified': lastModified.toUTCString(),
+          },
+        }),
+        0,
+      );
+      const inner = makeInnerResolver(
+        new NoDistributionAvailable(dataset, 'No endpoint', [probeResult]),
+      );
+
+      const mockImporter = {
+        import: vi
+          .fn()
+          .mockResolvedValue(
+            new ImportSuccessful(
+              Distribution.sparql(new URL('http://localhost:7878/sparql')),
+              'test-graph',
+            ),
+          ),
+      };
+
+      const resolver = new ImportResolver(inner, {
+        importer: mockImporter,
+        server: makeServer(),
+      });
+      await resolver.resolve(dataset);
+
+      expect(dataset.distributions[0].lastModified).toEqual(lastModified);
+      expect(mockImporter.import).toHaveBeenCalledWith([
+        dataset.distributions[0],
+      ]);
+    });
+
+    it('does not overwrite Last-Modified already set on the distribution', async () => {
+      const existingLastModified = new Date('2026-01-01T00:00:00Z');
+      const dataset = new Dataset({
+        iri: new URL('http://example.org/dataset'),
+        distributions: [
+          (() => {
+            const distribution = new Distribution(
+              new URL('http://example.org/data.nt'),
+              'application/n-triples',
+            );
+            distribution.lastModified = existingLastModified;
+            return distribution;
+          })(),
+        ],
+      });
+      const probeResult = new DataDumpProbeResult(
+        'http://example.org/data.nt',
+        new Response('', {
+          status: 200,
+          headers: {
+            'Content-Length': '1000',
+            'Content-Type': 'application/n-triples',
+            'Last-Modified': new Date('2026-02-15T10:00:00Z').toUTCString(),
+          },
+        }),
+        0,
+      );
+      const inner = makeInnerResolver(
+        new NoDistributionAvailable(dataset, 'No endpoint', [probeResult]),
+      );
+
+      const mockImporter = {
+        import: vi
+          .fn()
+          .mockResolvedValue(
+            new ImportSuccessful(
+              Distribution.sparql(new URL('http://localhost:7878/sparql')),
+              'test-graph',
+            ),
+          ),
+      };
+
+      const resolver = new ImportResolver(inner, {
+        importer: mockImporter,
+        server: makeServer(),
+      });
+      await resolver.resolve(dataset);
+
+      expect(dataset.distributions[0].lastModified).toEqual(
+        existingLastModified,
+      );
+    });
+
     it('preserves subjectFilter from imported distribution', async () => {
       const dataset = makeDataset();
       const inner = makeInnerResolver(

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 93.18,
-          lines: 93.23,
-          branches: 88.95,
-          statements: 92.76,
+          functions: 93.23,
+          lines: 93.3,
+          branches: 89.19,
+          statements: 92.83,
         },
       },
     },


### PR DESCRIPTION
Closes #296.

## Summary

`ImportResolver.importDataset()` now copies the HTTP `Last-Modified` header captured during probing (`ProbeResult.lastModified`) onto candidate distributions before passing them to the importer. This lets `LastModifiedDownloader.localFileIsUpToDate()` skip redundant downloads – and preserves the QLever index cache – for distributions that don’t have `lastModified` set by the dataset source (e.g. manual `dataset.ttl` selections).

Existing `lastModified` values (e.g. those set by `@lde/dataset-registry-client` from the registry’s `modified` field) are preserved.

## Test plan

- [x] New unit test verifies `Last-Modified` propagation from probe to candidate
- [x] New unit test verifies an existing `lastModified` is not overwritten by probe value
- [x] `npx nx test @lde/pipeline` (213 tests pass)