### PR TITLE
feat(pipeline-shacl-sampler): treat http and https schema.org as equivalent via namespaceAliases

### DIFF
--- a/packages/dataset-registry-client/tsconfig.lib.json
+++ b/packages/dataset-registry-client/tsconfig.lib.json
@@ -10,9 +10,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../local-sparql-endpoint/tsconfig.lib.json"
-    },
-    {
       "path": "../dataset/tsconfig.lib.json"
     }
   ],

--- a/packages/pipeline-shacl-sampler/README.md
+++ b/packages/pipeline-shacl-sampler/README.md
@@ -46,14 +46,15 @@ await new Pipeline({ /* … */, stages }).run();
 | `maxConcurrency`  | `10`              | Maximum concurrent in-flight executor batches per stage.                                                               |
 | `validator`       | —                 | Optional [`Validator`](../pipeline/src/validator.ts) attached to every generated stage (typically a `ShaclValidator`). |
 | `onInvalid`       | `'write'`         | Behaviour when a sampled batch fails validation: `'write'` \| `'skip'` \| `'halt'`. Only used when `validator` is set. |
-| `namespaceAliases`| `[{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }]` | Namespaces to treat as equivalent when matching `sh:targetClass` and when handing quads to the validator. See [Namespace aliases](#namespace-aliases). Pass `[]` to disable. |
+| `namespaceAliases`| `[]`              | Namespaces to treat as equivalent when matching `sh:targetClass` and when handing quads to the validator. See [Namespace aliases](#namespace-aliases). |
 
 ## Namespace aliases
 
-Schema.org publishes the same vocabulary at both `http://schema.org/` and
-`https://schema.org/`. SHACL shapes can only declare one as the
+Some vocabularies publish the same terms under multiple namespaces — most
+notably schema.org, which is reachable at both `http://schema.org/` and
+`https://schema.org/`. SHACL shapes can only declare one of those as the
 `sh:targetClass` namespace, so without help the sampler would silently
-skip resources typed under the other form — and the validator would
+skip resources typed under the other form, and the validator would
 report vacuously-conformant runs against datasets that mix the two.
 
 `namespaceAliases` closes the gap. For every declared pair the sampler:
@@ -66,8 +67,8 @@ report vacuously-conformant runs against datasets that mix the two.
   engine sees it, allowing the canonical-namespace
   `sh:targetClass` / `sh:path` patterns to match.
 
-The default covers the only known case in practice. To support another
-dual-namespace vocabulary:
+Defaults to no aliases. To cover schema.org datasets that publish under
+both HTTP and HTTPS:
 
 ```ts
 const stages = await shaclSampleStages({
@@ -75,7 +76,6 @@ const stages = await shaclSampleStages({
   validator,
   namespaceAliases: [
     { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
-    { canonical: 'https://example.org/v2/', alias: 'https://example.org/v1/' },
   ],
 });
 ```

--- a/packages/pipeline-shacl-sampler/README.md
+++ b/packages/pipeline-shacl-sampler/README.md
@@ -46,6 +46,39 @@ await new Pipeline({ /* … */, stages }).run();
 | `maxConcurrency`  | `10`              | Maximum concurrent in-flight executor batches per stage.                                                               |
 | `validator`       | —                 | Optional [`Validator`](../pipeline/src/validator.ts) attached to every generated stage (typically a `ShaclValidator`). |
 | `onInvalid`       | `'write'`         | Behaviour when a sampled batch fails validation: `'write'` \| `'skip'` \| `'halt'`. Only used when `validator` is set. |
+| `namespaceAliases`| `[{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }]` | Namespaces to treat as equivalent when matching `sh:targetClass` and when handing quads to the validator. See [Namespace aliases](#namespace-aliases). Pass `[]` to disable. |
+
+## Namespace aliases
+
+Schema.org publishes the same vocabulary at both `http://schema.org/` and
+`https://schema.org/`. SHACL shapes can only declare one as the
+`sh:targetClass` namespace, so without help the sampler would silently
+skip resources typed under the other form — and the validator would
+report vacuously-conformant runs against datasets that mix the two.
+
+`namespaceAliases` closes the gap. For every declared pair the sampler:
+
+- broadens its subject-selection SELECT to `?s a ?type . FILTER(?type IN
+  (<canonical/X>, <alias/X>))`, so instances typed under either
+  namespace are picked up;
+- decorates the configured `validator` so any alias-namespace IRI in
+  the sampled quads is rewritten to the canonical form before the SHACL
+  engine sees it, allowing the canonical-namespace
+  `sh:targetClass` / `sh:path` patterns to match.
+
+The default covers the only known case in practice. To support another
+dual-namespace vocabulary:
+
+```ts
+const stages = await shaclSampleStages({
+  shapesFile,
+  validator,
+  namespaceAliases: [
+    { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+    { canonical: 'https://example.org/v2/', alias: 'https://example.org/v1/' },
+  ],
+});
+```
 
 ## Limitations
 

--- a/packages/pipeline-shacl-sampler/src/index.ts
+++ b/packages/pipeline-shacl-sampler/src/index.ts
@@ -4,4 +4,5 @@ export {
   wrapValidatorWithAliasNormalization,
   type NamespaceAlias,
   type ShaclSampleStagesOptions,
+  type SubjectSelectorQueryOptions,
 } from './sampleStages.js';

--- a/packages/pipeline-shacl-sampler/src/index.ts
+++ b/packages/pipeline-shacl-sampler/src/index.ts
@@ -1,5 +1,7 @@
 export { extractTargetShapes, type TargetShape } from './pathExtractor.js';
 export {
   shaclSampleStages,
+  wrapValidatorWithAliasNormalization,
+  type NamespaceAlias,
   type ShaclSampleStagesOptions,
 } from './sampleStages.js';

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -218,10 +218,12 @@ function expandTargetClass(
 ): string[] {
   const iri = targetClass.value;
   for (const { canonical, alias } of namespaceAliases) {
-    const match =
-      (iri.startsWith(canonical) && { from: canonical, to: alias }) ||
-      (iri.startsWith(alias) && { from: alias, to: canonical });
-    if (match) return [iri, match.to + iri.slice(match.from.length)];
+    if (iri.startsWith(canonical)) {
+      return [iri, alias + iri.slice(canonical.length)];
+    }
+    if (iri.startsWith(alias)) {
+      return [iri, canonical + iri.slice(alias.length)];
+    }
   }
   return [iri];
 }

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -41,10 +41,6 @@ export interface NamespaceAlias {
   alias: string;
 }
 
-const DEFAULT_NAMESPACE_ALIASES: NamespaceAlias[] = [
-  { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
-];
-
 /** Options for {@link shaclSampleStages}. */
 export interface ShaclSampleStagesOptions {
   /** URL or local path to the SHACL shapes file. */
@@ -83,10 +79,15 @@ export interface ShaclSampleStagesOptions {
   onInvalid?: OnInvalid;
   /**
    * Namespace pairs to treat as equivalent when matching `sh:targetClass`
-   * and when handing quads to the validator. Defaults to a single entry
-   * that treats `http://schema.org/` as an alias of `https://schema.org/`
-   * — the only known case in practice where a single SHACL shape needs to
-   * cover both forms. Pass an empty array to disable.
+   * and when handing quads to the validator. For each pair, the sampler
+   * broadens its subject-selection SELECT so resources typed under either
+   * namespace are picked up, and wraps the configured {@link validator}
+   * so alias-namespace IRIs in the sampled quads are rewritten to the
+   * canonical form before SHACL evaluates them.
+   *
+   * Defaults to no aliases. To cover schema.org datasets that publish
+   * under both `http://schema.org/` and `https://schema.org/`, pass
+   * `[{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }]`.
    */
   namespaceAliases?: NamespaceAlias[];
 }
@@ -113,8 +114,7 @@ export async function shaclSampleStages(
   const timeout = options.timeout ?? 60_000;
   const batchSize = options.batchSize ?? samplesPerClass;
   const maxConcurrency = options.maxConcurrency;
-  const namespaceAliases =
-    options.namespaceAliases ?? DEFAULT_NAMESPACE_ALIASES;
+  const namespaceAliases = options.namespaceAliases ?? [];
   const validation = options.validator
     ? {
         validator: wrapValidatorWithAliasNormalization(
@@ -172,7 +172,7 @@ export function buildSubjectSelectorQuery(
   targetClass: NamedNode,
   subjectFilter?: string,
   namedGraph?: string,
-  namespaceAliases: NamespaceAlias[] = DEFAULT_NAMESPACE_ALIASES,
+  namespaceAliases: NamespaceAlias[] = [],
 ): string {
   let fromClause = '';
   if (namedGraph) {

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -154,12 +154,12 @@ function subjectSelector(
   assertSafeIri(targetClass.value);
   return {
     select(distribution, batchSize) {
-      const query = buildSubjectSelectorQuery(
+      const query = buildSubjectSelectorQuery({
         targetClass,
-        distribution.subjectFilter,
-        distribution.namedGraph,
+        subjectFilter: distribution.subjectFilter,
+        namedGraph: distribution.namedGraph,
         namespaceAliases,
-      );
+      });
       return new SparqlItemSelector({
         query,
         maxResults: limit,
@@ -168,12 +168,24 @@ function subjectSelector(
   };
 }
 
-export function buildSubjectSelectorQuery(
-  targetClass: NamedNode,
-  subjectFilter?: string,
-  namedGraph?: string,
-  namespaceAliases: NamespaceAlias[] = [],
-): string {
+/** Options for {@link buildSubjectSelectorQuery}. */
+export interface SubjectSelectorQueryOptions {
+  /** SHACL `sh:targetClass` to match. */
+  targetClass: NamedNode;
+  /** Optional extra triple pattern restricting subjects (interpolated verbatim). */
+  subjectFilter?: string;
+  /** Restrict to a single named graph via `FROM <…>`. */
+  namedGraph?: string;
+  /** Equivalent namespaces to broaden the type match across. @default [] */
+  namespaceAliases?: NamespaceAlias[];
+}
+
+export function buildSubjectSelectorQuery({
+  targetClass,
+  subjectFilter,
+  namedGraph,
+  namespaceAliases = [],
+}: SubjectSelectorQueryOptions): string {
   let fromClause = '';
   if (namedGraph) {
     assertSafeIri(namedGraph);
@@ -206,12 +218,10 @@ function expandTargetClass(
 ): string[] {
   const iri = targetClass.value;
   for (const { canonical, alias } of namespaceAliases) {
-    if (iri.startsWith(canonical)) {
-      return [iri, alias + iri.slice(canonical.length)];
-    }
-    if (iri.startsWith(alias)) {
-      return [iri, canonical + iri.slice(alias.length)];
-    }
+    const match =
+      (iri.startsWith(canonical) && { from: canonical, to: alias }) ||
+      (iri.startsWith(alias) && { from: alias, to: canonical });
+    if (match) return [iri, match.to + iri.slice(match.from.length)];
   }
   return [iri];
 }
@@ -282,12 +292,7 @@ function normalizeQuad(q: Quad, namespaceAliases: NamespaceAlias[]): Quad {
   ) {
     return q;
   }
-  return quad(
-    subject as Quad['subject'],
-    predicate as Quad['predicate'],
-    object as Quad['object'],
-    graph as Quad['graph'],
-  );
+  return quad(subject, predicate, object, graph);
 }
 
 function rewriteIfAlias(

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -4,13 +4,46 @@ import {
   SparqlItemSelector,
   type ItemSelector,
   type StageOptions,
+  type ValidationReport,
+  type ValidationResult,
   type Validator,
 } from '@lde/pipeline';
-import { assertSafeIri } from '@lde/dataset';
-import type { NamedNode } from '@rdfjs/types';
+import { assertSafeIri, type Dataset } from '@lde/dataset';
+import type { NamedNode, Quad } from '@rdfjs/types';
+import { DataFactory } from 'n3';
 import { extractTargetShapes, type TargetShape } from './pathExtractor.js';
 
+const { namedNode, quad } = DataFactory;
+
 type OnInvalid = NonNullable<StageOptions['validation']>['onInvalid'];
+
+/**
+ * Declares that two namespaces should be treated as equivalent when
+ * sampling and validating, working around vocabularies that publish under
+ * both HTTP and HTTPS variants of the same IRI (notably schema.org).
+ *
+ * The sampler accepts subjects typed under the {@link alias} namespace in
+ * addition to the SHACL `sh:targetClass` IRI under {@link canonical}, and
+ * rewrites alias-namespace IRIs to canonical ones in the sampled quads
+ * before validation so SHACL `sh:targetClass` and `sh:path` patterns
+ * match.
+ */
+export interface NamespaceAlias {
+  /**
+   * The namespace declared in the SHACL shapes file (e.g.
+   * `https://schema.org/`).
+   */
+  canonical: string;
+  /**
+   * The equivalent namespace that may appear in source data (e.g.
+   * `http://schema.org/`).
+   */
+  alias: string;
+}
+
+const DEFAULT_NAMESPACE_ALIASES: NamespaceAlias[] = [
+  { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+];
 
 /** Options for {@link shaclSampleStages}. */
 export interface ShaclSampleStagesOptions {
@@ -48,6 +81,14 @@ export interface ShaclSampleStagesOptions {
    * @default 'write'
    */
   onInvalid?: OnInvalid;
+  /**
+   * Namespace pairs to treat as equivalent when matching `sh:targetClass`
+   * and when handing quads to the validator. Defaults to a single entry
+   * that treats `http://schema.org/` as an alias of `https://schema.org/`
+   * — the only known case in practice where a single SHACL shape needs to
+   * cover both forms. Pass an empty array to disable.
+   */
+  namespaceAliases?: NamespaceAlias[];
 }
 
 /**
@@ -72,8 +113,16 @@ export async function shaclSampleStages(
   const timeout = options.timeout ?? 60_000;
   const batchSize = options.batchSize ?? samplesPerClass;
   const maxConcurrency = options.maxConcurrency;
+  const namespaceAliases =
+    options.namespaceAliases ?? DEFAULT_NAMESPACE_ALIASES;
   const validation = options.validator
-    ? { validator: options.validator, onInvalid: options.onInvalid ?? 'write' }
+    ? {
+        validator: wrapValidatorWithAliasNormalization(
+          options.validator,
+          namespaceAliases,
+        ),
+        onInvalid: options.onInvalid ?? 'write',
+      }
     : undefined;
   const shapes = await extractTargetShapes(options.shapesFile);
 
@@ -81,7 +130,11 @@ export async function shaclSampleStages(
     (shape) =>
       new Stage({
         name: `shacl-sample-${localName(shape.targetClass.value)}`,
-        itemSelector: subjectSelector(shape.targetClass, samplesPerClass),
+        itemSelector: subjectSelector(
+          shape.targetClass,
+          samplesPerClass,
+          namespaceAliases,
+        ),
         executors: new SparqlConstructExecutor({
           query: buildSampleQuery(shape),
           timeout,
@@ -93,7 +146,11 @@ export async function shaclSampleStages(
   );
 }
 
-function subjectSelector(targetClass: NamedNode, limit: number): ItemSelector {
+function subjectSelector(
+  targetClass: NamedNode,
+  limit: number,
+  namespaceAliases: NamespaceAlias[],
+): ItemSelector {
   assertSafeIri(targetClass.value);
   return {
     select(distribution, batchSize) {
@@ -101,6 +158,7 @@ function subjectSelector(targetClass: NamedNode, limit: number): ItemSelector {
         targetClass,
         distribution.subjectFilter,
         distribution.namedGraph,
+        namespaceAliases,
       );
       return new SparqlItemSelector({
         query,
@@ -114,17 +172,48 @@ export function buildSubjectSelectorQuery(
   targetClass: NamedNode,
   subjectFilter?: string,
   namedGraph?: string,
+  namespaceAliases: NamespaceAlias[] = DEFAULT_NAMESPACE_ALIASES,
 ): string {
   let fromClause = '';
   if (namedGraph) {
     assertSafeIri(namedGraph);
     fromClause = `FROM <${namedGraph}>`;
   }
+  const typePattern = buildTypePattern(targetClass, namespaceAliases);
   return [
     'SELECT DISTINCT ?s',
     fromClause,
-    `WHERE { ${subjectFilter ?? ''} ?s a <${targetClass.value}> . }`,
+    `WHERE { ${subjectFilter ?? ''} ${typePattern} }`,
   ].join('\n');
+}
+
+function buildTypePattern(
+  targetClass: NamedNode,
+  namespaceAliases: NamespaceAlias[],
+): string {
+  const equivalents = expandTargetClass(targetClass, namespaceAliases);
+  for (const iri of equivalents) assertSafeIri(iri);
+  if (equivalents.length === 1) {
+    return `?s a <${equivalents[0]}> .`;
+  }
+  const iriList = equivalents.map((iri) => `<${iri}>`).join(', ');
+  return `?s a ?type . FILTER(?type IN (${iriList}))`;
+}
+
+function expandTargetClass(
+  targetClass: NamedNode,
+  namespaceAliases: NamespaceAlias[],
+): string[] {
+  const iri = targetClass.value;
+  for (const { canonical, alias } of namespaceAliases) {
+    if (iri.startsWith(canonical)) {
+      return [iri, alias + iri.slice(canonical.length)];
+    }
+    if (iri.startsWith(alias)) {
+      return [iri, canonical + iri.slice(alias.length)];
+    }
+  }
+  return [iri];
 }
 
 export function buildSampleQuery(shape: TargetShape): string {
@@ -150,6 +239,68 @@ WHERE {
     ?s ?p ?o .
   }${chainBranches}
 }`;
+}
+
+/**
+ * Decorate a {@link Validator} so every quad it receives has any IRI in an
+ * alias namespace rewritten to the corresponding canonical namespace.
+ * Without this, SHACL shapes declared under the canonical namespace would
+ * silently skip resources whose types and predicates use the alias form,
+ * producing vacuously-conformant reports.
+ */
+export function wrapValidatorWithAliasNormalization(
+  inner: Validator,
+  namespaceAliases: NamespaceAlias[],
+): Validator {
+  if (namespaceAliases.length === 0) {
+    return inner;
+  }
+  return {
+    validate(quads: Quad[], dataset: Dataset): Promise<ValidationResult> {
+      return inner.validate(
+        quads.map((q) => normalizeQuad(q, namespaceAliases)),
+        dataset,
+      );
+    },
+    report(dataset: Dataset): Promise<ValidationReport> {
+      return inner.report(dataset);
+    },
+  };
+}
+
+function normalizeQuad(q: Quad, namespaceAliases: NamespaceAlias[]): Quad {
+  const subject = rewriteIfAlias(q.subject, namespaceAliases) ?? q.subject;
+  const predicate =
+    rewriteIfAlias(q.predicate, namespaceAliases) ?? q.predicate;
+  const object = rewriteIfAlias(q.object, namespaceAliases) ?? q.object;
+  const graph = rewriteIfAlias(q.graph, namespaceAliases) ?? q.graph;
+  if (
+    subject === q.subject &&
+    predicate === q.predicate &&
+    object === q.object &&
+    graph === q.graph
+  ) {
+    return q;
+  }
+  return quad(
+    subject as Quad['subject'],
+    predicate as Quad['predicate'],
+    object as Quad['object'],
+    graph as Quad['graph'],
+  );
+}
+
+function rewriteIfAlias(
+  term: Quad['subject' | 'predicate' | 'object' | 'graph'],
+  namespaceAliases: NamespaceAlias[],
+): NamedNode | undefined {
+  if (term.termType !== 'NamedNode') return undefined;
+  for (const { canonical, alias } of namespaceAliases) {
+    if (term.value.startsWith(alias)) {
+      return namedNode(canonical + term.value.slice(alias.length));
+    }
+  }
+  return undefined;
 }
 
 function localName(iri: string): string {

--- a/packages/pipeline-shacl-sampler/test/sampleStages.test.ts
+++ b/packages/pipeline-shacl-sampler/test/sampleStages.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
 import { DataFactory } from 'n3';
+import type { Quad } from '@rdfjs/types';
+import type { Dataset } from '@lde/dataset';
+import type { Validator } from '@lde/pipeline';
 import {
   buildSampleQuery,
   buildSubjectSelectorQuery,
   shaclSampleStages,
+  wrapValidatorWithAliasNormalization,
 } from '../src/sampleStages.js';
 import type { TargetShape } from '../src/pathExtractor.js';
 
-const { namedNode } = DataFactory;
+const { namedNode, quad, literal, defaultGraph } = DataFactory;
 const shapesFile = join(__dirname, 'fixtures', 'schema-profile.ttl');
 
 describe('buildSampleQuery', () => {
@@ -51,7 +55,42 @@ describe('buildSubjectSelectorQuery', () => {
     const query = buildSubjectSelectorQuery(targetClass);
     expect(query).toMatch(/SELECT DISTINCT \?s/);
     expect(query).not.toMatch(/\bLIMIT\b/);
-    expect(query).toContain('?s a <https://schema.org/CreativeWork>');
+  });
+
+  it('matches both HTTPS and HTTP schema.org via FILTER IN when the default alias applies', () => {
+    const query = buildSubjectSelectorQuery(targetClass);
+    expect(query).toContain('?s a ?type');
+    expect(query).toContain(
+      'FILTER(?type IN (<https://schema.org/CreativeWork>, <http://schema.org/CreativeWork>))',
+    );
+  });
+
+  it('emits the plain bound type pattern when no alias namespace matches the target class', () => {
+    const query = buildSubjectSelectorQuery(
+      namedNode('https://example.org/vocab/Widget'),
+    );
+    expect(query).toContain('?s a <https://example.org/vocab/Widget> .');
+    expect(query).not.toMatch(/FILTER\(\?type IN/);
+  });
+
+  it('also broadens when the target class IRI itself uses the alias namespace', () => {
+    const query = buildSubjectSelectorQuery(
+      namedNode('http://schema.org/CreativeWork'),
+    );
+    expect(query).toContain(
+      'FILTER(?type IN (<http://schema.org/CreativeWork>, <https://schema.org/CreativeWork>))',
+    );
+  });
+
+  it('emits the plain bound type pattern when namespace aliases are disabled', () => {
+    const query = buildSubjectSelectorQuery(
+      targetClass,
+      undefined,
+      undefined,
+      [],
+    );
+    expect(query).toContain('?s a <https://schema.org/CreativeWork> .');
+    expect(query).not.toMatch(/FILTER\(\?type IN/);
   });
 
   it('inlines a subjectFilter when provided', () => {
@@ -69,6 +108,95 @@ describe('buildSubjectSelectorQuery', () => {
       'https://example.org/graph',
     );
     expect(query).toContain('FROM <https://example.org/graph>');
+  });
+});
+
+describe('wrapValidatorWithAliasNormalization', () => {
+  const aliases = [
+    { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+  ];
+
+  function captureValidator(): {
+    validator: Validator;
+    seen: Quad[][];
+  } {
+    const seen: Quad[][] = [];
+    const validator: Validator = {
+      async validate(quads) {
+        seen.push(quads);
+        return { conforms: true, violations: 0 };
+      },
+      async report() {
+        return { conforms: true, violations: 0, quadsValidated: 0 };
+      },
+    };
+    return { validator, seen };
+  }
+
+  it('rewrites alias-namespace IRIs in subject, predicate, and object positions', async () => {
+    const { validator, seen } = captureValidator();
+    const wrapped = wrapValidatorWithAliasNormalization(validator, aliases);
+    const input = [
+      quad(
+        namedNode('https://example.org/work/1'),
+        namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        namedNode('http://schema.org/CreativeWork'),
+        defaultGraph(),
+      ),
+      quad(
+        namedNode('https://example.org/work/1'),
+        namedNode('http://schema.org/creator'),
+        namedNode('http://schema.org/Person/some-id'),
+        defaultGraph(),
+      ),
+    ];
+    await wrapped.validate(input, {} as Dataset);
+    expect(seen).toHaveLength(1);
+    const handed = seen[0] ?? [];
+    expect(handed.map((q) => q.predicate.value)).toEqual([
+      'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+      'https://schema.org/creator',
+    ]);
+    expect(handed.map((q) => q.object.value)).toEqual([
+      'https://schema.org/CreativeWork',
+      'https://schema.org/Person/some-id',
+    ]);
+  });
+
+  it('leaves quads that contain no alias IRI unchanged (same reference)', async () => {
+    const { validator, seen } = captureValidator();
+    const wrapped = wrapValidatorWithAliasNormalization(validator, aliases);
+    const untouched = quad(
+      namedNode('https://example.org/work/1'),
+      namedNode('https://schema.org/name'),
+      literal('Untouched'),
+      defaultGraph(),
+    );
+    await wrapped.validate([untouched], {} as Dataset);
+    expect(seen[0]?.[0]).toBe(untouched);
+  });
+
+  it('returns the inner validator unchanged when there are no aliases', () => {
+    const { validator } = captureValidator();
+    expect(wrapValidatorWithAliasNormalization(validator, [])).toBe(validator);
+  });
+
+  it('delegates report() straight through to the inner validator', async () => {
+    const reports: Dataset[] = [];
+    const inner: Validator = {
+      async validate() {
+        return { conforms: true, violations: 0 };
+      },
+      async report(dataset) {
+        reports.push(dataset);
+        return { conforms: true, violations: 7, quadsValidated: 42 };
+      },
+    };
+    const wrapped = wrapValidatorWithAliasNormalization(inner, aliases);
+    const dataset = { iri: 'urn:test' } as unknown as Dataset;
+    const result = await wrapped.report(dataset);
+    expect(reports[0]).toBe(dataset);
+    expect(result).toMatchObject({ violations: 7, quadsValidated: 42 });
   });
 });
 
@@ -91,18 +219,54 @@ describe('shaclSampleStages', () => {
     }
   });
 
-  it('attaches the provided validator to every stage', async () => {
-    const validator = {
-      validate: async () => ({ conforms: true, violations: 0 }),
-      report: async () => ({
-        conforms: true,
-        violations: 0,
-        quadsValidated: 0,
-      }),
+  it('wraps the provided validator so alias IRIs are rewritten before delegation', async () => {
+    const seen: Quad[][] = [];
+    const inner: Validator = {
+      async validate(quads) {
+        seen.push(quads);
+        return { conforms: true, violations: 0 };
+      },
+      async report() {
+        return { conforms: true, violations: 0, quadsValidated: 0 };
+      },
     };
-    const stages = await shaclSampleStages({ shapesFile, validator });
+    const [firstStage] = await shaclSampleStages({
+      shapesFile,
+      validator: inner,
+    });
+    const wrapped = firstStage?.validator;
+    expect(wrapped).toBeDefined();
+    expect(wrapped).not.toBe(inner);
+    await wrapped?.validate(
+      [
+        quad(
+          namedNode('https://example.org/work/1'),
+          namedNode('http://schema.org/creator'),
+          namedNode('https://example.org/person/2'),
+          defaultGraph(),
+        ),
+      ],
+      {} as Dataset,
+    );
+    expect(seen[0]?.[0]?.predicate.value).toBe('https://schema.org/creator');
+  });
+
+  it('keeps the validator unchanged when namespaceAliases is empty', async () => {
+    const inner: Validator = {
+      async validate() {
+        return { conforms: true, violations: 0 };
+      },
+      async report() {
+        return { conforms: true, violations: 0, quadsValidated: 0 };
+      },
+    };
+    const stages = await shaclSampleStages({
+      shapesFile,
+      validator: inner,
+      namespaceAliases: [],
+    });
     for (const stage of stages) {
-      expect(stage.validator).toBe(validator);
+      expect(stage.validator).toBe(inner);
     }
   });
 });

--- a/packages/pipeline-shacl-sampler/test/sampleStages.test.ts
+++ b/packages/pipeline-shacl-sampler/test/sampleStages.test.ts
@@ -50,26 +50,28 @@ describe('buildSampleQuery', () => {
 
 describe('buildSubjectSelectorQuery', () => {
   const targetClass = namedNode('https://schema.org/CreativeWork');
+  const schemaOrgAlias = {
+    canonical: 'https://schema.org/',
+    alias: 'http://schema.org/',
+  };
 
   it('produces a SELECT DISTINCT ?s without LIMIT (cap is applied by SparqlItemSelector.maxResults)', () => {
-    const query = buildSubjectSelectorQuery(targetClass);
+    const query = buildSubjectSelectorQuery({ targetClass });
     expect(query).toMatch(/SELECT DISTINCT \?s/);
     expect(query).not.toMatch(/\bLIMIT\b/);
   });
 
   it('emits the plain bound type pattern by default (no namespace aliases)', () => {
-    const query = buildSubjectSelectorQuery(targetClass);
+    const query = buildSubjectSelectorQuery({ targetClass });
     expect(query).toContain('?s a <https://schema.org/CreativeWork> .');
     expect(query).not.toMatch(/FILTER\(\?type IN/);
   });
 
   it('broadens to FILTER IN when a configured alias namespace matches the canonical target class IRI', () => {
-    const query = buildSubjectSelectorQuery(
+    const query = buildSubjectSelectorQuery({
       targetClass,
-      undefined,
-      undefined,
-      [{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }],
-    );
+      namespaceAliases: [schemaOrgAlias],
+    });
     expect(query).toContain('?s a ?type');
     expect(query).toContain(
       'FILTER(?type IN (<https://schema.org/CreativeWork>, <http://schema.org/CreativeWork>))',
@@ -77,42 +79,37 @@ describe('buildSubjectSelectorQuery', () => {
   });
 
   it('also broadens when the target class IRI itself uses the alias namespace', () => {
-    const query = buildSubjectSelectorQuery(
-      namedNode('http://schema.org/CreativeWork'),
-      undefined,
-      undefined,
-      [{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }],
-    );
+    const query = buildSubjectSelectorQuery({
+      targetClass: namedNode('http://schema.org/CreativeWork'),
+      namespaceAliases: [schemaOrgAlias],
+    });
     expect(query).toContain(
       'FILTER(?type IN (<http://schema.org/CreativeWork>, <https://schema.org/CreativeWork>))',
     );
   });
 
   it('leaves a target class outside every configured alias namespace as a plain bound pattern', () => {
-    const query = buildSubjectSelectorQuery(
-      namedNode('https://example.org/vocab/Widget'),
-      undefined,
-      undefined,
-      [{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }],
-    );
+    const query = buildSubjectSelectorQuery({
+      targetClass: namedNode('https://example.org/vocab/Widget'),
+      namespaceAliases: [schemaOrgAlias],
+    });
     expect(query).toContain('?s a <https://example.org/vocab/Widget> .');
     expect(query).not.toMatch(/FILTER\(\?type IN/);
   });
 
   it('inlines a subjectFilter when provided', () => {
-    const query = buildSubjectSelectorQuery(
+    const query = buildSubjectSelectorQuery({
       targetClass,
-      '?s <https://example.org/inDataset> <urn:d> .',
-    );
+      subjectFilter: '?s <https://example.org/inDataset> <urn:d> .',
+    });
     expect(query).toContain('?s <https://example.org/inDataset> <urn:d> .');
   });
 
   it('emits a FROM clause when the distribution has a named graph', () => {
-    const query = buildSubjectSelectorQuery(
+    const query = buildSubjectSelectorQuery({
       targetClass,
-      undefined,
-      'https://example.org/graph',
-    );
+      namedGraph: 'https://example.org/graph',
+    });
     expect(query).toContain('FROM <https://example.org/graph>');
   });
 });

--- a/packages/pipeline-shacl-sampler/test/sampleStages.test.ts
+++ b/packages/pipeline-shacl-sampler/test/sampleStages.test.ts
@@ -57,39 +57,45 @@ describe('buildSubjectSelectorQuery', () => {
     expect(query).not.toMatch(/\bLIMIT\b/);
   });
 
-  it('matches both HTTPS and HTTP schema.org via FILTER IN when the default alias applies', () => {
+  it('emits the plain bound type pattern by default (no namespace aliases)', () => {
     const query = buildSubjectSelectorQuery(targetClass);
+    expect(query).toContain('?s a <https://schema.org/CreativeWork> .');
+    expect(query).not.toMatch(/FILTER\(\?type IN/);
+  });
+
+  it('broadens to FILTER IN when a configured alias namespace matches the canonical target class IRI', () => {
+    const query = buildSubjectSelectorQuery(
+      targetClass,
+      undefined,
+      undefined,
+      [{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }],
+    );
     expect(query).toContain('?s a ?type');
     expect(query).toContain(
       'FILTER(?type IN (<https://schema.org/CreativeWork>, <http://schema.org/CreativeWork>))',
     );
   });
 
-  it('emits the plain bound type pattern when no alias namespace matches the target class', () => {
-    const query = buildSubjectSelectorQuery(
-      namedNode('https://example.org/vocab/Widget'),
-    );
-    expect(query).toContain('?s a <https://example.org/vocab/Widget> .');
-    expect(query).not.toMatch(/FILTER\(\?type IN/);
-  });
-
   it('also broadens when the target class IRI itself uses the alias namespace', () => {
     const query = buildSubjectSelectorQuery(
       namedNode('http://schema.org/CreativeWork'),
+      undefined,
+      undefined,
+      [{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }],
     );
     expect(query).toContain(
       'FILTER(?type IN (<http://schema.org/CreativeWork>, <https://schema.org/CreativeWork>))',
     );
   });
 
-  it('emits the plain bound type pattern when namespace aliases are disabled', () => {
+  it('leaves a target class outside every configured alias namespace as a plain bound pattern', () => {
     const query = buildSubjectSelectorQuery(
-      targetClass,
+      namedNode('https://example.org/vocab/Widget'),
       undefined,
       undefined,
-      [],
+      [{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }],
     );
-    expect(query).toContain('?s a <https://schema.org/CreativeWork> .');
+    expect(query).toContain('?s a <https://example.org/vocab/Widget> .');
     expect(query).not.toMatch(/FILTER\(\?type IN/);
   });
 
@@ -219,7 +225,7 @@ describe('shaclSampleStages', () => {
     }
   });
 
-  it('wraps the provided validator so alias IRIs are rewritten before delegation', async () => {
+  it('wraps the provided validator so configured alias IRIs are rewritten before delegation', async () => {
     const seen: Quad[][] = [];
     const inner: Validator = {
       async validate(quads) {
@@ -233,6 +239,9 @@ describe('shaclSampleStages', () => {
     const [firstStage] = await shaclSampleStages({
       shapesFile,
       validator: inner,
+      namespaceAliases: [
+        { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+      ],
     });
     const wrapped = firstStage?.validator;
     expect(wrapped).toBeDefined();
@@ -251,7 +260,7 @@ describe('shaclSampleStages', () => {
     expect(seen[0]?.[0]?.predicate.value).toBe('https://schema.org/creator');
   });
 
-  it('keeps the validator unchanged when namespaceAliases is empty', async () => {
+  it('passes the validator through unchanged when no namespaceAliases are configured (the default)', async () => {
     const inner: Validator = {
       async validate() {
         return { conforms: true, violations: 0 };
@@ -263,7 +272,6 @@ describe('shaclSampleStages', () => {
     const stages = await shaclSampleStages({
       shapesFile,
       validator: inner,
-      namespaceAliases: [],
     });
     for (const stage of stages) {
       expect(stage.validator).toBe(inner);

--- a/packages/pipeline-shacl-sampler/vite.config.ts
+++ b/packages/pipeline-shacl-sampler/vite.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 96.77,
-          lines: 97.35,
-          branches: 90.12,
-          statements: 95.15,
+          lines: 97.38,
+          branches: 89.87,
+          statements: 95.18,
         },
       },
     },

--- a/packages/pipeline-shacl-sampler/vite.config.ts
+++ b/packages/pipeline-shacl-sampler/vite.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 96.77,
-          lines: 97.4,
+          lines: 97.38,
           branches: 89.87,
-          statements: 95.2,
+          statements: 95.18,
         },
       },
     },

--- a/packages/pipeline-shacl-sampler/vite.config.ts
+++ b/packages/pipeline-shacl-sampler/vite.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 96.77,
-          lines: 97.38,
-          branches: 89.87,
-          statements: 95.18,
+          lines: 97.35,
+          branches: 90.12,
+          statements: 95.15,
         },
       },
     },

--- a/packages/pipeline-shacl-sampler/vite.config.ts
+++ b/packages/pipeline-shacl-sampler/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 95.45,
-          lines: 96.63,
-          branches: 84,
-          statements: 93.79,
+          functions: 96.77,
+          lines: 97.4,
+          branches: 89.87,
+          statements: 95.2,
         },
       },
     },

--- a/packages/pipeline/tsconfig.lib.json
+++ b/packages/pipeline/tsconfig.lib.json
@@ -10,9 +10,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../local-sparql-endpoint/tsconfig.lib.json"
-    },
-    {
       "path": "../sparql-server/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
## Summary

Add a `namespaceAliases` option to `shaclSampleStages` for vocabularies that publish the same terms under multiple namespaces — most notably schema.org (`http://schema.org/` vs `https://schema.org/`). SHACL shapes can only declare one namespace as `sh:targetClass`, so the sampler previously skipped every resource typed under the other form and the validator reported vacuously-conformant results. Observed on the ldmax.nl WO2 collecties dataset: 125k+ `schema:CreativeWork` instances typed under HTTP, validator emitted zero violations against the canonical-HTTPS SCHEMA-AP-NDE shapes.

For every declared `{ canonical, alias }` pair the sampler:

- broadens the subject-selection SELECT to `?s a ?type . FILTER(?type IN (<canonical/T>, <alias/T>))` so instances typed under either namespace are picked up;
- wraps the configured `validator` so alias-namespace IRIs in the sampled buffer (subject, predicate, object, graph) are rewritten to the canonical form before SHACL evaluates them, allowing canonical-namespace `sh:targetClass` / `sh:path` patterns to match. Quads with no alias IRI pass through by reference (no copy).

Defaults to `[]` — sampler stays vocabulary-neutral; callers opt in explicitly. README documents the schema.org example.

## Other changes

`packages/dataset-registry-client/tsconfig.lib.json` and `packages/pipeline/tsconfig.lib.json` lose a stale reference to `local-sparql-endpoint` — collateral from running `nx sync` to typecheck the worktree.
