### PR TITLE
ci(deps): ignore @comunica 5.2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,8 @@ updates:
       - dependency-name: 'vite'
       - dependency-name: 'vitest'
       - dependency-name: '@vitest/*'
+      # comunica 5.2.x has a server-side regression that hangs on CONSTRUCT queries
+      # with multiple OPTIONAL clauses (used by ldkit in dataset-registry-client tests).
+      # Re-evaluate when 5.3 lands or comunica/comunica#new-issue is resolved.
+      - dependency-name: '@comunica/*'
+        versions: ['>=5.2.0 <5.3.0']


### PR DESCRIPTION
@comunica/query-sparql-file 5.2.x introduces a server-side regression where complex CONSTRUCT queries with multiple OPTIONAL clauses hang indefinitely. This affects @lde/dataset-registry-client integration tests, which spin up a comunica server and query it via ldkit.

The hang is reproducible by curling the ldkit-generated CONSTRUCT directly against comunica-sparql-file-http 5.2.x — request never returns. The same query returns within milliseconds against 5.1.3. Investigated all of 5.2.0, 5.2.1, 5.2.2; all hang.

Ignoring the 5.2.x range until a fix lands upstream (likely a regression introduced by one of: DistinctTerms optimizer, property-paths optimizer, or the filter-pushdown changes in 5.2). Closing #379 in tandem.