### PR TITLE
test(sparql-qlever): raise Docker-backed test timeouts to 120s

### DIFF
--- a/packages/sparql-qlever/test/importer.test.ts
+++ b/packages/sparql-qlever/test/importer.test.ts
@@ -78,7 +78,7 @@ describe('Importer', () => {
       const result = await importer.import(distributions);
       expect(result).toBeInstanceOf(ImportSuccessful);
       expect((result as ImportSuccessful).tripleCount).toBe(1);
-    }, 30_000);
+    }, 120_000);
   });
 
   describe('index caching', () => {

--- a/packages/sparql-qlever/test/server.test.ts
+++ b/packages/sparql-qlever/test/server.test.ts
@@ -25,6 +25,6 @@ describe('Server', () => {
         `http://localhost:${port}/sparql`,
       );
       await server.stop();
-    }, 20_000);
+    }, 120_000);
   });
 });


### PR DESCRIPTION
## Summary

- The last 3 CI runs on `main` failed with `@lde/sparql-qlever:test > test/server.test.ts > Server > start > starts and stops QLever` timing out at 20s. The Docker-backed `importer.test.ts` (30s) trips on some runs too.
- Root cause: both tests use `DockerTaskRunner.run()`, which pulls `adfreiburg/qlever:commit-a14e0a0` inline. On cold GitHub runners the pull alone exceeds the test budget.
- Fix: raise the per-test timeouts to 120s on the two tests that pull the QLever image. No CI-side coordination needed.

## Test plan

- [x] CI on this PR passes the `@lde/sparql-qlever:test` step.
- [x] After merge, monitor the next `main` CI run to confirm the QLever timeout no longer recurs.
