### PR TITLE
fix(docgen): unwrap xsd:string literals after jsonld v9 fromRDF

### DIFF
--- a/packages/docgen/src/parse.ts
+++ b/packages/docgen/src/parse.ts
@@ -4,6 +4,8 @@ import jsonld from 'jsonld';
 import { rdfSerializer } from 'rdf-serialize';
 import streamToString from 'stream-to-string';
 
+const XSD_STRING = 'http://www.w3.org/2001/XMLSchema#string';
+
 export async function parseRdfToJsonLd(filePath: string): Promise<JsonLdArray> {
   const { data } = await rdfDereferencer.dereference(filePath, {
     localFiles: true,
@@ -16,7 +18,32 @@ export async function parseRdfToJsonLd(filePath: string): Promise<JsonLdArray> {
 
   const nqString = await streamToString(nq);
 
-  return jsonld.fromRDF(nqString, {
+  const expanded = await jsonld.fromRDF(nqString, {
     useNativeTypes: true, // Convert xsd:integer to Number etc.
   });
+
+  // jsonld v9 emits @type: xsd:string on every plain string literal; v8 omitted
+  // it because xsd:string is the JSON-LD default datatype. Without this strip,
+  // framing yields { @value, @type } objects that templates render as
+  // ‘[object Object]’. See https://github.com/ldelements/lde/issues/369.
+  return stripDefaultStringType(expanded);
+}
+
+function stripDefaultStringType<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(stripDefaultStringType) as T;
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (record['@value'] !== undefined && record['@type'] === XSD_STRING) {
+      const { ['@type']: _, ...rest } = record;
+      return rest as T;
+    }
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(record)) {
+      result[key] = stripDefaultStringType(record[key]);
+    }
+    return result as T;
+  }
+  return value;
 }

--- a/packages/docgen/test/fixtures/shacl.ttl
+++ b/packages/docgen/test/fixtures/shacl.ttl
@@ -6,6 +6,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 [] a sh:NodeShape ;
+    sh:name "Dataset" ;
     sh:targetClass dcat:Dataset ;
     sh:property [
         sh:path dct:title ;

--- a/packages/docgen/test/fixtures/template.liquid
+++ b/packages/docgen/test/fixtures/template.liquid
@@ -1,4 +1,5 @@
 {% for nodeShape in nodeShapes -%}
+    name: {{ nodeShape.name }}
     targetClass: {{ nodeShape.targetClass }}
     {% assign mergedProperties = nodeShape.property | mergePropertiesByPath -%}
     numOfProperties: {{ mergedProperties.size -}}

--- a/packages/docgen/test/index.test.ts
+++ b/packages/docgen/test/index.test.ts
@@ -11,8 +11,8 @@ describe('Integration tests', () => {
   it('should render template using the built-in default frame', async () => {
     const output = await generateDocumentation(SHACL_PATH, TEMPLATE_PATH);
 
-    expect(output.trim().replace(/ +$/gm, ''))
-      .toBe(`targetClass: http://www.w3.org/ns/dcat#Dataset
+    expect(output.trim().replace(/ +$/gm, '')).toBe(`name: Dataset
+    targetClass: http://www.w3.org/ns/dcat#Dataset
     numOfProperties: 5
         path: http://purl.org/dc/terms/title
         minCount: 1


### PR DESCRIPTION
## Summary

Fixes the `docgen from-shacl` regression where named values in framed JSON-LD render as `[object Object]` in Liquid templates (e.g. `{{ nodeShape.name }}`).

Root cause: between jsonld **v8 → v9**, the `fromRDF` implementation changed. v8 explicitly skipped writing `@type` when the datatype was `xsd:string` (the JSON-LD default datatype); v9 always writes it. With `useNativeTypes: true`, plain string literals therefore arrive as `{ "@value": "...", "@type": "xsd:string" }` instead of unwrapped scalars. After framing, Liquid stringifies the wrapper as `[object Object]`.

## Changes

- `packages/docgen/src/parse.ts` — post-process the `jsonld.fromRDF` output and drop `@type` from any value object whose type is `xsd:string`, restoring v8 behaviour.
- `packages/docgen/test/fixtures/shacl.ttl`, `template.liquid`, `index.test.ts` — extend the integration fixture with `sh:name "Dataset"` and assert it renders as a plain string, locking in the fix.

Fix #369
