### PR TITLE
feat(pipeline-shacl-sampler): add per-class sampling stages derived from SHACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Data transformations are expressed as plain SPARQL queries: portable, transparen
 
 ## Standards
 
-| Standard                                                              | Usage                                                                                     |
-| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| [DCAT-AP 3.0](https://semiceu.github.io/DCAT-AP/releases/3.0.0/) (EU) | Dataset discovery and registry queries                                                    |
-| [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/)                   | Data transformations, dataset queries and endpoint management                             |
-| [SHACL](https://www.w3.org/TR/shacl/)                                 | Validation (`@lde/pipeline-shacl-validator`) and documentation generation (`@lde/docgen`) |
-| [VoID](https://www.w3.org/TR/void/)                                   | Statistical analysis of RDF datasets (`@lde/pipeline-void`)                               |
-| [RDF/JS](https://rdf.js.org/)                                         | Internal data model (N3)                                                                  |
-| [LDES](https://semiceu.github.io/LinkedDataEventStreams/) (EU)        | Event stream consumption and publication (planned)                                        |
+| Standard                                                              | Usage                                                                                                                                         |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [DCAT-AP 3.0](https://semiceu.github.io/DCAT-AP/releases/3.0.0/) (EU) | Dataset discovery and registry queries                                                                                                        |
+| [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/)                   | Data transformations, dataset queries and endpoint management                                                                                 |
+| [SHACL](https://www.w3.org/TR/shacl/)                                 | Per-class sampling (`@lde/pipeline-shacl-sampler`), validation (`@lde/pipeline-shacl-validator`) and documentation generation (`@lde/docgen`) |
+| [VoID](https://www.w3.org/TR/void/)                                   | Statistical analysis of RDF datasets (`@lde/pipeline-void`)                                                                                   |
+| [RDF/JS](https://rdf.js.org/)                                         | Internal data model (N3)                                                                                                                      |
+| [LDES](https://semiceu.github.io/LinkedDataEventStreams/) (EU)        | Event stream consumption and publication (planned)                                                                                            |
 
 ## Quick example
 
@@ -86,6 +86,11 @@ await pipeline.run();
   <td><a href="packages/pipeline">@lde/pipeline</a></td>
   <td><a href="https://www.npmjs.com/package/@lde/pipeline"><img src="https://img.shields.io/npm/v/@lde/pipeline" alt="npm"></a></td>
   <td>Build pipelines that query, transform and enrich Linked Data</td>
+</tr>
+<tr>
+  <td><a href="packages/pipeline-shacl-sampler">@lde/pipeline-shacl-sampler</a></td>
+  <td><a href="https://www.npmjs.com/package/@lde/pipeline-shacl-sampler"><img src="https://img.shields.io/npm/v/@lde/pipeline-shacl-sampler" alt="npm"></a></td>
+  <td>Per-class sampling stages derived from SHACL shapes</td>
 </tr>
 <tr>
   <td><a href="packages/pipeline-shacl-validator">@lde/pipeline-shacl-validator</a></td>
@@ -185,6 +190,7 @@ graph TD
     pipeline --> dataset-registry-client
     pipeline --> sparql-server
     pipeline --> sparql-importer
+    pipeline-shacl-sampler --> pipeline
     pipeline-shacl-validator --> pipeline
     pipeline-void --> pipeline
     distribution-downloader --> dataset

--- a/package-lock.json
+++ b/package-lock.json
@@ -22722,6 +22722,10 @@
       "resolved": "packages/pipeline-console-reporter",
       "link": true
     },
+    "node_modules/@lde/pipeline-shacl-sampler": {
+      "resolved": "packages/pipeline-shacl-sampler",
+      "link": true
+    },
     "node_modules/@lde/pipeline-shacl-validator": {
       "resolved": "packages/pipeline-shacl-validator",
       "link": true
@@ -38280,7 +38284,7 @@
         "c12": "^3.3.4",
         "commander": "^14.0.3",
         "cron": "^4.1.0",
-        "drizzle-kit": "^1.0.0-rc.2",
+        "drizzle-kit": "1.0.0-rc.2",
         "drizzle-orm": "1.0.0-beta.22-41a7d21",
         "postgres": "^3.4.9",
         "tslib": "^2.3.0"
@@ -39256,6 +39260,34 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "packages/pipeline-shacl-sampler": {
+      "name": "@lde/pipeline-shacl-sampler",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.1",
+        "n3": "^2.0.3",
+        "rdf-dereference": "^5.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@lde/dataset": "0.7.3",
+        "@lde/pipeline": "0.28.13"
+      }
+    },
+    "packages/pipeline-shacl-sampler/node_modules/n3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-2.0.3.tgz",
+      "integrity": "sha512-um/toGVENTarHBYIK2TdH6ByBhW75WpdKpv8iTYt9wF2QfBk8s8a16iaWZFUAAC1BKfGdb99kfgx6pltdDwfKA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "packages/pipeline-shacl-validator": {

--- a/packages/pipeline-console-reporter/src/consoleReporter.ts
+++ b/packages/pipeline-console-reporter/src/consoleReporter.ts
@@ -231,7 +231,7 @@ export class ConsoleReporter implements ProgressReporter {
     }
   }
 
-  stageValidated(_stage: string, report: ValidationReport): void {
+  datasetValidated(_dataset: Dataset, report: ValidationReport): void {
     if (report.conforms) {
       this.printLine(
         logSymbols.success,

--- a/packages/pipeline-console-reporter/test/consoleReporter.test.ts
+++ b/packages/pipeline-console-reporter/test/consoleReporter.test.ts
@@ -32,12 +32,12 @@ describe('ConsoleReporter', () => {
     expect(reporter).toBeInstanceOf(ConsoleReporter);
   });
 
-  describe('stageValidated', () => {
+  describe('datasetValidated', () => {
     it('shows success when validation conforms', () => {
       const reporter = new ConsoleReporter();
       const spy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
 
-      reporter.stageValidated('transform', {
+      reporter.datasetValidated(makeDataset(), {
         conforms: true,
         violations: 0,
         quadsValidated: 5000,
@@ -52,7 +52,7 @@ describe('ConsoleReporter', () => {
       const reporter = new ConsoleReporter();
       const spy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
 
-      reporter.stageValidated('transform', {
+      reporter.datasetValidated(makeDataset(), {
         conforms: false,
         violations: 3,
         quadsValidated: 10000,

--- a/packages/pipeline-shacl-sampler/README.md
+++ b/packages/pipeline-shacl-sampler/README.md
@@ -4,14 +4,17 @@ Per-class sampling stages for [`@lde/pipeline`](../pipeline),
 derived from SHACL shapes.
 
 Given a SHACL shapes file, this package builds one
-[`Stage`](../pipeline/src/stage.ts) per `sh:targetClass`. Each stage’s
-CONSTRUCT executor pulls N instances of the target class from the
-distribution’s SPARQL endpoint plus their depth-1 neighbours along every
-path the SHACL declares with a nested shape constraint (`sh:node`,
-`sh:class`, `sh:qualifiedValueShape`, or `sh:or` branches that reference
-those). The resulting quads are a sample subgraph rich enough for
-[`@lde/pipeline-shacl-validator`](../pipeline-shacl-validator) to validate
-without false-positive ‘missing nested node’ violations.
+[`Stage`](../pipeline/src/stage.ts) per `sh:targetClass`. Each stage
+pairs an [`ItemSelector`](../pipeline/src/sparql/selector.ts) that picks
+N instances of the target class from the distribution’s SPARQL endpoint
+with a CONSTRUCT executor that, for every path chain the SHACL declares
+(walked recursively through `sh:node`, `sh:class`,
+`sh:qualifiedValueShape`, and `sh:or` branches, stopping at leaf
+constraints or shape cycles), pulls in the triples reachable along that
+chain’s terminal node. The resulting quads are a sample subgraph rich
+enough for
+[`@lde/pipeline-shacl-validator`](../pipeline-shacl-validator) to
+validate without false-positive ‘missing nested node’ violations.
 
 ## Usage
 
@@ -34,17 +37,20 @@ await new Pipeline({ /* … */, stages }).run();
 
 ## Options
 
-| Option            | Default | Description                                                                       |
-| ----------------- | ------- | --------------------------------------------------------------------------------- |
-| `shapesFile`      | —       | URL or local path to the SHACL shapes file. Any format `rdf-dereference` accepts. |
-| `samplesPerClass` | `50`    | Number of top-level resources to sample per `sh:targetClass`.                     |
-| `timeout`         | `60000` | SPARQL query timeout in milliseconds.                                             |
+| Option            | Default           | Description                                                                                                            |
+| ----------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `shapesFile`      | —                 | URL or local path to the SHACL shapes file. Any format `rdf-dereference` accepts.                                      |
+| `samplesPerClass` | `50`              | Number of top-level resources to sample per `sh:targetClass`.                                                          |
+| `timeout`         | `60000`           | SPARQL query timeout in milliseconds.                                                                                  |
+| `batchSize`       | `samplesPerClass` | Maximum sampled subjects per executor call. Lower values spread work across multiple parallel queries.                 |
+| `maxConcurrency`  | `10`              | Maximum concurrent in-flight executor batches per stage.                                                               |
+| `validator`       | —                 | Optional [`Validator`](../pipeline/src/validator.ts) attached to every generated stage (typically a `ShaclValidator`). |
+| `onInvalid`       | `'write'`         | Behaviour when a sampled batch fails validation: `'write'` \| `'skip'` \| `'halt'`. Only used when `validator` is set. |
 
 ## Limitations
 
-- Only plain-IRI `sh:path` values are supported. Sequence, alternative and
-  inverse paths throw at extraction time.
-- Depth-1 follow only: shapes nested more than one hop from a sampled
-  top-level resource are not fully populated. If those nested classes are
-  themselves `sh:targetClass` shapes they will be sampled and validated
-  independently.
+- Only plain-IRI `sh:path` values are supported. Sequence, alternative
+  and inverse paths throw at extraction time.
+- `sh:targetClass` is the only target form recognised; `sh:targetNode`,
+  `sh:targetSubjectsOf`, `sh:targetObjectsOf` and `sh:sparqlTarget` are
+  not yet supported.

--- a/packages/pipeline-shacl-sampler/README.md
+++ b/packages/pipeline-shacl-sampler/README.md
@@ -1,0 +1,50 @@
+# @lde/pipeline-shacl-sampler
+
+Per-class sampling stages for [`@lde/pipeline`](../pipeline),
+derived from SHACL shapes.
+
+Given a SHACL shapes file, this package builds one
+[`Stage`](../pipeline/src/stage.ts) per `sh:targetClass`. Each stage’s
+CONSTRUCT executor pulls N instances of the target class from the
+distribution’s SPARQL endpoint plus their depth-1 neighbours along every
+path the SHACL declares with a nested shape constraint (`sh:node`,
+`sh:class`, `sh:qualifiedValueShape`, or `sh:or` branches that reference
+those). The resulting quads are a sample subgraph rich enough for
+[`@lde/pipeline-shacl-validator`](../pipeline-shacl-validator) to validate
+without false-positive ‘missing nested node’ violations.
+
+## Usage
+
+```typescript
+import { Pipeline } from '@lde/pipeline';
+import { shaclSampleStages } from '@lde/pipeline-shacl-sampler';
+import { ShaclValidator } from '@lde/pipeline-shacl-validator';
+
+const shapesFile = 'https://docs.nde.nl/schema-profile/shacl.ttl';
+const validator = new ShaclValidator({ shapesFile, reportDir: './validation' });
+
+const stages = await shaclSampleStages({
+  shapesFile,
+  samplesPerClass: 50,
+  validator,
+});
+
+await new Pipeline({ /* … */, stages }).run();
+```
+
+## Options
+
+| Option            | Default | Description                                                                       |
+| ----------------- | ------- | --------------------------------------------------------------------------------- |
+| `shapesFile`      | —       | URL or local path to the SHACL shapes file. Any format `rdf-dereference` accepts. |
+| `samplesPerClass` | `50`    | Number of top-level resources to sample per `sh:targetClass`.                     |
+| `timeout`         | `60000` | SPARQL query timeout in milliseconds.                                             |
+
+## Limitations
+
+- Only plain-IRI `sh:path` values are supported. Sequence, alternative and
+  inverse paths throw at extraction time.
+- Depth-1 follow only: shapes nested more than one hop from a sampled
+  top-level resource are not fully populated. If those nested classes are
+  themselves `sh:targetClass` shapes they will be sampled and validated
+  independently.

--- a/packages/pipeline-shacl-sampler/README.md
+++ b/packages/pipeline-shacl-sampler/README.md
@@ -54,3 +54,39 @@ await new Pipeline({ /* … */, stages }).run();
 - `sh:targetClass` is the only target form recognised; `sh:targetNode`,
   `sh:targetSubjectsOf`, `sh:targetObjectsOf` and `sh:sparqlTarget` are
   not yet supported.
+
+## Related work
+
+### `extract-cbd-shape`
+
+The TREEcg / W3C TREE-incubation
+[`extract-cbd-shape`](https://github.com/TREEcg/extract-cbd-shape)
+library implements a per-entity walk over an in-memory `RdfStore`,
+falling back to an HTTP dereference of the focus node whenever a
+required path is missing from the local store. It is the right tool
+for streaming hypermedia consumers (e.g. LDES clients) that already
+hold a current context and can fetch more of it over HTTP.
+
+It is the wrong tool for this package’s setting. We assemble sample
+subgraphs against a remote SPARQL endpoint with millions of triples;
+the per-entity round-trip pattern would issue _N samples × M target
+classes_ dereferences per dataset and assumes content-negotiable
+entity IRIs that resolve to RDF — rarely true for the cultural
+heritage datasets this package was built for.
+
+### SHACL2SPARQL
+
+The Corman, Reutter & Savković 2019
+[translation](https://link.springer.com/chapter/10.1007/978-3-030-30796-7_27)
+of SHACL constraints to SPARQL targets validation, not sample
+subgraph extraction. No production JavaScript implementation exists.
+
+### Why batch CONSTRUCT per `sh:targetClass`
+
+For each top-level shape, this package emits one `Stage` whose
+CONSTRUCT executor receives a batch of sampled subjects and walks
+every path chain the SHACL declares server-side. A capable SPARQL
+endpoint (e.g. QLever) evaluates the property-path UNIONs in a
+single round-trip per batch, regardless of chain count. The
+alternative — extracting per entity in the client — would multiply
+round-trips by the sample size.

--- a/packages/pipeline-shacl-sampler/eslint.config.mjs
+++ b/packages/pipeline-shacl-sampler/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/packages/pipeline-shacl-sampler/package.json
+++ b/packages/pipeline-shacl-sampler/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@lde/pipeline-shacl-sampler",
+  "version": "0.1.0",
+  "description": "Per-class sampling stages for @lde/pipeline, derived from SHACL shapes",
+  "repository": {
+    "url": "git+https://github.com/ldelements/lde.git",
+    "directory": "packages/pipeline-shacl-sampler"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@rdfjs/types": "^2.0.1",
+    "n3": "^2.0.3",
+    "rdf-dereference": "^5.0.0",
+    "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "@lde/dataset": "0.7.3",
+    "@lde/pipeline": "0.28.13"
+  }
+}

--- a/packages/pipeline-shacl-sampler/src/index.ts
+++ b/packages/pipeline-shacl-sampler/src/index.ts
@@ -1,0 +1,5 @@
+export { extractTargetShapes, type TargetShape } from './pathExtractor.js';
+export {
+  shaclSampleStages,
+  type ShaclSampleStagesOptions,
+} from './sampleStages.js';

--- a/packages/pipeline-shacl-sampler/src/pathExtractor.ts
+++ b/packages/pipeline-shacl-sampler/src/pathExtractor.ts
@@ -1,0 +1,171 @@
+import { DataFactory, Store } from 'n3';
+import type { NamedNode, Quad, Term } from '@rdfjs/types';
+import { rdfDereferencer } from 'rdf-dereference';
+
+const { namedNode } = DataFactory;
+
+const SHACL = 'http://www.w3.org/ns/shacl#';
+const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+
+const sh = {
+  targetClass: namedNode(`${SHACL}targetClass`),
+  property: namedNode(`${SHACL}property`),
+  path: namedNode(`${SHACL}path`),
+  node: namedNode(`${SHACL}node`),
+  class: namedNode(`${SHACL}class`),
+  or: namedNode(`${SHACL}or`),
+  qualifiedValueShape: namedNode(`${SHACL}qualifiedValueShape`),
+};
+
+const rdfFirst = namedNode(`${RDF}first`);
+const rdfRest = namedNode(`${RDF}rest`);
+const rdfNil = namedNode(`${RDF}nil`);
+
+/**
+ * A SHACL NodeShape with `sh:targetClass`, distilled to the information the
+ * sampler needs: which paths are declared, and which of those need depth-1
+ * follow because their constraint references a nested shape.
+ */
+export interface TargetShape {
+  /** The class targeted by `sh:targetClass`. */
+  targetClass: NamedNode;
+  /** All distinct `sh:path` IRIs declared on property shapes of this target. */
+  paths: NamedNode[];
+  /**
+   * Subset of {@link paths} whose property shape constrains the value to
+   * another shape — via `sh:node`, `sh:class`, `sh:qualifiedValueShape`, or
+   * `sh:or` branches that themselves reference a nested shape. The sampler
+   * pulls in depth-1 triples reachable along these paths so SHACL nested
+   * constraints (e.g. `creator → Person.name`) can validate.
+   */
+  followPaths: NamedNode[];
+}
+
+/**
+ * Load the SHACL shapes file and extract its `sh:targetClass` shapes.
+ *
+ * Multiple NodeShapes can target the same class — they are merged into a
+ * single {@link TargetShape} entry per class. Only plain-IRI `sh:path`
+ * values are supported; sequence, alternative and inverse paths throw.
+ *
+ * @param shapesFile URL or local path to the SHACL shapes file.
+ *   Any format supported by `rdf-dereference` (Turtle, JSON-LD, N-Triples …).
+ */
+export async function extractTargetShapes(
+  shapesFile: string,
+): Promise<TargetShape[]> {
+  const store = await loadShapes(shapesFile);
+
+  const byClass = new Map<string, { iri: NamedNode; shapeIris: Term[] }>();
+  for (const quad of store.getQuads(null, sh.targetClass, null, null)) {
+    if (quad.object.termType !== 'NamedNode') continue;
+    const key = quad.object.value;
+    const entry = byClass.get(key) ?? {
+      iri: quad.object as NamedNode,
+      shapeIris: [],
+    };
+    entry.shapeIris.push(quad.subject);
+    byClass.set(key, entry);
+  }
+
+  const result: TargetShape[] = [];
+  for (const { iri, shapeIris } of byClass.values()) {
+    const paths: NamedNode[] = [];
+    const followPaths: NamedNode[] = [];
+    const seenPath = new Set<string>();
+    const seenFollow = new Set<string>();
+
+    for (const shapeIri of shapeIris) {
+      for (const propQuad of store.getQuads(
+        shapeIri,
+        sh.property,
+        null,
+        null,
+      )) {
+        const propShape = propQuad.object;
+        const path = readPath(store, propShape);
+        if (!seenPath.has(path.value)) {
+          seenPath.add(path.value);
+          paths.push(path);
+        }
+        if (
+          constraintReferencesNestedShape(store, propShape) &&
+          !seenFollow.has(path.value)
+        ) {
+          seenFollow.add(path.value);
+          followPaths.push(path);
+        }
+      }
+    }
+
+    result.push({ targetClass: iri, paths, followPaths });
+  }
+
+  return result;
+}
+
+async function loadShapes(shapesFile: string): Promise<Store> {
+  const { data } = await rdfDereferencer.dereference(shapesFile, {
+    localFiles: true,
+  });
+  const store = new Store();
+  return new Promise<Store>((resolve, reject) => {
+    data
+      .on('data', (quad: Quad) => store.addQuad(quad))
+      .on('end', () => resolve(store))
+      .on('error', (error: Error) => reject(error));
+  });
+}
+
+function readPath(store: Store, propShape: Term): NamedNode {
+  const pathQuads = store.getQuads(propShape, sh.path, null, null);
+  if (pathQuads.length !== 1) {
+    throw new Error(
+      `Property shape ${termLabel(propShape)} must have exactly one sh:path; found ${pathQuads.length}`,
+    );
+  }
+  const pathTerm = pathQuads[0].object;
+  if (pathTerm.termType !== 'NamedNode') {
+    throw new Error(
+      `Unsupported sh:path form on property shape ${termLabel(propShape)}: ` +
+        `only plain IRI paths are supported (sequence, alternative and inverse paths are not).`,
+    );
+  }
+  return pathTerm;
+}
+
+function constraintReferencesNestedShape(
+  store: Store,
+  propShape: Term,
+): boolean {
+  if (store.getQuads(propShape, sh.node, null, null).length > 0) return true;
+  if (store.getQuads(propShape, sh.class, null, null).length > 0) return true;
+  if (store.getQuads(propShape, sh.qualifiedValueShape, null, null).length > 0)
+    return true;
+  for (const orQuad of store.getQuads(propShape, sh.or, null, null)) {
+    if (orListReferencesNestedShape(store, orQuad.object)) return true;
+  }
+  return false;
+}
+
+function orListReferencesNestedShape(store: Store, listHead: Term): boolean {
+  let current: Term = listHead;
+  while (
+    !(current.termType === 'NamedNode' && current.value === rdfNil.value)
+  ) {
+    if (current.termType !== 'NamedNode' && current.termType !== 'BlankNode') {
+      return false;
+    }
+    const firsts = store.getQuads(current, rdfFirst, null, null);
+    if (firsts.length === 0) return false;
+    if (constraintReferencesNestedShape(store, firsts[0].object)) return true;
+    const rests = store.getQuads(current, rdfRest, null, null);
+    if (rests.length === 0) return false;
+    current = rests[0].object;
+  }
+  return false;
+}
+
+function termLabel(term: Term): string {
+  return term.termType === 'BlankNode' ? `_:${term.value}` : `<${term.value}>`;
+}

--- a/packages/pipeline-shacl-sampler/src/pathExtractor.ts
+++ b/packages/pipeline-shacl-sampler/src/pathExtractor.ts
@@ -114,11 +114,12 @@ function expandShape(
   const seen = new Set<string>();
   for (const propQuad of store.getQuads(shape, sh.property, null, null)) {
     const propShape = propQuad.object;
-    if (!constraintReferencesValueShape(store, propShape)) continue;
+    const analysis = valueShapeAnalysis(store, propShape, classToShapes);
+    if (!analysis.emit) continue;
     const path = readPath(store, propShape);
 
     addUnique(chains, seen, [path]);
-    for (const nestedRef of nestedShapeRefs(store, propShape, classToShapes)) {
+    for (const nestedRef of analysis.refs) {
       for (const subChain of expandShape(
         store,
         nestedRef,
@@ -134,44 +135,32 @@ function expandShape(
   return chains;
 }
 
-/**
- * Whether the property shape has any constraint that ties the value to a
- * shape — `sh:node`, `sh:class`, `sh:qualifiedValueShape`, or `sh:or`
- * branches with those. Independent of whether the referenced classes
- * actually have target shapes in this SHACL: we still want a chain to
- * the value node so the validator can see its type triples.
- */
-function constraintReferencesValueShape(
-  store: Store,
-  constraintShape: Term,
-): boolean {
-  if (store.getQuads(constraintShape, sh.node, null, null).length > 0) {
-    return true;
-  }
-  if (store.getQuads(constraintShape, sh.class, null, null).length > 0) {
-    return true;
-  }
-  if (
-    store.getQuads(constraintShape, sh.qualifiedValueShape, null, null).length >
-    0
-  ) {
-    return true;
-  }
-  for (const q of store.getQuads(constraintShape, sh.or, null, null)) {
-    for (const branch of orListBranches(store, q.object)) {
-      if (constraintReferencesValueShape(store, branch)) return true;
-    }
-  }
-  return false;
+interface ValueShapeAnalysis {
+  /**
+   * True if any value-shape constraint is present (`sh:node`, `sh:class`,
+   * `sh:qualifiedValueShape`, or `sh:or` containing those) — independent of
+   * whether each referenced class actually has a target shape in the SHACL.
+   * Drives whether the sampler emits a chain ending at this property so the
+   * validator can see the value node’s type triples.
+   */
+  emit: boolean;
+  /**
+   * Shapes the recursion should descend into for deeper chains: resolved
+   * targets of `sh:class`, direct shape references from `sh:node` /
+   * `sh:qualifiedValueShape`, and the same harvested from `sh:or` branches.
+   */
+  refs: Term[];
 }
 
-function nestedShapeRefs(
+function valueShapeAnalysis(
   store: Store,
   constraintShape: Term,
   classToShapes: ReadonlyMap<string, Term[]>,
-): Term[] {
+): ValueShapeAnalysis {
   const refs: Term[] = [];
+  let emit = false;
   for (const q of store.getQuads(constraintShape, sh.node, null, null)) {
+    emit = true;
     refs.push(q.object);
   }
   for (const q of store.getQuads(
@@ -180,9 +169,11 @@ function nestedShapeRefs(
     null,
     null,
   )) {
+    emit = true;
     refs.push(q.object);
   }
   for (const q of store.getQuads(constraintShape, sh.class, null, null)) {
+    emit = true;
     if (q.object.termType !== 'NamedNode') continue;
     for (const target of classToShapes.get(q.object.value) ?? []) {
       refs.push(target);
@@ -190,10 +181,12 @@ function nestedShapeRefs(
   }
   for (const q of store.getQuads(constraintShape, sh.or, null, null)) {
     for (const branch of orListBranches(store, q.object)) {
-      refs.push(...nestedShapeRefs(store, branch, classToShapes));
+      const sub = valueShapeAnalysis(store, branch, classToShapes);
+      if (sub.emit) emit = true;
+      refs.push(...sub.refs);
     }
   }
-  return refs;
+  return { emit, refs };
 }
 
 function orListBranches(store: Store, listHead: Term): Term[] {

--- a/packages/pipeline-shacl-sampler/src/pathExtractor.ts
+++ b/packages/pipeline-shacl-sampler/src/pathExtractor.ts
@@ -1,5 +1,5 @@
 import { DataFactory, Store } from 'n3';
-import type { NamedNode, Quad, Term } from '@rdfjs/types';
+import type { NamedNode, Term } from '@rdfjs/types';
 import { rdfDereferencer } from 'rdf-dereference';
 
 const { namedNode } = DataFactory;
@@ -22,86 +22,197 @@ const rdfRest = namedNode(`${RDF}rest`);
 const rdfNil = namedNode(`${RDF}nil`);
 
 /**
- * A SHACL NodeShape with `sh:targetClass`, distilled to the information the
- * sampler needs: which paths are declared, and which of those need depth-1
- * follow because their constraint references a nested shape.
+ * A SHACL `sh:targetClass` shape distilled into the path chains the sampler
+ * needs to walk to feed the validator a closed sample subgraph.
  */
 export interface TargetShape {
   /** The class targeted by `sh:targetClass`. */
   targetClass: NamedNode;
-  /** All distinct `sh:path` IRIs declared on property shapes of this target. */
-  paths: NamedNode[];
   /**
-   * Subset of {@link paths} whose property shape constrains the value to
-   * another shape — via `sh:node`, `sh:class`, `sh:qualifiedValueShape`, or
-   * `sh:or` branches that themselves reference a nested shape. The sampler
-   * pulls in depth-1 triples reachable along these paths so SHACL nested
-   * constraints (e.g. `creator → Person.name`) can validate.
+   * Property-path chains rooted at a sampled instance of {@link targetClass}.
+   *
+   * Each chain is the sequence of `sh:path` IRIs leading from the sampled
+   * subject to a node whose direct triples are needed for validation —
+   * because the SHACL declares a nested-shape constraint on that path
+   * (`sh:node`, `sh:class`, `sh:qualifiedValueShape`, or `sh:or` branches
+   * that reference those). Chains continue recursively into every shape
+   * thus referenced and stop on a cycle (a shape revisited on the current
+   * stack) or on a leaf property shape whose constraints reference no
+   * further shape.
+   *
+   * Each chain is *additive*: shorter prefixes are also present in the
+   * list when they themselves terminate at a nested-shape property.
    */
-  followPaths: NamedNode[];
+  pathChains: NamedNode[][];
 }
 
 /**
- * Load the SHACL shapes file and extract its `sh:targetClass` shapes.
+ * Load a SHACL shapes file and extract its `sh:targetClass` shapes into
+ * {@link TargetShape}s.
  *
  * Multiple NodeShapes can target the same class — they are merged into a
- * single {@link TargetShape} entry per class. Only plain-IRI `sh:path`
- * values are supported; sequence, alternative and inverse paths throw.
+ * single entry. Only plain-IRI `sh:path` values are supported; sequence,
+ * alternative and inverse paths throw.
  *
- * @param shapesFile URL or local path to the SHACL shapes file.
- *   Any format supported by `rdf-dereference` (Turtle, JSON-LD, N-Triples …).
+ * @param shapesFile URL or local path to the SHACL shapes file. Any format
+ *   supported by `rdf-dereference` (Turtle, JSON-LD, N-Triples, …).
  */
 export async function extractTargetShapes(
   shapesFile: string,
 ): Promise<TargetShape[]> {
   const store = await loadShapes(shapesFile);
 
-  const byClass = new Map<string, { iri: NamedNode; shapeIris: Term[] }>();
+  const classToShapes = new Map<string, Term[]>();
   for (const quad of store.getQuads(null, sh.targetClass, null, null)) {
     if (quad.object.termType !== 'NamedNode') continue;
     const key = quad.object.value;
-    const entry = byClass.get(key) ?? {
-      iri: quad.object as NamedNode,
-      shapeIris: [],
-    };
-    entry.shapeIris.push(quad.subject);
-    byClass.set(key, entry);
+    const list = classToShapes.get(key) ?? [];
+    list.push(quad.subject);
+    classToShapes.set(key, list);
   }
 
   const result: TargetShape[] = [];
-  for (const { iri, shapeIris } of byClass.values()) {
-    const paths: NamedNode[] = [];
-    const followPaths: NamedNode[] = [];
-    const seenPath = new Set<string>();
-    const seenFollow = new Set<string>();
-
+  for (const [classIri, shapeIris] of classToShapes) {
+    const pathChains: NamedNode[][] = [];
+    const seen = new Set<string>();
     for (const shapeIri of shapeIris) {
-      for (const propQuad of store.getQuads(
+      for (const chain of expandShape(
+        store,
         shapeIri,
-        sh.property,
-        null,
-        null,
+        new Set(),
+        classToShapes,
       )) {
-        const propShape = propQuad.object;
-        const path = readPath(store, propShape);
-        if (!seenPath.has(path.value)) {
-          seenPath.add(path.value);
-          paths.push(path);
-        }
-        if (
-          constraintReferencesNestedShape(store, propShape) &&
-          !seenFollow.has(path.value)
-        ) {
-          seenFollow.add(path.value);
-          followPaths.push(path);
+        const key = chainKey(chain);
+        if (!seen.has(key)) {
+          seen.add(key);
+          pathChains.push(chain);
         }
       }
     }
-
-    result.push({ targetClass: iri, paths, followPaths });
+    result.push({ targetClass: namedNode(classIri), pathChains });
   }
 
   return result;
+}
+
+/**
+ * Walk one shape's property graph, producing every path chain that ends at a
+ * nested-shape property. Cycle-detected via the {@link stack} of shape keys
+ * the current recursion has entered but not yet left.
+ */
+function expandShape(
+  store: Store,
+  shape: Term,
+  stack: Set<string>,
+  classToShapes: ReadonlyMap<string, Term[]>,
+): NamedNode[][] {
+  const key = termKey(shape);
+  if (stack.has(key)) return [];
+  stack.add(key);
+
+  const chains: NamedNode[][] = [];
+  const seen = new Set<string>();
+  for (const propQuad of store.getQuads(shape, sh.property, null, null)) {
+    const propShape = propQuad.object;
+    if (!constraintReferencesValueShape(store, propShape)) continue;
+    const path = readPath(store, propShape);
+
+    addUnique(chains, seen, [path]);
+    for (const nestedRef of nestedShapeRefs(store, propShape, classToShapes)) {
+      for (const subChain of expandShape(
+        store,
+        nestedRef,
+        stack,
+        classToShapes,
+      )) {
+        addUnique(chains, seen, [path, ...subChain]);
+      }
+    }
+  }
+
+  stack.delete(key);
+  return chains;
+}
+
+/**
+ * Whether the property shape has any constraint that ties the value to a
+ * shape — `sh:node`, `sh:class`, `sh:qualifiedValueShape`, or `sh:or`
+ * branches with those. Independent of whether the referenced classes
+ * actually have target shapes in this SHACL: we still want a chain to
+ * the value node so the validator can see its type triples.
+ */
+function constraintReferencesValueShape(
+  store: Store,
+  constraintShape: Term,
+): boolean {
+  if (store.getQuads(constraintShape, sh.node, null, null).length > 0) {
+    return true;
+  }
+  if (store.getQuads(constraintShape, sh.class, null, null).length > 0) {
+    return true;
+  }
+  if (
+    store.getQuads(constraintShape, sh.qualifiedValueShape, null, null).length >
+    0
+  ) {
+    return true;
+  }
+  for (const q of store.getQuads(constraintShape, sh.or, null, null)) {
+    for (const branch of orListBranches(store, q.object)) {
+      if (constraintReferencesValueShape(store, branch)) return true;
+    }
+  }
+  return false;
+}
+
+function nestedShapeRefs(
+  store: Store,
+  constraintShape: Term,
+  classToShapes: ReadonlyMap<string, Term[]>,
+): Term[] {
+  const refs: Term[] = [];
+  for (const q of store.getQuads(constraintShape, sh.node, null, null)) {
+    refs.push(q.object);
+  }
+  for (const q of store.getQuads(
+    constraintShape,
+    sh.qualifiedValueShape,
+    null,
+    null,
+  )) {
+    refs.push(q.object);
+  }
+  for (const q of store.getQuads(constraintShape, sh.class, null, null)) {
+    if (q.object.termType !== 'NamedNode') continue;
+    for (const target of classToShapes.get(q.object.value) ?? []) {
+      refs.push(target);
+    }
+  }
+  for (const q of store.getQuads(constraintShape, sh.or, null, null)) {
+    for (const branch of orListBranches(store, q.object)) {
+      refs.push(...nestedShapeRefs(store, branch, classToShapes));
+    }
+  }
+  return refs;
+}
+
+function orListBranches(store: Store, listHead: Term): Term[] {
+  const branches: Term[] = [];
+  let current: Term = listHead;
+  while (
+    !(current.termType === 'NamedNode' && current.value === rdfNil.value)
+  ) {
+    if (current.termType !== 'NamedNode' && current.termType !== 'BlankNode') {
+      break;
+    }
+    const firsts = store.getQuads(current, rdfFirst, null, null);
+    if (firsts.length === 0) break;
+    branches.push(firsts[0].object);
+    const rests = store.getQuads(current, rdfRest, null, null);
+    if (rests.length === 0) break;
+    current = rests[0].object;
+  }
+  return branches;
 }
 
 async function loadShapes(shapesFile: string): Promise<Store> {
@@ -109,12 +220,13 @@ async function loadShapes(shapesFile: string): Promise<Store> {
     localFiles: true,
   });
   const store = new Store();
-  return new Promise<Store>((resolve, reject) => {
-    data
-      .on('data', (quad: Quad) => store.addQuad(quad))
-      .on('end', () => resolve(store))
-      .on('error', (error: Error) => reject(error));
-  });
+  await new Promise<void>((resolve, reject) =>
+    store
+      .import(data)
+      .on('end', () => resolve())
+      .on('error', reject),
+  );
+  return store;
 }
 
 function readPath(store: Store, propShape: Term): NamedNode {
@@ -134,36 +246,23 @@ function readPath(store: Store, propShape: Term): NamedNode {
   return pathTerm;
 }
 
-function constraintReferencesNestedShape(
-  store: Store,
-  propShape: Term,
-): boolean {
-  if (store.getQuads(propShape, sh.node, null, null).length > 0) return true;
-  if (store.getQuads(propShape, sh.class, null, null).length > 0) return true;
-  if (store.getQuads(propShape, sh.qualifiedValueShape, null, null).length > 0)
-    return true;
-  for (const orQuad of store.getQuads(propShape, sh.or, null, null)) {
-    if (orListReferencesNestedShape(store, orQuad.object)) return true;
-  }
-  return false;
+function addUnique(
+  chains: NamedNode[][],
+  seen: Set<string>,
+  chain: NamedNode[],
+): void {
+  const key = chainKey(chain);
+  if (seen.has(key)) return;
+  seen.add(key);
+  chains.push(chain);
 }
 
-function orListReferencesNestedShape(store: Store, listHead: Term): boolean {
-  let current: Term = listHead;
-  while (
-    !(current.termType === 'NamedNode' && current.value === rdfNil.value)
-  ) {
-    if (current.termType !== 'NamedNode' && current.termType !== 'BlankNode') {
-      return false;
-    }
-    const firsts = store.getQuads(current, rdfFirst, null, null);
-    if (firsts.length === 0) return false;
-    if (constraintReferencesNestedShape(store, firsts[0].object)) return true;
-    const rests = store.getQuads(current, rdfRest, null, null);
-    if (rests.length === 0) return false;
-    current = rests[0].object;
-  }
-  return false;
+function chainKey(chain: NamedNode[]): string {
+  return chain.map((n) => n.value).join('/');
+}
+
+function termKey(term: Term): string {
+  return `${term.termType}:${term.value}`;
 }
 
 function termLabel(term: Term): string {

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -40,9 +40,9 @@ export interface ShaclSampleStagesOptions {
 /**
  * Build one sampling {@link Stage} per `sh:targetClass` declared in the SHACL
  * shapes file. Each stage's CONSTRUCT executor takes N instances of its
- * target class plus their depth-1 neighbours along every path the SHACL
- * declares with a nested shape constraint (`sh:node`, `sh:class`,
- * `sh:qualifiedValueShape`, or `sh:or` branches that reference those).
+ * target class plus, for every path chain the SHACL declares (recursively,
+ * stopping at leaf constraints or cycles), the triples reachable along that
+ * chain’s terminal node.
  *
  * Pass a {@link Validator} to attach it to every generated stage:
  *
@@ -76,16 +76,18 @@ export async function shaclSampleStages(
 
 function buildSampleQuery(shape: TargetShape, limit: number): string {
   assertSafeIri(shape.targetClass.value);
-  for (const path of shape.followPaths) assertSafeIri(path.value);
+  for (const chain of shape.pathChains) {
+    for (const path of chain) assertSafeIri(path.value);
+  }
 
-  const followClause =
-    shape.followPaths.length === 0
-      ? ''
-      : ` UNION {
-    ?s ?followPath ?neighbour .
-    VALUES ?followPath { ${shape.followPaths.map((p) => `<${p.value}>`).join(' ')} }
+  const chainBranches = shape.pathChains
+    .map(
+      (chain) => ` UNION {
+    ?s ${chain.map((p) => `<${p.value}>`).join('/')} ?neighbour .
     ?neighbour ?np ?nv .
-  }`;
+  }`,
+    )
+    .join('');
 
   return `CONSTRUCT {
   ?s ?p ?o .
@@ -101,7 +103,7 @@ WHERE {
   }
   {
     ?s ?p ?o .
-  }${followClause}
+  }${chainBranches}
 }`;
 }
 

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -1,10 +1,13 @@
 import {
   Stage,
   SparqlConstructExecutor,
+  SparqlItemSelector,
+  type ItemSelector,
   type StageOptions,
   type Validator,
 } from '@lde/pipeline';
 import { assertSafeIri } from '@lde/dataset';
+import type { NamedNode } from '@rdfjs/types';
 import { extractTargetShapes, type TargetShape } from './pathExtractor.js';
 
 type OnInvalid = NonNullable<StageOptions['validation']>['onInvalid'];
@@ -24,6 +27,16 @@ export interface ShaclSampleStagesOptions {
    */
   timeout?: number;
   /**
+   * Maximum number of sampled subjects per executor call. Defaults to
+   * {@link samplesPerClass} so the whole sample fits in one CONSTRUCT
+   * round-trip; lower to spread work across multiple parallel queries.
+   */
+  batchSize?: number;
+  /**
+   * Maximum concurrent in-flight executor batches per stage. @default 10
+   */
+  maxConcurrency?: number;
+  /**
    * Validator attached to every generated stage. Typically a
    * {@link https://www.npmjs.com/package/@lde/pipeline-shacl-validator ShaclValidator}
    * configured with the same {@link shapesFile}.
@@ -39,10 +52,11 @@ export interface ShaclSampleStagesOptions {
 
 /**
  * Build one sampling {@link Stage} per `sh:targetClass` declared in the SHACL
- * shapes file. Each stage's CONSTRUCT executor takes N instances of its
- * target class plus, for every path chain the SHACL declares (recursively,
- * stopping at leaf constraints or cycles), the triples reachable along that
- * chain’s terminal node.
+ * shapes file. Each stage pairs a SELECT-based {@link ItemSelector} that picks
+ * N instances of its target class with a CONSTRUCT executor that, for every
+ * path chain the SHACL declares (recursively, stopping at leaf constraints
+ * or cycles), pulls in the triples reachable along that chain’s terminal
+ * node.
  *
  * Pass a {@link Validator} to attach it to every generated stage:
  *
@@ -56,6 +70,8 @@ export async function shaclSampleStages(
 ): Promise<Stage[]> {
   const samplesPerClass = options.samplesPerClass ?? 50;
   const timeout = options.timeout ?? 60_000;
+  const batchSize = options.batchSize ?? samplesPerClass;
+  const maxConcurrency = options.maxConcurrency;
   const validation = options.validator
     ? { validator: options.validator, onInvalid: options.onInvalid ?? 'write' }
     : undefined;
@@ -65,17 +81,53 @@ export async function shaclSampleStages(
     (shape) =>
       new Stage({
         name: `shacl-sample-${localName(shape.targetClass.value)}`,
+        itemSelector: subjectSelector(shape.targetClass, samplesPerClass),
         executors: new SparqlConstructExecutor({
-          query: buildSampleQuery(shape, samplesPerClass),
+          query: buildSampleQuery(shape),
           timeout,
         }),
+        batchSize,
+        maxConcurrency,
         validation,
       }),
   );
 }
 
-function buildSampleQuery(shape: TargetShape, limit: number): string {
-  assertSafeIri(shape.targetClass.value);
+function subjectSelector(targetClass: NamedNode, limit: number): ItemSelector {
+  assertSafeIri(targetClass.value);
+  return {
+    select(distribution, batchSize) {
+      const query = buildSubjectSelectorQuery(
+        targetClass,
+        limit,
+        distribution.subjectFilter,
+        distribution.namedGraph,
+      );
+      return new SparqlItemSelector({ query }).select(distribution, batchSize);
+    },
+  };
+}
+
+export function buildSubjectSelectorQuery(
+  targetClass: NamedNode,
+  limit: number,
+  subjectFilter?: string,
+  namedGraph?: string,
+): string {
+  let fromClause = '';
+  if (namedGraph) {
+    assertSafeIri(namedGraph);
+    fromClause = `FROM <${namedGraph}>`;
+  }
+  return [
+    'SELECT DISTINCT ?s',
+    fromClause,
+    `WHERE { ${subjectFilter ?? ''} ?s a <${targetClass.value}> . }`,
+    `LIMIT ${limit}`,
+  ].join('\n');
+}
+
+export function buildSampleQuery(shape: TargetShape): string {
   for (const chain of shape.pathChains) {
     for (const path of chain) assertSafeIri(path.value);
   }
@@ -94,13 +146,6 @@ function buildSampleQuery(shape: TargetShape, limit: number): string {
   ?neighbour ?np ?nv .
 }
 WHERE {
-  {
-    SELECT ?s {
-      #subjectFilter#
-      ?s a <${shape.targetClass.value}> .
-    }
-    LIMIT ${limit}
-  }
   {
     ?s ?p ?o .
   }${chainBranches}

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -1,6 +1,13 @@
-import { Stage, SparqlConstructExecutor, type Validator } from '@lde/pipeline';
+import {
+  Stage,
+  SparqlConstructExecutor,
+  type StageOptions,
+  type Validator,
+} from '@lde/pipeline';
 import { assertSafeIri } from '@lde/dataset';
 import { extractTargetShapes, type TargetShape } from './pathExtractor.js';
+
+type OnInvalid = NonNullable<StageOptions['validation']>['onInvalid'];
 
 /** Options for {@link shaclSampleStages}. */
 export interface ShaclSampleStagesOptions {
@@ -27,7 +34,7 @@ export interface ShaclSampleStagesOptions {
    * {@link validator} is set.
    * @default 'write'
    */
-  onInvalid?: 'write' | 'skip' | 'halt';
+  onInvalid?: OnInvalid;
 }
 
 /**

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -1,0 +1,104 @@
+import { Stage, SparqlConstructExecutor, type Validator } from '@lde/pipeline';
+import { assertSafeIri } from '@lde/dataset';
+import { extractTargetShapes, type TargetShape } from './pathExtractor.js';
+
+/** Options for {@link shaclSampleStages}. */
+export interface ShaclSampleStagesOptions {
+  /** URL or local path to the SHACL shapes file. */
+  shapesFile: string;
+  /**
+   * Number of top-level resources to sample per `sh:targetClass`.
+   * @default 50
+   */
+  samplesPerClass?: number;
+  /**
+   * SPARQL query timeout in milliseconds.
+   * @default 60000
+   */
+  timeout?: number;
+  /**
+   * Validator attached to every generated stage. Typically a
+   * {@link https://www.npmjs.com/package/@lde/pipeline-shacl-validator ShaclValidator}
+   * configured with the same {@link shapesFile}.
+   */
+  validator?: Validator;
+  /**
+   * Behaviour when a sampled batch fails validation. Only used when
+   * {@link validator} is set.
+   * @default 'write'
+   */
+  onInvalid?: 'write' | 'skip' | 'halt';
+}
+
+/**
+ * Build one sampling {@link Stage} per `sh:targetClass` declared in the SHACL
+ * shapes file. Each stage's CONSTRUCT executor takes N instances of its
+ * target class plus their depth-1 neighbours along every path the SHACL
+ * declares with a nested shape constraint (`sh:node`, `sh:class`,
+ * `sh:qualifiedValueShape`, or `sh:or` branches that reference those).
+ *
+ * Pass a {@link Validator} to attach it to every generated stage:
+ *
+ * ```ts
+ * const validator = new ShaclValidator({ shapesFile, reportDir });
+ * const stages = await shaclSampleStages({ shapesFile, validator });
+ * ```
+ */
+export async function shaclSampleStages(
+  options: ShaclSampleStagesOptions,
+): Promise<Stage[]> {
+  const samplesPerClass = options.samplesPerClass ?? 50;
+  const timeout = options.timeout ?? 60_000;
+  const validation = options.validator
+    ? { validator: options.validator, onInvalid: options.onInvalid ?? 'write' }
+    : undefined;
+  const shapes = await extractTargetShapes(options.shapesFile);
+
+  return shapes.map(
+    (shape) =>
+      new Stage({
+        name: `shacl-sample-${localName(shape.targetClass.value)}`,
+        executors: new SparqlConstructExecutor({
+          query: buildSampleQuery(shape, samplesPerClass),
+          timeout,
+        }),
+        validation,
+      }),
+  );
+}
+
+function buildSampleQuery(shape: TargetShape, limit: number): string {
+  assertSafeIri(shape.targetClass.value);
+  for (const path of shape.followPaths) assertSafeIri(path.value);
+
+  const followClause =
+    shape.followPaths.length === 0
+      ? ''
+      : ` UNION {
+    ?s ?followPath ?neighbour .
+    VALUES ?followPath { ${shape.followPaths.map((p) => `<${p.value}>`).join(' ')} }
+    ?neighbour ?np ?nv .
+  }`;
+
+  return `CONSTRUCT {
+  ?s ?p ?o .
+  ?neighbour ?np ?nv .
+}
+WHERE {
+  {
+    SELECT ?s {
+      #subjectFilter#
+      ?s a <${shape.targetClass.value}> .
+    }
+    LIMIT ${limit}
+  }
+  {
+    ?s ?p ?o .
+  }${followClause}
+}`;
+}
+
+function localName(iri: string): string {
+  const match = /[#/]([^#/]+)$/.exec(iri);
+  return (match?.[1] ?? iri).replace(/[^A-Za-z0-9_-]/g, '_');
+}

--- a/packages/pipeline-shacl-sampler/test/fixtures/schema-profile.ttl
+++ b/packages/pipeline-shacl-sampler/test/fixtures/schema-profile.ttl
@@ -1,0 +1,839 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+_:CreativeWorkShape
+    a sh:NodeShape ;
+    sh:targetClass schema:CreativeWork ;
+    sh:nodeKind sh:IRI ;
+    sh:name "CreativeWork" ;
+    sh:description """
+        The type for [=heritage objects=] ([[DERA]]’s *cultuurhistorisch object*) in this application profile.
+
+        Some heritage objects fit CreativeWork well, such as paintings, books or musical compositions.
+        Others are a less natural fit, such as fossils, buses or bridges,
+        either because they are not ‘creative works’ in the everyday sense
+        or because they fit somewhere else in Schema.org’s type hierarchy.
+
+        Nevertheless, CreativeWork serves as the catch-all type for all heritage objects in this application profile,
+        to differentiate them from the other top-level classes (Person, Organization, Place).
+
+        For more fine-grained typing, [[#CreativeWork-additionalType]] *SHOULD* be used.
+    """ ;
+    sh:property
+        [
+            sh:path schema:name ;
+            sh:datatype rdf:langString ;
+            sh:uniqueLang true ;
+            sh:minCount 1 ;
+            sh:description """
+                The CreativeWork’s name or title, assigned either by its creator, collection managers or by others.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "A language-tagged name" ;
+                rdfs:comment "file://examples/CreativeWork-name.jsonld" ;
+            ]
+        ] ,
+        [
+            sh:path schema:creator ;
+            sh:or (
+                [ sh:class schema:Person ]
+                [ sh:class schema:Organization ]
+                [ sh:node _:CreatorShape ]
+            ) ;
+            sh:minCount 1 ;
+            sh:description """
+                A *REQUIRED* property that identifies the person(s) or organization(s) that had a role in the production of the CreativeWork.
+
+                If a [=term=] is available, that MUST be referenced. If not, a Person or Organization resource *MUST* be used instead.
+
+                The type *MAY* be omitted if the dataset publisher does not know whether the creator is a Person or Organization.
+
+                Even where more specific properties, applicable to CreativeWork’s subtypes, are available in Schema.org,
+                such as [artist](https://schema.org/artist), [composer](https://schema.org/composer) and [director](https://schema.org/director),
+                the creator property *MUST* be used for consistency.
+                Although Schema.org defines [author](https://schema.org/author) as equivalent to creator for CreativeWorks,
+                this profile picks creator so that consumers can rely on a single property.
+
+                Multiple creators (for example an author and a photographer) *MUST* each be expressed as separate, flat creator values.
+                The creator property *MUST NOT* wrap its values in a [Role](https://schema.org/Role) node,
+                since this would force consumers to handle two value shapes.
+                Publishers who wish to express qualified contributor roles *MAY* do so on a separate property such as [contributor](https://schema.org/contributor),
+                which is outside this profile and does not affect profile validity.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "Van Gogh’s panting The Starry Night" ;
+                rdfs:comment "file://examples/CreativeWork-creator.jsonld" ;
+            ] , [
+                rdfs:label "A creator with unknown type:" ;
+                rdfs:comment "file://examples/CreativeWork-creator-untyped.jsonld" ;
+            ]
+        ] ,
+        [
+            sh:path schema:isPartOf ;
+            sh:minCount 1 ;
+            sh:severity sh:Warning ;
+            sh:description """
+                Points to the dataset(s) that the CreativeWork is part of, *REQUIRED* if the CreativeWork is part of one or more datasets.
+
+                This contextualizes the CreativeWork for consumers, with the [[NDE-DATASETS|dataset’s description]] providing
+                information about properties that are shared between CreativeWorks in the same dataset,
+                such as publisher and license.
+
+                Note that a CreativeWork may be part of multiple datasets.
+
+                The dataset *MUST* be typed as a `Dataset`.
+
+                The `isPartOf` property *MAY* also be used to indicate hierarchical relations between CreativeWorks within the dataset.
+                In that case, the value’s type will be something other than `Dataset`.
+                This usage is out of scope for this document.
+                """ ;
+            rdfs:seeAlso [
+                rdfs:label "Indicating the dataset that the CreativeWork is part of:" ;
+                rdfs:comment "file://examples/CreativeWork-isPartOf.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:associatedMedia ;
+            sh:or (
+                [ sh:node _:MediaObjectShape ]
+                [ sh:node _:IIIFPresentationManifestShape ]
+            ) ;
+            sh:minCount 1 ;
+            sh:severity sh:Warning ;
+            sh:description """
+                One or more media objects that represent the CreativeWork.
+                This property is *REQUIRED* if at least one media object is available.
+
+                If an <a href="https://iiif.io/api/presentation/">IIIF Presentation API</a> manifest is available
+                for the CreativeWork, it *MUST* be included as an additional `associatedMedia` entry with:
+                - `@id` set to the manifest URI
+                - `encodingFormat` set to `application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'`.
+                - `license` matching the `rights` property specified in the presentation manifest
+
+                The IIIF Presentation manifest *MUST* describe all media for the CreativeWork.
+
+                IIIF-aware consumers *SHOULD* access media via the IIIF Presentation manifest.
+
+                Non-IIIF consumers *SHOULD* access media via the per-image entries’ `contentUrl` and `thumbnailUrl`,
+                and can ignore the manifest entry (it has no `contentUrl`).
+
+                Note: Schema.org lists MediaObject as the only range of `associatedMedia`. This profile additionally permits a single IIIF Presentation manifest entry, which is not itself a MediaObject but is identified by its `encodingFormat` rather than by its class.
+
+                See MediaObject for this property’s allowed values.
+            """;
+            rdfs:seeAlso [
+                rdfs:label "An image representation of the Starry Night:" ;
+                rdfs:comment "file://examples/CreativeWork-associatedMedia.jsonld" ;
+            ] , [
+                rdfs:label "IIIF Presentation manifest as `associatedMedia`:" ;
+                rdfs:comment "file://examples/CreativeWork-IIIF-Presentation.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:identifier ;
+            sh:or (
+              [ sh:datatype xsd:string ]
+              [ sh:class schema:PropertyValue ]
+          ) ;
+            sh:minCount 0 ;
+            sh:description """
+                An *OPTIONAL* property that provides a unique identifier for the CreativeWork,
+                usually an assigned alphanumeric string.
+                The identifier may be useful for referencing the CreativeWork in non-RDF contexts, such as exhibitions.
+                Note that this is different from the CreativeWork’s URI.
+                The value *MUST* be either a string or a [schema:PropertyValue](https://schema.org/PropertyValue).
+            """;
+            rdfs:seeAlso [
+                rdfs:label "A string as identifier:" ;
+                rdfs:comment "file://examples/CreativeWork-identifier-string.jsonld" ;
+            ] , [
+                rdfs:label "A structured PropertyValue as identifier:" ;
+                rdfs:comment "file://examples/CreativeWork-identifier-structured.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:additionalType ;
+            sh:nodeKind sh:IRI ;
+            sh:minCount 0 ;
+            sh:description """
+                An *OPTIONAL* property that provides additional types for the CreativeWork.
+                This is useful to add more specific types to your [=metadata record=] that may not be available as a Schema.org [[#subclasses|subclass]].
+
+                The value *MUST* reference [=terms=].
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "The Starry Night is both a Schema.org Painting and an AAT painting:" ;
+                rdfs:comment "file://examples/CreativeWork-additionalType.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:description ;
+            sh:datatype rdf:langString ;
+            sh:minCount 0 ;
+            sh:description """
+                An *OPTIONAL* property that gives a full description of the CreativeWork.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "A description of the Starry Night:" ;
+                rdfs:comment "file://examples/CreativeWork-description.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:abstract ;
+            sh:datatype rdf:langString ;
+            sh:minCount 0 ;
+            sh:description """
+                Summarizes the CreativeWork in one sentence.
+                The abstract *SHOULD* be free of jargon and abbreviations so it can be understood by others.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "A single-sentence abstract:" ;
+                rdfs:comment "file://examples/CreativeWork-abstract.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:text ;
+            sh:datatype rdf:langString ;
+            sh:minCount 0 ;
+            sh:description """
+                An *OPTIONAL* property containing the complete textual content of the CreativeWork,
+                primarily used for search indexing and discovery.
+
+                This includes content such as:
+                - the full text of a written work (e.g. story)
+                - transcribed text from visual media (e.g., inscriptions in photographs).
+
+                Note that this property contains plain text only, without preserving structural elements
+                like paragraphs, headings or the relationship between text and embedded media.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "A story:" ;
+                rdfs:comment "file://examples/CreativeWork-text.jsonld" ;
+            ] ;
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:size ;
+            sh:datatype xsd:string ;
+            sh:minCount 0 ;
+            sh:description """
+                Indicates the physical size of the CreativeWork in its preferred display form.
+            """;
+            rdfs:seeAlso [
+                rdfs:label "The dimensions of Van Gogh’s Starry Night" ;
+                rdfs:comment "file://examples/CreativeWork-size.jsonld" ;
+            ] ;
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:contentLocation ;
+            sh:or (
+                [ sh:node _:DefinedTermShape ]
+                [ sh:node _:PlaceShape ]
+            ) ;
+            sh:minCount 0 ;
+            sh:description """
+                Indicates the location(s) depicted or described in the CreativeWork.
+                For example, the location in a photograph or painting.
+
+                If available, a term *MUST* be referenced. If not, a Place resource *MUST* be used instead.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "Van Gogh’s painting The Starry Night:" ;
+                rdfs:comment "file://examples/CreativeWork-contentLocation.jsonld" ;
+            ] ;
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:temporalCoverage ;
+            sh:or (
+                [ sh:nodeKind sh:IRI ; sh:pattern "^https?://" ]
+                [ sh:pattern "^(-?\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}:\\d{2}(:\\d{2})?)?)?)?|\\.\\.)(/(-?\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}:\\d{2}(:\\d{2})?)?)?)?|\\d{2}(-\\d{2})?|\\.\\.))?$" ]
+            ) ;
+            sh:minCount 0 ;
+            sh:description """
+                Indicates the period that the content applies to,
+                i.e. the time period(s) that the CreativeWork describes or depicts.
+
+                The value *MUST* be either an ISO 8601 date or time interval
+                (such as ‘2011’, ‘2011/2012’, ‘1889-06/07’ for shortened notation,
+                ‘-0431/-0404’ for BCE dates, or ‘1440/..’ for an open-ended range),
+                or an HTTP(S) URI.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "Van Gogh’s painting The Starry Night:" ;
+                rdfs:comment "file://examples/CreativeWork-temporalCoverage.jsonld" ;
+            ] ;
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:locationCreated ;
+            sh:or (
+                [ sh:node _:DefinedTermShape ]
+                [ sh:node _:PlaceShape ]
+            ) ;
+            sh:minCount 0 ;
+            sh:description """
+                Indicates the location(s) where the CreativeWork was created
+                (which may be different from its contentLocation).
+
+                If available, a term *MUST* be referenced. If not, a Place resource *MUST* be used instead.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "Van Gogh’s painting The Starry Night:" ;
+                rdfs:comment "file://examples/CreativeWork-locationCreated.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:dateCreated ;
+            sh:node _:DateShape ;
+            sh:minCount 0 ;
+            sh:description """
+                Indicates the date the CreativeWork was created.
+
+                The value *MUST* be in ISO 8601 format: YYYY, YYYY-MM, or YYYY-MM-DD. Partial dates *MAY* be used if the exact date is unknown.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "Van Gogh painted The Starry Night in June 1889:" ;
+                rdfs:comment "file://examples/CreativeWork-dateCreated.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:about ;
+            sh:or (
+                [ sh:node _:DefinedTermShape ]
+                [ sh:class schema:CreativeWork ]
+            ) ;
+            sh:minCount 0 ;
+            sh:description """
+                Indicates the subject-matter of the CreativeWork.
+                For example, which subjects are depicted in a painting or photograph?
+                Or which subjects is a story about?
+                And/or which CreativeWork (e.g. collection object) is this CreativeWork (story) about?
+
+                The value *MUST* either reference terms or other CreativeWork(s).
+
+                If the subject is a location, it *MUST* be listed under contentLocation instead.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "The Starry Night depicts ‘starry sky’ and ‘Moon’." ;
+                rdfs:comment "file://examples/CreativeWork-about.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:material ;
+            sh:node _:DefinedTermShape ;
+            sh:minCount 0 ;
+            sh:description """
+                Indicates the material(s) that the CreativeWork is made from, e.g. leather, wool, cotton, paper.
+                The value *MUST* reference terms.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "The Starry Night is made from ‘oil paint’ and ‘canvas’:" ;
+                rdfs:comment "file://examples/CreativeWork-material.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:genre ;
+            sh:node _:DefinedTermShape ;
+            sh:minCount 0 ;
+            sh:description """
+                Indicates the genre(s) of the CreativeWork,
+                for example art movements or periods.
+
+                The value *MUST* reference a term.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "The Starry Night belongs to the Post-Impressionist art movement:" ;
+                rdfs:comment "file://examples/CreativeWork-genre.jsonld" ;
+            ]
+        ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path schema:sdDatePublished ;
+            sh:or (
+                [
+                    sh:datatype xsd:date ;
+                    sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" ;
+                ]
+                [
+                    sh:datatype xsd:dateTime ;
+                    sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})?$" ;
+                ]
+            ) ;
+            sh:minCount 0 ;
+            sh:description """
+                Indicates the date when the [=metadata record=] was last changed.
+
+                The value *MUST* be in ISO 8601 format: `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ`.
+            """ ;
+        ]
+    .
+
+_:CreatorShape
+    a sh:NodeShape ;
+    sh:description """
+        If the type of a creator is not known, the type *MAY* be omitted.
+        A name is still *REQUIRED* to identify the creator.
+    """ ;
+    sh:not [
+        sh:path rdf:type ;
+        sh:minCount 1
+    ] ;
+    sh:property [
+        sh:path schema:name ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+        sh:minCount 1 ;
+        sh:description """
+            A *REQUIRED* property that indicates the creator’s name in its preferred display form.
+        """ ;
+    ] .
+
+_:DefinedTermShape
+    a sh:NodeShape ;
+    sh:class schema:DefinedTerm ;
+    sh:description """
+        A vocabulary term identified by a human-readable name and, when available, a URI.
+        A name is *REQUIRED* and sameAs is *RECOMMENDED*.
+    """ ;
+    sh:property [
+        sh:path schema:name ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+        sh:minCount 1 ;
+        sh:description """
+            A *REQUIRED* property that indicates the term’s preferred label.
+        """ ;
+    ] ,
+    [
+        sh:path schema:sameAs ;
+        sh:nodeKind sh:IRI ;
+        sh:minCount 0 ;
+        sh:description """
+            A *RECOMMENDED* property that references the term in a controlled vocabulary.
+            If a public term URI is known, it *MUST* be provided.
+        """ ;
+    ] .
+
+_:PersonShape
+    a sh:NodeShape ;
+    sh:name "Person" ;
+    sh:targetClass schema:Person ;
+    sh:description """
+        If a [=metadata record=] is a person, it *MUST* be typed as `Person`.
+        If a [=term=] is available for the person, that *MUST* be [[#reference-terms|referenced]].
+        If not, the person *MUST* be defined by the required properties listed below.
+
+        The objective for the Person model is not to fully describe all aspects of a person,
+        but to easily identify and distinguish between similar persons.
+    """ ;
+    sh:property
+        [
+            sh:path schema:name ;
+            sh:datatype rdf:langString ;
+            sh:uniqueLang true ;
+            sh:minCount 1 ;
+            sh:description """
+                A *REQUIRED* property that indicates the Person’s full name in its preferred display form.
+
+                The name *MUST NOT* contain information that belongs to other properties, such as birthDate or deathDate.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "Person with a language-tagged name:" ;
+                rdfs:comment "file://examples/Person-name.jsonld" ;
+            ]
+        ] ,
+        [
+            sh:path schema:birthDate ;
+            sh:node _:DateShape ;
+            sh:minCount 0 ;
+            sh:maxCount 1 ;
+            sh:description """
+                An *OPTIONAL* property that indicates the person’s date of birth in ISO 8601 format: `YYYY-MM-DD`. Partial dates *MAY* be used if the exact date is unknown: `YYYY` or `YYYY-MM`.
+            """ ;
+        ] ,
+        [
+            sh:path schema:birthPlace ;
+            sh:or (
+                [ sh:node _:DefinedTermShape ]
+                [ sh:node _:PlaceShape ]
+            ) ;
+            sh:minCount 0 ;
+            sh:maxCount 1 ;
+            sh:description """
+                An *OPTIONAL* property that references the person’s place of birth.
+                The value *MUST* reference a [=term=]. If no term is available, a custom Place resource *MUST* be used.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "Person with birthPlace:" ;
+                rdfs:comment "file://examples/Person-birthPlace.jsonld" ;
+            ]
+        ] ,
+        [
+            sh:path schema:deathDate ;
+            sh:node _:DateShape ;
+            sh:minCount 0 ;
+            sh:maxCount 1 ;
+            sh:description """
+                An *OPTIONAL* property that indicates the person’s date of death in ISO 8601 format: `YYYY-MM-DD`. Partial dates *MAY* be used if the exact date is unknown: `YYYY` or `YYYY-MM`.
+            """ ;
+        ] ,
+        [
+            sh:path schema:deathPlace ;
+            sh:or (
+                [ sh:node _:DefinedTermShape ]
+                [ sh:node _:PlaceShape ]
+            ) ;
+            sh:minCount 0 ;
+            sh:maxCount 1 ;
+            sh:description """
+                An *OPTIONAL* property that references the person’s place of death.
+                The value *MUST* reference a term, or, if no term is available, a custom Place resource *MUST* be used.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "Person with deathPlace:" ;
+                rdfs:comment "file://examples/Person-deathPlace.jsonld" ;
+            ]
+        ] ,
+        [
+            sh:path schema:hasOccupation ;
+            sh:or (
+                [ sh:node _:DefinedTermShape ]
+                [ sh:node _:OccupationShape ]
+            ) ;
+            sh:minCount 0 ;
+            sh:description """
+                An *OPTIONAL* property that indicates the person’s occupation(s).
+                If available, a [[#reference-terms|term reference]] *MUST* be included in `sameAs`.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "A carpenter (as a term):" ;
+                rdfs:comment "file://examples/Person-hasOccupation-term.jsonld" ;
+            ] ;
+            rdfs:seeAlso [
+                rdfs:label "A sekreetruimer (for which no term is known):" ;
+                rdfs:comment "file://examples/Person-hasOccupation.jsonld" ;
+            ]
+        ] .
+
+_:OrganizationShape
+    a sh:NodeShape ;
+    sh:targetClass schema:Organization ;
+    sh:nodeKind sh:IRI ;
+    sh:name "Organization" ;
+    sh:description """
+        Each Organization *MUST* be identified by a persistent URI.
+        Blank nodes *MUST NOT* be used for identifying Organizations.
+    """ ;
+    sh:property [
+        sh:path schema:name ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+        sh:minCount 1 ;
+        sh:description """
+            A *REQUIRED* property that indicates the Organization’s full name in its preferred display form.
+        """ ;
+        rdfs:seeAlso [
+            rdfs:label "Organization name:" ;
+            rdfs:comment "file://examples/Organization-name.jsonld" ;
+        ]
+    ] ,
+    [
+        sh:path schema:location ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:class schema:Place ;
+        sh:node _:PlaceShape ;
+        sh:description """
+            An *OPTIONAL* property that indicates the Organization’s location,
+            useful for distinguishing the organization from others with similar names.
+
+            See Place for this property’s allowed values.
+        """ ;
+        rdfs:seeAlso [
+            rdfs:label "Organization with a location:" ;
+            rdfs:comment "file://examples/Organization-location.jsonld" ;
+        ]
+    ] .
+
+_:MediaObjectShape
+    a sh:NodeShape ;
+    sh:name "MediaObject" ;
+    sh:description """
+        In case of image, video, audio or 3d model objects, in addition to the MediaObject class,
+        the relevant subclass *MUST* be used:
+        - ImageObject
+        - VideoObject
+        - AudioObject
+        - 3DModel
+
+        For other types of media, the generic class MediaObject *MUST* be used by itself.
+    """ ;
+    sh:property
+        [
+            sh:path schema:license ;
+            sh:nodeKind sh:IRI ;
+            sh:minCount 1 ;
+            sh:pattern "^https?://" ;
+            sh:description """
+                A REQUIRED property that points to the URI for a license under which the digital reproduction may be used.
+                This concerns the use of the reproduction, not of the heritage object itself.
+                The value *MUST* be the canonical URI of a license.
+                For example, use https://creativecommons.org/licenses/by/4.0/ instead
+                of http://creativecommons.org/licenses/by/4.0/deed.nl.
+
+                The value *SHOULD* be an open license that allows the media to consumed,
+                for example one of the [Creative Commons](https://creativecommons.org/choose/) licenses.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "CC0 “No Rights Reserved” license on an ImageObject:" ;
+                rdfs:comment "file://examples/MediaObject-license.jsonld" ;
+            ]
+        ] ,
+        [
+            sh:path schema:contentUrl ;
+            sh:nodeKind sh:IRI ;
+            sh:minCount 1 ;
+            sh:pattern "^https?://" ;
+            sh:severity sh:Warning ;
+            sh:description """
+                Points to the URL of the media object, *REQUIRED* if the MediaObject is published under an open license.
+
+                For ImageObjects, this *SHOULD* be a high-resolution image to be used in full-screen viewers etc.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "Full-sized image representation of the Starry Night." ;
+                rdfs:comment "file://examples/MediaObject-contentUrl.jsonld" ;
+            ]
+        ] ,
+        [
+            sh:path schema:thumbnailUrl ;
+            sh:nodeKind sh:IRI ;
+            sh:minCount 1 ;
+            sh:pattern "^https?://" ;
+            sh:severity sh:Warning ;
+            sh:description """
+                Points to a smaller version of the MediaObject, *REQUIRED* if the MediaObject is published under an open license.
+
+                For ImageObjects, this *SHOULD* be a small image to be used in lists, search results etc.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "Both full-sized image and thumbnail of the Starry Night." ;
+                rdfs:comment "file://examples/MediaObject-thumbnailUrl.jsonld" ;
+            ]
+        ] ,
+        [
+            sh:path schema:copyrightNotice ;
+            sh:datatype rdf:langString ;
+            sh:minCount 0 ;
+            sh:description """
+                An *OPTIONAL* property that indicates the copyright aspects of the MediaObject,
+                particularly useful if the license requires attribution.
+            """ ;
+            rdfs:seeAlso [
+                rdfs:label "A MediaObject that may be used only with attribution." ;
+                rdfs:comment "file://examples/MediaObject-copyrightNotice.jsonld" ;
+            ]
+        ] .
+
+_:IIIFPresentationManifestShape
+    a sh:NodeShape ;
+    sh:nodeKind sh:IRI ;
+    sh:property [
+        sh:path schema:license ;
+        sh:nodeKind sh:IRI ;
+        sh:minCount 1 ;
+        sh:pattern "^https?://" ;
+    ] ,
+    [
+        sh:path schema:encodingFormat ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^application/ld\\+json;profile='http://iiif\\.io/api/presentation/\\d+/context\\.json'$" ;
+    ] .
+
+_:CreativeWorkAssociatedMediaCardinalityShape
+    a sh:NodeShape ;
+    sh:targetClass schema:CreativeWork ;
+    sh:property [
+        sh:path schema:associatedMedia ;
+        sh:qualifiedValueShape _:MediaObjectShape ;
+        sh:qualifiedMinCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message "At least one renderable MediaObject is required when media is available." ;
+    ] ,
+    [
+        sh:path schema:associatedMedia ;
+        sh:qualifiedValueShape _:IIIFPresentationManifestShape ;
+        sh:qualifiedMaxCount 1 ;
+        sh:message "At most one IIIF Presentation manifest may be exposed per CreativeWork." ;
+    ] .
+
+_:PlaceShape
+    a sh:NodeShape ;
+    sh:name "Place" ;
+    sh:targetClass schema:Place ;
+    sh:description """
+        For properties that reference locations, if no term is available, a custom Place resource *MUST* be used instead.
+    """ ;
+    sh:property [
+        sh:path schema:name ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+        sh:minCount 1 ;
+        sh:description """
+            A *REQUIRED* property that indicates the name of the place.
+        """ ;
+    ] ,
+    [
+        sh:path schema:address ;
+        sh:class schema:PostalAddress ;
+        sh:node _:PostalAddressShape ;
+        sh:minCount 0 ;
+        sh:description """
+            A property that indicates the Place’s address, *REQUIRED* if known.
+
+            See PostalAddress for this property’s allowed values.
+        """ ;
+        rdfs:seeAlso [
+            rdfs:label "A place with an address:" ;
+            rdfs:comment "file://examples/Place-address.jsonld" ;
+        ]
+    ] ,
+    [
+        sh:path schema:geo ;
+        sh:or (
+            [
+                sh:class schema:GeoCoordinates ;
+                sh:node [
+                    a sh:NodeShape ;
+                    sh:name "GeoCoordinates" ;
+                    sh:description """
+                        Geographic coordinates for a Place.
+                    """ ;
+                    sh:property [
+                        sh:path schema:latitude ;
+                        sh:datatype xsd:double ;
+                        sh:minCount 1 ;
+                        sh:maxCount 1 ;
+                        sh:description """
+                            The latitude of a location. For example 37.42242 (WGS 84).
+                        """ ;
+                    ] ,
+                    [
+                        sh:path schema:longitude ;
+                        sh:datatype xsd:double ;
+                        sh:minCount 1 ;
+                        sh:maxCount 1 ;
+                        sh:description """
+                            The longitude of a location. For example -122.08585 (WGS 84).
+                        """ ;
+                    ]
+                ] ;
+            ]
+            [ sh:class schema:GeoShape ]
+        ) ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:description """
+            A property that indicates the Place’s [[!WGS84]] geo coordinates, *REQUIRED* if known.
+        """ ;
+        rdfs:seeAlso [
+            rdfs:label "A place with coordinates:" ;
+            rdfs:comment "file://examples/Place-geo.jsonld" ;
+        ]
+    ] .
+
+_:OccupationShape
+    a sh:NodeShape ;
+    sh:class schema:Occupation ;
+    sh:description """
+        A Person’s occupation.
+    """ ;
+    sh:property [
+        sh:path schema:name ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+        sh:minCount 1 ;
+        sh:description """
+            A *REQUIRED* property that indicates the occupation’s name.
+        """ ;
+    ] .
+
+_:PostalAddressShape
+    a sh:NodeShape ;
+    sh:name "PostalAddress" ;
+    sh:description """
+        A postal address for an Organization or Place.
+        All properties are *OPTIONAL*.
+    """ ;
+    sh:property [
+        sh:path schema:streetAddress ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:description """
+            An *OPTIONAL* property that indicates the street address, e.g. ‘Street 123’.
+        """ ;
+    ] ,
+    [
+        sh:path schema:postalCode ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:description """
+            An *OPTIONAL* property that indicates the postal code, e.g. ‘1234 AB’.
+        """ ;
+    ] ,
+    [
+        sh:path schema:addressLocality ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:description """
+            An *OPTIONAL* property that indicates the locality (city).
+        """ ;
+    ] ,
+    [
+        sh:path schema:addressRegion ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:description """
+            An *OPTIONAL* property that indicates the region (province or state).
+        """ ;
+    ] ,
+    [
+        sh:path schema:addressCountry ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:description """
+            An *OPTIONAL* property that indicates the country.
+            For countries that have an [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) alpha-2 country code (e.g. ‘NL’), that *MUST* be used.
+            For historical countries, their name *MAY* be used instead (e.g. ‘Prussia’).
+        """ ;
+    ] .
+
+_:DateShape
+    a sh:NodeShape ;
+    sh:or (
+        [ sh:datatype schema:Date ]
+        [ sh:datatype xsd:date ]
+    ) ;
+    sh:pattern "^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$" ;
+.

--- a/packages/pipeline-shacl-sampler/test/fixtures/unsupported-path.ttl
+++ b/packages/pipeline-shacl-sampler/test/fixtures/unsupported-path.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+_:Shape a sh:NodeShape ;
+    sh:targetClass schema:Thing ;
+    sh:property [
+        sh:path ( schema:a schema:b ) ;
+        sh:class schema:Other ;
+    ] .

--- a/packages/pipeline-shacl-sampler/test/pathExtractor.test.ts
+++ b/packages/pipeline-shacl-sampler/test/pathExtractor.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { extractTargetShapes } from '../src/pathExtractor.js';
+
+const shapesFile = join(__dirname, 'fixtures', 'schema-profile.ttl');
+
+describe('extractTargetShapes', () => {
+  it('returns one entry per sh:targetClass declared in the SHACL', async () => {
+    const shapes = await extractTargetShapes(shapesFile);
+    const classes = shapes.map((s) => s.targetClass.value).sort();
+    expect(classes).toEqual([
+      'https://schema.org/CreativeWork',
+      'https://schema.org/Organization',
+      'https://schema.org/Person',
+      'https://schema.org/Place',
+    ]);
+  });
+
+  it('merges multiple NodeShapes that target the same class', async () => {
+    const shapes = await extractTargetShapes(shapesFile);
+    const creativeWork = findByClass(shapes, 'https://schema.org/CreativeWork');
+    // CreativeWorkShape declares schema:name + schema:creator + …;
+    // CreativeWorkAssociatedMediaCardinalityShape adds qualified shapes on
+    // schema:associatedMedia. Both target schema:CreativeWork — paths must be
+    // deduplicated across the two shapes.
+    const pathValues = creativeWork.paths.map((p) => p.value);
+    expect(pathValues).toContain('https://schema.org/name');
+    expect(pathValues).toContain('https://schema.org/creator');
+    expect(pathValues).toContain('https://schema.org/associatedMedia');
+    // associatedMedia appears in both shapes but only once in the merged set.
+    expect(
+      pathValues.filter((p) => p === 'https://schema.org/associatedMedia'),
+    ).toHaveLength(1);
+  });
+
+  it('marks paths with nested-shape constraints as follow paths', async () => {
+    const shapes = await extractTargetShapes(shapesFile);
+    const creativeWork = findByClass(shapes, 'https://schema.org/CreativeWork');
+    const followValues = creativeWork.followPaths.map((p) => p.value);
+
+    // sh:or with sh:class/sh:node branches.
+    expect(followValues).toContain('https://schema.org/creator');
+    expect(followValues).toContain('https://schema.org/associatedMedia');
+    expect(followValues).toContain('https://schema.org/contentLocation');
+    expect(followValues).toContain('https://schema.org/locationCreated');
+    expect(followValues).toContain('https://schema.org/about');
+    expect(followValues).toContain('https://schema.org/identifier');
+    // Direct sh:node.
+    expect(followValues).toContain('https://schema.org/material');
+    expect(followValues).toContain('https://schema.org/genre');
+    expect(followValues).toContain('https://schema.org/dateCreated');
+  });
+
+  it('omits paths whose constraint is purely datatype/nodeKind from follow paths', async () => {
+    const shapes = await extractTargetShapes(shapesFile);
+    const creativeWork = findByClass(shapes, 'https://schema.org/CreativeWork');
+    const followValues = creativeWork.followPaths.map((p) => p.value);
+
+    // schema:name has only sh:datatype rdf:langString — must not appear.
+    expect(followValues).not.toContain('https://schema.org/name');
+    // schema:description, schema:abstract: pure datatype.
+    expect(followValues).not.toContain('https://schema.org/description');
+    expect(followValues).not.toContain('https://schema.org/abstract');
+    // schema:isPartOf has no value-shape constraint.
+    expect(followValues).not.toContain('https://schema.org/isPartOf');
+  });
+
+  it('extracts Person nested paths so depth-1 from a CreativeWork creator hits them', async () => {
+    const shapes = await extractTargetShapes(shapesFile);
+    const person = findByClass(shapes, 'https://schema.org/Person');
+    const pathValues = person.paths.map((p) => p.value);
+    expect(pathValues).toContain('https://schema.org/name');
+    expect(pathValues).toContain('https://schema.org/birthDate');
+    expect(pathValues).toContain('https://schema.org/birthPlace');
+    expect(pathValues).toContain('https://schema.org/hasOccupation');
+  });
+});
+
+function findByClass(
+  shapes: Awaited<ReturnType<typeof extractTargetShapes>>,
+  iri: string,
+) {
+  const shape = shapes.find((s) => s.targetClass.value === iri);
+  if (!shape) throw new Error(`No shape found for ${iri}`);
+  return shape;
+}

--- a/packages/pipeline-shacl-sampler/test/pathExtractor.test.ts
+++ b/packages/pipeline-shacl-sampler/test/pathExtractor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
-import { extractTargetShapes } from '../src/pathExtractor.js';
+import { extractTargetShapes, type TargetShape } from '../src/pathExtractor.js';
 
 const shapesFile = join(__dirname, 'fixtures', 'schema-profile.ttl');
 
@@ -16,71 +16,105 @@ describe('extractTargetShapes', () => {
     ]);
   });
 
-  it('merges multiple NodeShapes that target the same class', async () => {
+  it('emits a chain for every path whose constraint references a nested shape', async () => {
     const shapes = await extractTargetShapes(shapesFile);
     const creativeWork = findByClass(shapes, 'https://schema.org/CreativeWork');
-    // CreativeWorkShape declares schema:name + schema:creator + …;
-    // CreativeWorkAssociatedMediaCardinalityShape adds qualified shapes on
-    // schema:associatedMedia. Both target schema:CreativeWork — paths must be
-    // deduplicated across the two shapes.
-    const pathValues = creativeWork.paths.map((p) => p.value);
-    expect(pathValues).toContain('https://schema.org/name');
-    expect(pathValues).toContain('https://schema.org/creator');
-    expect(pathValues).toContain('https://schema.org/associatedMedia');
-    // associatedMedia appears in both shapes but only once in the merged set.
-    expect(
-      pathValues.filter((p) => p === 'https://schema.org/associatedMedia'),
-    ).toHaveLength(1);
+    const top = topChains(creativeWork);
+
+    // sh:or with sh:class/sh:node branches:
+    expect(top).toContain('https://schema.org/creator');
+    expect(top).toContain('https://schema.org/associatedMedia');
+    expect(top).toContain('https://schema.org/contentLocation');
+    expect(top).toContain('https://schema.org/locationCreated');
+    expect(top).toContain('https://schema.org/about');
+    expect(top).toContain('https://schema.org/identifier');
+    // Direct sh:node:
+    expect(top).toContain('https://schema.org/material');
+    expect(top).toContain('https://schema.org/genre');
+    expect(top).toContain('https://schema.org/dateCreated');
   });
 
-  it('marks paths with nested-shape constraints as follow paths', async () => {
+  it('omits leaf paths (datatype / nodeKind only) from chains', async () => {
     const shapes = await extractTargetShapes(shapesFile);
     const creativeWork = findByClass(shapes, 'https://schema.org/CreativeWork');
-    const followValues = creativeWork.followPaths.map((p) => p.value);
+    const top = topChains(creativeWork);
 
-    // sh:or with sh:class/sh:node branches.
-    expect(followValues).toContain('https://schema.org/creator');
-    expect(followValues).toContain('https://schema.org/associatedMedia');
-    expect(followValues).toContain('https://schema.org/contentLocation');
-    expect(followValues).toContain('https://schema.org/locationCreated');
-    expect(followValues).toContain('https://schema.org/about');
-    expect(followValues).toContain('https://schema.org/identifier');
-    // Direct sh:node.
-    expect(followValues).toContain('https://schema.org/material');
-    expect(followValues).toContain('https://schema.org/genre');
-    expect(followValues).toContain('https://schema.org/dateCreated');
+    // schema:name has only sh:datatype rdf:langString — leaf.
+    expect(top).not.toContain('https://schema.org/name');
+    expect(top).not.toContain('https://schema.org/description');
+    expect(top).not.toContain('https://schema.org/abstract');
+    // schema:isPartOf has only minCount — no value-shape ref.
+    expect(top).not.toContain('https://schema.org/isPartOf');
   });
 
-  it('omits paths whose constraint is purely datatype/nodeKind from follow paths', async () => {
+  it('extends chains recursively into nested shapes', async () => {
     const shapes = await extractTargetShapes(shapesFile);
     const creativeWork = findByClass(shapes, 'https://schema.org/CreativeWork');
-    const followValues = creativeWork.followPaths.map((p) => p.value);
 
-    // schema:name has only sh:datatype rdf:langString — must not appear.
-    expect(followValues).not.toContain('https://schema.org/name');
-    // schema:description, schema:abstract: pure datatype.
-    expect(followValues).not.toContain('https://schema.org/description');
-    expect(followValues).not.toContain('https://schema.org/abstract');
-    // schema:isPartOf has no value-shape constraint.
-    expect(followValues).not.toContain('https://schema.org/isPartOf');
+    // CreativeWork.creator → CreatorShape.name is a leaf, but Person itself
+    // has sh:targetClass Person so via sh:class Person we recurse:
+    // creator → Person → birthPlace → Place → address (PostalAddress is
+    // referenced via sh:node so we get this chain).
+    expect(hasChain(creativeWork, ['creator', 'birthPlace', 'address'])).toBe(
+      true,
+    );
+    // creator → Person → hasOccupation (sh:or contains sh:node):
+    expect(hasChain(creativeWork, ['creator', 'hasOccupation'])).toBe(true);
   });
 
-  it('extracts Person nested paths so depth-1 from a CreativeWork creator hits them', async () => {
+  it('handles self-cycles in the shape graph', async () => {
+    // CreativeWork.about → sh:class CreativeWork → cycle back to
+    // CreativeWorkShape. The extractor must terminate the recursion at
+    // the second visit.
     const shapes = await extractTargetShapes(shapesFile);
-    const person = findByClass(shapes, 'https://schema.org/Person');
-    const pathValues = person.paths.map((p) => p.value);
-    expect(pathValues).toContain('https://schema.org/name');
-    expect(pathValues).toContain('https://schema.org/birthDate');
-    expect(pathValues).toContain('https://schema.org/birthPlace');
-    expect(pathValues).toContain('https://schema.org/hasOccupation');
+    const creativeWork = findByClass(shapes, 'https://schema.org/CreativeWork');
+
+    // The about hop itself must be present:
+    expect(hasChain(creativeWork, ['about'])).toBe(true);
+    // … but the recursion must not produce an infinite [about, about, …]:
+    for (const chain of creativeWork.pathChains) {
+      const aboutHops = chain.filter(
+        (p) => p.value === 'https://schema.org/about',
+      ).length;
+      expect(aboutHops).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('throws on unsupported sh:path forms (sequence/alternative/inverse)', async () => {
+    await expect(
+      extractTargetShapes(join(__dirname, 'fixtures', 'unsupported-path.ttl')),
+    ).rejects.toThrow(/only plain IRI paths are supported/);
+  });
+
+  it('walks Place’s nested shape graph for the Place target', async () => {
+    const shapes = await extractTargetShapes(shapesFile);
+    const place = findByClass(shapes, 'https://schema.org/Place');
+    // Place.address → PostalAddress has only leaf properties, so the chain
+    // stops at [address]:
+    expect(hasChain(place, ['address'])).toBe(true);
+    // Place.geo → branches with sh:node and sh:class on GeoCoordinates /
+    // GeoShape — at minimum [geo] must be present:
+    expect(hasChain(place, ['geo'])).toBe(true);
   });
 });
 
-function findByClass(
-  shapes: Awaited<ReturnType<typeof extractTargetShapes>>,
-  iri: string,
-) {
+function findByClass(shapes: TargetShape[], iri: string): TargetShape {
   const shape = shapes.find((s) => s.targetClass.value === iri);
   if (!shape) throw new Error(`No shape found for ${iri}`);
   return shape;
+}
+
+function topChains(shape: TargetShape): string[] {
+  return shape.pathChains
+    .filter((chain) => chain.length === 1)
+    .map((chain) => chain[0].value);
+}
+
+function hasChain(shape: TargetShape, localNames: string[]): boolean {
+  const expected = localNames.map((name) => `https://schema.org/${name}`);
+  return shape.pathChains.some(
+    (chain) =>
+      chain.length === expected.length &&
+      chain.every((node, i) => node.value === expected[i]),
+  );
 }

--- a/packages/pipeline-shacl-sampler/test/sampleStages.test.ts
+++ b/packages/pipeline-shacl-sampler/test/sampleStages.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { DataFactory } from 'n3';
+import {
+  buildSampleQuery,
+  buildSubjectSelectorQuery,
+  shaclSampleStages,
+} from '../src/sampleStages.js';
+import type { TargetShape } from '../src/pathExtractor.js';
+
+const { namedNode } = DataFactory;
+const shapesFile = join(__dirname, 'fixtures', 'schema-profile.ttl');
+
+describe('buildSampleQuery', () => {
+  const shape: TargetShape = {
+    targetClass: namedNode('https://schema.org/CreativeWork'),
+    pathChains: [
+      [namedNode('https://schema.org/creator')],
+      [
+        namedNode('https://schema.org/creator'),
+        namedNode('https://schema.org/birthPlace'),
+      ],
+    ],
+  };
+
+  it('contains no inner SELECT or LIMIT — sample selection is the ItemSelector’s job', () => {
+    const query = buildSampleQuery(shape);
+    expect(query).not.toMatch(/\bSELECT\b/);
+    expect(query).not.toMatch(/\bLIMIT\b/);
+  });
+
+  it('emits one UNION branch per path chain using SPARQL property-paths', () => {
+    const query = buildSampleQuery(shape);
+    expect(query).toContain('<https://schema.org/creator> ?neighbour');
+    expect(query).toContain(
+      '<https://schema.org/creator>/<https://schema.org/birthPlace> ?neighbour',
+    );
+  });
+
+  it('emits CONSTRUCT for the sampled subject and its neighbours', () => {
+    const query = buildSampleQuery(shape);
+    expect(query).toMatch(/^CONSTRUCT \{\s*\?s \?p \?o \./);
+    expect(query).toContain('?neighbour ?np ?nv');
+  });
+});
+
+describe('buildSubjectSelectorQuery', () => {
+  const targetClass = namedNode('https://schema.org/CreativeWork');
+
+  it('produces a SELECT DISTINCT ?s with LIMIT', () => {
+    const query = buildSubjectSelectorQuery(targetClass, 50);
+    expect(query).toMatch(/SELECT DISTINCT \?s/);
+    expect(query).toMatch(/LIMIT 50/);
+    expect(query).toContain('?s a <https://schema.org/CreativeWork>');
+  });
+
+  it('inlines a subjectFilter when provided', () => {
+    const query = buildSubjectSelectorQuery(
+      targetClass,
+      10,
+      '?s <https://example.org/inDataset> <urn:d> .',
+    );
+    expect(query).toContain('?s <https://example.org/inDataset> <urn:d> .');
+  });
+
+  it('emits a FROM clause when the distribution has a named graph', () => {
+    const query = buildSubjectSelectorQuery(
+      targetClass,
+      10,
+      undefined,
+      'https://example.org/graph',
+    );
+    expect(query).toContain('FROM <https://example.org/graph>');
+  });
+});
+
+describe('shaclSampleStages', () => {
+  it('returns one Stage per sh:targetClass in the SHACL', async () => {
+    const stages = await shaclSampleStages({ shapesFile });
+    const names = stages.map((s) => s.name).sort();
+    expect(names).toEqual([
+      'shacl-sample-CreativeWork',
+      'shacl-sample-Organization',
+      'shacl-sample-Person',
+      'shacl-sample-Place',
+    ]);
+  });
+
+  it('does not attach a validator slot when no validator is passed', async () => {
+    const stages = await shaclSampleStages({ shapesFile });
+    for (const stage of stages) {
+      expect(stage.validator).toBeUndefined();
+    }
+  });
+
+  it('attaches the provided validator to every stage', async () => {
+    const validator = {
+      validate: async () => ({ conforms: true, violations: 0 }),
+      report: async () => ({
+        conforms: true,
+        violations: 0,
+        quadsValidated: 0,
+      }),
+    };
+    const stages = await shaclSampleStages({ shapesFile, validator });
+    for (const stage of stages) {
+      expect(stage.validator).toBe(validator);
+    }
+  });
+});

--- a/packages/pipeline-shacl-sampler/tsconfig.json
+++ b/packages/pipeline-shacl-sampler/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/pipeline-shacl-sampler/tsconfig.lib.json
+++ b/packages/pipeline-shacl-sampler/tsconfig.lib.json
@@ -1,0 +1,34 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../dataset/tsconfig.lib.json"
+    },
+    {
+      "path": "../pipeline/tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx",
+    "test/**/*.test.js",
+    "test/**/*.spec.js",
+    "test/**/*.test.jsx",
+    "test/**/*.spec.jsx"
+  ]
+}

--- a/packages/pipeline-shacl-sampler/tsconfig.spec.json
+++ b/packages/pipeline-shacl-sampler/tsconfig.spec.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "types": ["node"]
+  },
+  "include": [
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx",
+    "test/**/*.test.js",
+    "test/**/*.spec.js",
+    "test/**/*.test.jsx",
+    "test/**/*.spec.jsx",
+    "test/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pipeline-shacl-sampler/vite.config.ts
+++ b/packages/pipeline-shacl-sampler/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 80,
-          lines: 92.42,
-          branches: 77.77,
-          statements: 89.04,
+          functions: 100,
+          lines: 97.93,
+          branches: 82.5,
+          statements: 94.33,
         },
       },
     },

--- a/packages/pipeline-shacl-sampler/vite.config.ts
+++ b/packages/pipeline-shacl-sampler/vite.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 100,
-          lines: 97.93,
-          branches: 82.5,
-          statements: 94.33,
+          lines: 97.87,
+          branches: 79.41,
+          statements: 94.17,
         },
       },
     },

--- a/packages/pipeline-shacl-sampler/vite.config.ts
+++ b/packages/pipeline-shacl-sampler/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vite.base.config.js';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    root: __dirname,
+    cacheDir: '../../node_modules/.vite/packages/pipeline-shacl-sampler',
+    test: {
+      coverage: {
+        thresholds: {
+          autoUpdate: true,
+          functions: 80,
+          lines: 92.42,
+          branches: 77.77,
+          statements: 89.04,
+        },
+      },
+    },
+  }),
+);

--- a/packages/pipeline-shacl-sampler/vite.config.ts
+++ b/packages/pipeline-shacl-sampler/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 100,
-          lines: 97.87,
-          branches: 79.41,
-          statements: 94.17,
+          functions: 95.45,
+          lines: 96.63,
+          branches: 84,
+          statements: 93.79,
         },
       },
     },

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -74,7 +74,10 @@ Selects resources from the distribution and fans out executor calls per batch of
 
 ```typescript
 interface ItemSelector {
-  select(distribution: Distribution, batchSize?: number): AsyncIterable<VariableBindings>;
+  select(
+    distribution: Distribution,
+    batchSize?: number,
+  ): AsyncIterable<VariableBindings>;
 }
 ```
 
@@ -217,6 +220,26 @@ new Stage({
 | `'halt'`    | Throw an error, stopping the pipeline              |
 
 `Validator` is an interface, so you can implement your own validation strategy. See [@lde/pipeline-shacl-validator](../pipeline-shacl-validator) for the SHACL implementation.
+
+#### Per-dataset reporting
+
+After all stages for a dataset have run, the pipeline calls `validator.report(dataset)` once for each distinct validator attached to any stage and emits a `datasetValidated(dataset, report)` event on the reporter. The call happens **regardless of whether any stage actually invoked `validate()`** — useful for decorators that want to surface a verdict even when every stage’s `ItemSelector` returned zero items.
+
+#### `requireNonEmptyData`
+
+A small generic decorator over any `Validator`. Wraps the inner validator so its dataset report flips to non-conforming when `quadsValidated === 0` for that dataset — i.e. no stage ever produced data for the validator to inspect.
+
+```typescript
+import { requireNonEmptyData } from '@lde/pipeline';
+import { ShaclValidator } from '@lde/pipeline-shacl-validator';
+
+const validator = requireNonEmptyData(
+  new ShaclValidator({ shapesFile: './shapes.ttl', reportDir: './validation' }),
+  { message: 'No target class matched in this dataset.' },
+);
+```
+
+The decorator is stateless; per-dataset accumulation stays in the inner validator.
 
 ### Writer
 

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -23,6 +23,7 @@ import type {
   DistributionAnalysisResult,
   ProgressReporter,
 } from './progressReporter.js';
+import type { Validator } from './validator.js';
 
 /** Plugin that hooks into pipeline lifecycle events. */
 export interface PipelinePlugin {
@@ -243,11 +244,30 @@ export class Pipeline {
     }
 
     await this.writer.flush?.(dataset);
+    await this.reportValidators(dataset);
     const datasetMemory = process.memoryUsage();
     this.reporter?.datasetComplete?.(dataset, {
       memoryUsageBytes: datasetMemory.rss,
       heapUsedBytes: datasetMemory.heapUsed,
     });
+  }
+
+  private async reportValidators(dataset: Dataset): Promise<void> {
+    const validators = new Set<Validator>();
+    for (const stage of this.collectStages(this.stages)) {
+      if (stage.validator) validators.add(stage.validator);
+    }
+    for (const validator of validators) {
+      const report = await validator.report(dataset);
+      this.reporter?.datasetValidated?.(dataset, report);
+    }
+  }
+
+  private *collectStages(stages: readonly Stage[]): Iterable<Stage> {
+    for (const stage of stages) {
+      yield stage;
+      if (stage.stages.length > 0) yield* this.collectStages(stage.stages);
+    }
   }
 
   /**
@@ -290,11 +310,6 @@ export class Pipeline {
       quadsGenerated,
       duration: Date.now() - stageStart,
     });
-
-    if (stage.validator) {
-      const report = await stage.validator.report(dataset);
-      this.reporter?.stageValidated?.(stage.name, report);
-    }
 
     return true;
   }

--- a/packages/pipeline/src/progressReporter.ts
+++ b/packages/pipeline/src/progressReporter.ts
@@ -43,9 +43,15 @@ export interface ProgressReporter {
     },
   ): void;
   stageFailed?(stage: string, error: Error): void;
-  /** Called after a stage completes if it has a validator. */
-  stageValidated?(stage: string, report: ValidationReport): void;
   stageSkipped?(stage: string, reason: string): void;
+  /**
+   * Called once per (dataset, validator) pair after all stages for a dataset
+   * have run. Fires regardless of whether any stage actually invoked
+   * `validate()` — the report reflects the validator’s accumulated state,
+   * which lets decorators such as `requireNonEmptyData` surface a verdict
+   * even when no stage produced data.
+   */
+  datasetValidated?(dataset: Dataset, report: ValidationReport): void;
   datasetComplete?(
     dataset: Dataset,
     result: { memoryUsageBytes: number; heapUsedBytes: number },

--- a/packages/pipeline/src/validator.ts
+++ b/packages/pipeline/src/validator.ts
@@ -22,3 +22,46 @@ export interface ValidationResult {
 export interface ValidationReport extends ValidationResult {
   quadsValidated: number;
 }
+
+/** Options for {@link requireNonEmptyData}. */
+export interface RequireNonEmptyDataOptions {
+  /**
+   * Message attached to the synthesised non-conformance.
+   * @default 'Validator received no quads for this dataset.'
+   */
+  message?: string;
+}
+
+/**
+ * Decorate a {@link Validator} so its dataset report flips to non-conforming
+ * when no quads were ever validated for that dataset.
+ *
+ * Useful when the upstream stages are expected to produce *some* data — for
+ * instance per-class samplers whose `ItemSelector` returns zero subjects for
+ * every target class. The decorator keeps the underlying validator’s
+ * semantics intact: it only synthesises an extra violation when
+ * {@link ValidationReport.quadsValidated} is `0`.
+ *
+ * The decorator is stateless; per-dataset accumulation stays in the
+ * underlying validator.
+ */
+export function requireNonEmptyData(
+  inner: Validator,
+  options?: RequireNonEmptyDataOptions,
+): Validator {
+  const message =
+    options?.message ?? 'Validator received no quads for this dataset.';
+  return {
+    validate: (quads, dataset) => inner.validate(quads, dataset),
+    async report(dataset) {
+      const innerReport = await inner.report(dataset);
+      if (innerReport.quadsValidated > 0) return innerReport;
+      return {
+        conforms: false,
+        violations: innerReport.violations + 1,
+        quadsValidated: 0,
+        message,
+      };
+    },
+  };
+}

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -89,8 +89,9 @@ function makeReporter(): RequiredReporter {
     stageProgress: vi.fn<NonNullable<ProgressReporter['stageProgress']>>(),
     stageComplete: vi.fn<NonNullable<ProgressReporter['stageComplete']>>(),
     stageFailed: vi.fn<NonNullable<ProgressReporter['stageFailed']>>(),
-    stageValidated: vi.fn<NonNullable<ProgressReporter['stageValidated']>>(),
     stageSkipped: vi.fn<NonNullable<ProgressReporter['stageSkipped']>>(),
+    datasetValidated:
+      vi.fn<NonNullable<ProgressReporter['datasetValidated']>>(),
     datasetComplete: vi.fn<NonNullable<ProgressReporter['datasetComplete']>>(),
     datasetSkipped: vi.fn<NonNullable<ProgressReporter['datasetSkipped']>>(),
     pipelineComplete:

--- a/packages/pipeline/test/validator.test.ts
+++ b/packages/pipeline/test/validator.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Dataset } from '@lde/dataset';
+import type { Quad } from '@rdfjs/types';
+import {
+  requireNonEmptyData,
+  type Validator,
+  type ValidationResult,
+  type ValidationReport,
+} from '../src/validator.js';
+
+const datasetA = new Dataset({
+  iri: new URL('http://example.org/dataset/a'),
+  distributions: [],
+});
+
+const datasetB = new Dataset({
+  iri: new URL('http://example.org/dataset/b'),
+  distributions: [],
+});
+
+function fakeValidator(report: ValidationReport): Validator {
+  const validate =
+    vi.fn<(quads: Quad[], dataset: Dataset) => Promise<ValidationResult>>();
+  validate.mockResolvedValue({
+    conforms: report.conforms,
+    violations: report.violations,
+  });
+  return {
+    validate,
+    report: vi
+      .fn<(dataset: Dataset) => Promise<ValidationReport>>()
+      .mockResolvedValue(report),
+  };
+}
+
+describe('requireNonEmptyData', () => {
+  it('forwards validate calls unchanged', async () => {
+    const inner = fakeValidator({
+      conforms: true,
+      violations: 0,
+      quadsValidated: 0,
+    });
+    const wrapped = requireNonEmptyData(inner);
+
+    const quads: Quad[] = [];
+    await wrapped.validate(quads, datasetA);
+
+    expect(inner.validate).toHaveBeenCalledWith(quads, datasetA);
+  });
+
+  it('returns the inner report unchanged when quadsValidated > 0', async () => {
+    const innerReport: ValidationReport = {
+      conforms: true,
+      violations: 0,
+      quadsValidated: 42,
+    };
+    const wrapped = requireNonEmptyData(fakeValidator(innerReport));
+
+    const report = await wrapped.report(datasetA);
+
+    expect(report).toEqual(innerReport);
+  });
+
+  it('flips to non-conforming when quadsValidated is 0', async () => {
+    const wrapped = requireNonEmptyData(
+      fakeValidator({ conforms: true, violations: 0, quadsValidated: 0 }),
+    );
+
+    const report = await wrapped.report(datasetA);
+
+    expect(report.conforms).toBe(false);
+    expect(report.violations).toBe(1);
+    expect(report.quadsValidated).toBe(0);
+    expect(report.message).toMatch(/no quads/i);
+  });
+
+  it('increments existing violations rather than overwriting them', async () => {
+    const wrapped = requireNonEmptyData(
+      fakeValidator({ conforms: false, violations: 3, quadsValidated: 0 }),
+    );
+
+    const report = await wrapped.report(datasetA);
+
+    expect(report.violations).toBe(4);
+  });
+
+  it('surfaces a custom message when provided', async () => {
+    const wrapped = requireNonEmptyData(
+      fakeValidator({ conforms: true, violations: 0, quadsValidated: 0 }),
+      { message: 'No SCHEMA-AP-NDE target class matched.' },
+    );
+
+    const report = await wrapped.report(datasetA);
+
+    expect(report.message).toBe('No SCHEMA-AP-NDE target class matched.');
+  });
+
+  it('produces independent reports for different datasets', async () => {
+    // The inner validator’s mock returns one report; in real use it would
+    // accumulate per-dataset state. Here we just check the wrapper doesn’t
+    // hold on to dataset-scoped state of its own.
+    const innerReport: ValidationReport = {
+      conforms: true,
+      violations: 0,
+      quadsValidated: 10,
+    };
+    const wrapped = requireNonEmptyData(fakeValidator(innerReport));
+
+    expect(await wrapped.report(datasetA)).toEqual(innerReport);
+    expect(await wrapped.report(datasetB)).toEqual(innerReport);
+  });
+});

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 93.38,
-          lines: 93.36,
-          branches: 89.32,
-          statements: 92.9,
+          functions: 93.47,
+          lines: 93.43,
+          branches: 89.39,
+          statements: 92.85,
         },
       },
     },

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 93.23,
-          lines: 93.3,
-          branches: 89.19,
-          statements: 92.83,
+          functions: 93.38,
+          lines: 93.36,
+          branches: 89.32,
+          statements: 92.9,
         },
       },
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,6 +57,9 @@
       "path": "./packages/pipeline-shacl-validator"
     },
     {
+      "path": "./packages/pipeline-shacl-sampler"
+    },
+    {
       "path": "./packages/distribution-probe"
     }
   ]


### PR DESCRIPTION
## Summary

Adds two pieces of shared infrastructure for SHACL-driven sampling and validation in `@lde/pipeline`-based pipelines, plus a small refactor of how validators report per dataset.

**`@lde/pipeline-shacl-sampler` (new package)** — turns a SHACL shapes file into one sampling `Stage` per `sh:targetClass`. Each stage pairs a `SparqlItemSelector` that picks N target-class subjects with a `SparqlConstructExecutor` that, for every path chain the SHACL declares (walked recursively through `sh:node`, `sh:class`, `sh:qualifiedValueShape`, and `sh:or` branches, stopping at leaf constraints or shape cycles), pulls in the triples reachable along that chain’s terminal node. The result is a sample subgraph rich enough for `@lde/pipeline-shacl-validator` to validate without false-positive ‘missing nested node’ violations.

**`@lde/pipeline` additions**:
- `requireNonEmptyData(validator, { message? })` — a generic `Validator` decorator that flips a dataset’s report to non-conforming when `quadsValidated === 0`, i.e. when no stage ever fed the validator any data. Stateless; per-dataset accumulation stays in the inner validator.
- `validator.report(dataset)` is now called **once per dataset** at the end of `processDataset`, instead of once per successful stage. The reporter hook renames from `stageValidated(stage, report)` → `datasetValidated(dataset, report)` and now fires even when every stage returned `NotSupported` — which is what makes `requireNonEmptyData` observable in the “no target class matched” case.

## Why

Pipelines that validate large remote datasets against SHACL need three things that the LDE ecosystem didn’t cover:
1. A way to assemble a shape-complete sample subgraph via a single CONSTRUCT per target class (instead of per-entity HTTP dereferencing as in `extract-cbd-shape`).
2. A way to walk the SHACL recursively so depth-N nested shapes (`creator → Person → birthPlace → Place → address → PostalAddress` in NDE’s SCHEMA-AP, with self-cycles via `schema:about → CreativeWork`) don’t produce false-positive cascading violations.
3. A way to surface a “dataset matches no target class at all” verdict — necessary because pure SHACL Core treats empty target sets as vacuously valid, so a dataset that doesn’t fit the profile passes silently.

The immediate consumer is the [NDE Dataset Knowledge Graph](https://github.com/netwerk-digitaal-erfgoed/dataset-knowledge-graph) ([issue #273](https://github.com/netwerk-digitaal-erfgoed/dataset-knowledge-graph/issues/273)), which validates samples against [SCHEMA-AP-NDE](https://github.com/netwerk-digitaal-erfgoed/schema-profile). The shape of the API stays generic: `shaclSampleStages` accepts any SHACL file and any `Validator`; `requireNonEmptyData` wraps any `Validator`; the reporter rename benefits every pipeline.

## Notes

- **Sampler scope:** only plain-IRI `sh:path` is supported (sequence, alternative and inverse paths throw at extraction time — none appear in current SCHEMA-AP-NDE). `sh:targetClass` is the only target form recognised; `sh:targetNode`, `sh:targetSubjectsOf`, `sh:targetObjectsOf` and `sh:sparqlTarget` are not yet supported. Both are documented in the package README’s `Limitations` section.
- **Standards survey** in `pipeline-shacl-sampler/README.md` → `Related work`: explains why `extract-cbd-shape` (TREEcg) and SHACL2SPARQL (Corman et al. 2019) are not the right tools for batched CONSTRUCT extraction over a remote SPARQL endpoint.
- **Pre-release housekeeping:** the `stageValidated` → `datasetValidated` rename is a breaking change to the `ProgressReporter` interface. Per the repo’s pre-release policy, no back-compat shim was added.
- **`requireNonEmptyData` observability:** depends on the per-dataset `report()` call landing in this same PR. Without that refactor, the decorator’s flip would have nowhere to fire on a “every selector empty” dataset.
- **`onInvalid` type:** the sampler reuses the `'write' | 'skip' | 'halt'` union from `@lde/pipeline`’s `StageOptions` via a type lookup, so the two stay in lockstep without duplication.
