### PR TITLE
feat(pipeline-shacl-validator)!: composable reportWriters in place of reportDir

### DIFF
--- a/packages/dataset-registry-client/tsconfig.lib.json
+++ b/packages/dataset-registry-client/tsconfig.lib.json
@@ -10,6 +10,9 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
+      "path": "../local-sparql-endpoint/tsconfig.lib.json"
+    },
+    {
       "path": "../dataset/tsconfig.lib.json"
     }
   ],

--- a/packages/pipeline-shacl-sampler/README.md
+++ b/packages/pipeline-shacl-sampler/README.md
@@ -19,12 +19,15 @@ validate without false-positive ‘missing nested node’ violations.
 ## Usage
 
 ```typescript
-import { Pipeline } from '@lde/pipeline';
+import { Pipeline, FileWriter } from '@lde/pipeline';
 import { shaclSampleStages } from '@lde/pipeline-shacl-sampler';
 import { ShaclValidator } from '@lde/pipeline-shacl-validator';
 
 const shapesFile = 'https://docs.nde.nl/schema-profile/shacl.ttl';
-const validator = new ShaclValidator({ shapesFile, reportDir: './validation' });
+const validator = new ShaclValidator({
+  shapesFile,
+  reportWriters: [new FileWriter({ outputDir: './validation', format: 'turtle' })],
+});
 
 const stages = await shaclSampleStages({
   shapesFile,
@@ -37,16 +40,16 @@ await new Pipeline({ /* … */, stages }).run();
 
 ## Options
 
-| Option            | Default           | Description                                                                                                            |
-| ----------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `shapesFile`      | —                 | URL or local path to the SHACL shapes file. Any format `rdf-dereference` accepts.                                      |
-| `samplesPerClass` | `50`              | Number of top-level resources to sample per `sh:targetClass`.                                                          |
-| `timeout`         | `60000`           | SPARQL query timeout in milliseconds.                                                                                  |
-| `batchSize`       | `samplesPerClass` | Maximum sampled subjects per executor call. Lower values spread work across multiple parallel queries.                 |
-| `maxConcurrency`  | `10`              | Maximum concurrent in-flight executor batches per stage.                                                               |
-| `validator`       | —                 | Optional [`Validator`](../pipeline/src/validator.ts) attached to every generated stage (typically a `ShaclValidator`). |
-| `onInvalid`       | `'write'`         | Behaviour when a sampled batch fails validation: `'write'` \| `'skip'` \| `'halt'`. Only used when `validator` is set. |
-| `namespaceAliases`| `[]`              | Namespaces to treat as equivalent when matching `sh:targetClass` and when handing quads to the validator. See [Namespace aliases](#namespace-aliases). |
+| Option             | Default           | Description                                                                                                                                            |
+| ------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `shapesFile`       | —                 | URL or local path to the SHACL shapes file. Any format `rdf-dereference` accepts.                                                                      |
+| `samplesPerClass`  | `50`              | Number of top-level resources to sample per `sh:targetClass`.                                                                                          |
+| `timeout`          | `60000`           | SPARQL query timeout in milliseconds.                                                                                                                  |
+| `batchSize`        | `samplesPerClass` | Maximum sampled subjects per executor call. Lower values spread work across multiple parallel queries.                                                 |
+| `maxConcurrency`   | `10`              | Maximum concurrent in-flight executor batches per stage.                                                                                               |
+| `validator`        | —                 | Optional [`Validator`](../pipeline/src/validator.ts) attached to every generated stage (typically a `ShaclValidator`).                                 |
+| `onInvalid`        | `'write'`         | Behaviour when a sampled batch fails validation: `'write'` \| `'skip'` \| `'halt'`. Only used when `validator` is set.                                 |
+| `namespaceAliases` | `[]`              | Namespaces to treat as equivalent when matching `sh:targetClass` and when handing quads to the validator. See [Namespace aliases](#namespace-aliases). |
 
 ## Namespace aliases
 
@@ -60,7 +63,7 @@ report vacuously-conformant runs against datasets that mix the two.
 `namespaceAliases` closes the gap. For every declared pair the sampler:
 
 - broadens its subject-selection SELECT to `?s a ?type . FILTER(?type IN
-  (<canonical/X>, <alias/X>))`, so instances typed under either
+(<canonical/X>, <alias/X>))`, so instances typed under either
   namespace are picked up;
 - decorates the configured `validator` so any alias-namespace IRI in
   the sampled quads is rewritten to the canonical form before the SHACL

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -103,7 +103,7 @@ export interface ShaclSampleStagesOptions {
  * Pass a {@link Validator} to attach it to every generated stage:
  *
  * ```ts
- * const validator = new ShaclValidator({ shapesFile, reportDir });
+ * const validator = new ShaclValidator({ shapesFile, reportWriters: [...] });
  * const stages = await shaclSampleStages({ shapesFile, validator });
  * ```
  */

--- a/packages/pipeline-shacl-validator/README.md
+++ b/packages/pipeline-shacl-validator/README.md
@@ -3,18 +3,28 @@
 SHACL validation for [`@lde/pipeline`](../pipeline).
 
 Validates RDF quads produced by pipeline stages against [SHACL shapes](https://www.w3.org/TR/shacl/),
-writing per-dataset report files in SHACL validation report format.
-Shapes can be provided in any RDF serialization (Turtle, JSON-LD, N-Triples etc.).
+streaming the per-dataset SHACL validation report to any number of configured
+[`Writer`](../pipeline/src/writer/writer.ts)s. Shapes can be provided in any
+RDF serialization (Turtle, JSON-LD, N-Triples etc.).
 
 ## Usage
 
 ```typescript
-import { Pipeline, Stage, SparqlConstructExecutor } from '@lde/pipeline';
+import {
+  Pipeline,
+  Stage,
+  SparqlConstructExecutor,
+  FileWriter,
+  SparqlUpdateWriter,
+} from '@lde/pipeline';
 import { ShaclValidator } from '@lde/pipeline-shacl-validator';
 
 const validator = new ShaclValidator({
   shapesFile: './shapes.ttl',
-  reportDir: './validation',
+  reportWriters: [
+    new FileWriter({ outputDir: './validation', format: 'turtle' }),
+    new SparqlUpdateWriter({ endpoint: new URL('http://store/update') }),
+  ],
 });
 
 const pipeline = new Pipeline({
@@ -42,16 +52,19 @@ await pipeline.run();
 | `'skip'`  | Discard invalid quads silently                                   |
 | `'halt'`  | Throw an error, stopping the pipeline                            |
 
-### Report files
+### Report writers
 
-Validation violations are written to `<reportDir>/<dataset-iri>.validation.<ext>`
-as SHACL validation report triples. The output format defaults to Turtle (`.ttl`)
-and can be changed with the `reportFormat` option:
+Each `validate()` call that produces violations fans the SHACL report quads
+(`sh:ValidationResult` triples, etc.) out to every configured `reportWriter`
+via `Writer.write(dataset, quads)`. Each writer's `Writer.flush(dataset)` is
+invoked from `ShaclValidator.report(dataset)` — i.e. once the pipeline
+finishes a dataset.
 
-```typescript
-const validator = new ShaclValidator({
-  shapesFile: './shapes.ttl',
-  reportDir: './validation',
-  reportFormat: 'N-Triples', // 'Turtle' (default) | 'N-Triples' | 'N-Quads'
-});
-```
+Validators with no `reportWriters` only produce aggregate counts
+(`{ conforms, violations, quadsValidated }`); the report quads are discarded.
+
+The bundled `FileWriter` and `SparqlUpdateWriter` already implement the
+`Writer` contract; bring your own for custom destinations. Note that writers
+receive the original `Dataset`, so a `SparqlUpdateWriter` uses `dataset.iri`
+as the named graph by default — wrap or configure your writer if you need
+validation results in a separate graph from the dataset itself.

--- a/packages/pipeline-shacl-validator/README.md
+++ b/packages/pipeline-shacl-validator/README.md
@@ -61,10 +61,36 @@ invoked from `ShaclValidator.report(dataset)` — i.e. once the pipeline
 finishes a dataset.
 
 Validators with no `reportWriters` only produce aggregate counts
-(`{ conforms, violations, quadsValidated }`); the report quads are discarded.
+(`{ conforms, violations, quadsValidated }`); the report quads themselves are
+discarded. This is deliberate — callers who only need pass/fail metrics
+don't have to wire up a sink — but it does mean misconfiguring (passing
+`reportWriters: []` while expecting persistence) silently loses violation
+detail. Configure at least one writer in production pipelines.
 
 The bundled `FileWriter` and `SparqlUpdateWriter` already implement the
-`Writer` contract; bring your own for custom destinations. Note that writers
-receive the original `Dataset`, so a `SparqlUpdateWriter` uses `dataset.iri`
-as the named graph by default — wrap or configure your writer if you need
-validation results in a separate graph from the dataset itself.
+`Writer` contract; bring your own for custom destinations.
+
+#### Filesystem collisions with `FileWriter`
+
+`FileWriter` derives its filename from `dataset.iri` only. If the pipeline's
+main writer and a report writer both target the same `outputDir` with the
+same format, they will collide on the same path and the second open will
+truncate the first. Use a separate `outputDir` for validation reports:
+
+```ts
+new ShaclValidator({
+  shapesFile,
+  reportWriters: [new FileWriter({ outputDir: './output/validation' })],
+});
+```
+
+#### Named graphs with `SparqlUpdateWriter`
+
+`SparqlUpdateWriter` uses `dataset.iri.toString()` as the named graph URI on
+every write, with no per-call override. A report writer that shares the
+endpoint with the pipeline's main writer would land the SHACL report in the
+same graph as the dataset's data — and `CLEAR GRAPH` on first write per
+dataset would erase it. To keep validation results in a separate graph,
+either point the report writer at a different repository/endpoint, or
+implement a small wrapper `Writer` that swaps `dataset.iri` for a derived
+report-graph IRI before delegating.

--- a/packages/pipeline-shacl-validator/package.json
+++ b/packages/pipeline-shacl-validator/package.json
@@ -26,7 +26,6 @@
   ],
   "dependencies": {
     "@rdfjs/types": "^2.0.1",
-    "filenamify-url": "^4.0.0",
     "rdf-dereference": "^5.0.0",
     "rdf-ext": "^2.5.2",
     "shacl-engine": "^1.1.0",

--- a/packages/pipeline-shacl-validator/src/shacl-validator.ts
+++ b/packages/pipeline-shacl-validator/src/shacl-validator.ts
@@ -87,7 +87,14 @@ export class ShaclValidator implements Validator {
       }
     }
 
-    return { conforms, violations };
+    // Surface where to look for the report in halt-mode error messages
+    // (read by @lde/pipeline's Stage.validateBuffer when onInvalid:'halt').
+    const message =
+      violations > 0 && this.reportWriters.length > 0
+        ? `Report sent to ${this.reportWriters.length} writer(s)`
+        : undefined;
+
+    return { conforms, violations, ...(message !== undefined && { message }) };
   }
 
   async report(dataset: Dataset): Promise<ValidationReport> {

--- a/packages/pipeline-shacl-validator/src/shacl-validator.ts
+++ b/packages/pipeline-shacl-validator/src/shacl-validator.ts
@@ -1,5 +1,3 @@
-import { mkdir, appendFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import type { Quad } from '@rdfjs/types';
 import type { Dataset } from '@lde/dataset';
 
@@ -7,30 +5,28 @@ import type {
   Validator,
   ValidationResult,
   ValidationReport,
+  Writer,
 } from '@lde/pipeline';
-import { serializeQuads, type SerializationFormat } from '@lde/pipeline';
 // @ts-expect-error -- shacl-engine has no type declarations.
 import ShaclEngine from 'shacl-engine/Validator.js';
 // @ts-expect-error -- rdf-ext has no type declarations.
 import rdf from 'rdf-ext';
 import { rdfDereferencer } from 'rdf-dereference';
-import filenamifyUrl from 'filenamify-url';
-
-/** File extension per serialization format. */
-const formatExtensions: Record<SerializationFormat, string> = {
-  Turtle: '.ttl',
-  'N-Triples': '.nt',
-  'N-Quads': '.nq',
-};
 
 /** Options for {@link ShaclValidator}. */
 export interface ShaclValidatorOptions {
   /** Path to an RDF file containing SHACL shapes (any format supported by rdf-dereference). */
   shapesFile: string;
-  /** Directory for validation report files. */
-  reportDir: string;
-  /** Serialization format for report files. @default 'Turtle' */
-  reportFormat?: SerializationFormat;
+  /**
+   * Writers that receive the per-dataset SHACL validation report quads. Each
+   * batch with violations is streamed to every writer via {@link Writer.write};
+   * each writer's {@link Writer.flush} is called from {@link ShaclValidator.report}.
+   *
+   * Pass a {@link FileWriter} to mirror the previous on-disk behaviour, a
+   * {@link SparqlUpdateWriter} to land reports in a named graph, or any custom
+   * writer. Validators with no `reportWriters` only produce aggregate counts.
+   */
+  reportWriters?: Writer[];
 }
 
 interface DatasetAccumulator {
@@ -43,22 +39,19 @@ interface DatasetAccumulator {
  * SHACL-based {@link Validator} for `@lde/pipeline`.
  *
  * Validates quads against shapes loaded from an RDF file (any format
- * supported by rdf-dereference) and writes per-dataset report files
- * in SHACL validation report format.
+ * supported by rdf-dereference) and streams the per-dataset SHACL validation
+ * report to any number of configured {@link Writer}s.
  */
 export class ShaclValidator implements Validator {
   private readonly shapesFile: string;
-  private readonly reportDir: string;
-  private readonly reportFormat: SerializationFormat;
+  private readonly reportWriters: Writer[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private shapesDataset: any | undefined;
   private readonly accumulators = new Map<string, DatasetAccumulator>();
-  private readonly initializedFiles = new Set<string>();
 
   constructor(options: ShaclValidatorOptions) {
     this.shapesFile = options.shapesFile;
-    this.reportDir = options.reportDir;
-    this.reportFormat = options.reportFormat ?? 'Turtle';
+    this.reportWriters = options.reportWriters ?? [];
   }
 
   async validate(quads: Quad[], dataset: Dataset): Promise<ValidationResult> {
@@ -72,7 +65,7 @@ export class ShaclValidator implements Validator {
     const validator = new ShaclEngine(shapes, { factory: rdf });
     const report = await validator.validate({ dataset: dataDataset });
 
-    const violations = report.results.length;
+    const violations = report.results.length as number;
     const conforms = report.conforms as boolean;
 
     // Accumulate per dataset.
@@ -87,16 +80,21 @@ export class ShaclValidator implements Validator {
     if (!conforms) acc.conforms = false;
     this.accumulators.set(key, acc);
 
-    // Write violations to report file.
-    if (violations > 0) {
-      const reportFile = await this.writeReportFile(dataset, report);
-      return { conforms, violations, message: `See ${reportFile}` };
+    if (violations > 0 && this.reportWriters.length > 0) {
+      const reportQuads: Quad[] = [...report.dataset];
+      for (const writer of this.reportWriters) {
+        await writer.write(dataset, asyncIterableOf(reportQuads));
+      }
     }
 
     return { conforms, violations };
   }
 
   async report(dataset: Dataset): Promise<ValidationReport> {
+    for (const writer of this.reportWriters) {
+      await writer.flush?.(dataset);
+    }
+
     const key = dataset.iri.toString();
     const acc = this.accumulators.get(key);
     if (!acc) {
@@ -119,31 +117,8 @@ export class ShaclValidator implements Validator {
     }
     return this.shapesDataset;
   }
+}
 
-  private async writeReportFile(
-    dataset: Dataset,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    report: any,
-  ): Promise<string> {
-    await mkdir(this.reportDir, { recursive: true });
-
-    const datasetName = filenamifyUrl(dataset.iri.toString());
-    const extension = formatExtensions[this.reportFormat];
-    const filePath = join(
-      this.reportDir,
-      `${datasetName}.validation${extension}`,
-    );
-
-    const reportQuads: Quad[] = [...report.dataset];
-    const serialized = await serializeQuads(reportQuads, this.reportFormat);
-
-    if (this.initializedFiles.has(filePath)) {
-      await appendFile(filePath, '\n' + serialized);
-    } else {
-      await writeFile(filePath, serialized);
-      this.initializedFiles.add(filePath);
-    }
-
-    return filePath;
-  }
+async function* asyncIterableOf<T>(items: Iterable<T>): AsyncGenerator<T> {
+  for (const item of items) yield item;
 }

--- a/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
+++ b/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
@@ -49,6 +49,28 @@ describe('ShaclValidator', () => {
     expect(result.violations).toBeGreaterThan(0);
   });
 
+  it('sets a message on the result when reportWriters consumed violations', async () => {
+    // The pipeline's halt-mode error reads ValidationResult.message to point
+    // operators at the report; without writers there is nowhere to point.
+    const writer: Writer = { write: vi.fn() };
+    const validator = new ShaclValidator({
+      shapesFile,
+      reportWriters: [writer],
+    });
+
+    const withViolations = await validator.validate(
+      parseFixture('invalid.ttl'),
+      dataset,
+    );
+    expect(withViolations.message).toMatch(/writer/i);
+
+    const withoutWriters = await new ShaclValidator({ shapesFile }).validate(
+      parseFixture('invalid.ttl'),
+      dataset,
+    );
+    expect(withoutWriters.message).toBeUndefined();
+  });
+
   it('streams report quads to every configured writer on violations', async () => {
     const writer1: Writer = {
       write: vi.fn(async (_dataset, quads) => {

--- a/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
+++ b/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { join } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { Parser } from 'n3';
 import type { Quad } from '@rdfjs/types';
 import { Dataset } from '@lde/dataset';
+import { FileWriter, type Writer } from '@lde/pipeline';
 import { ShaclValidator } from '../src/shacl-validator.js';
 
 const shapesFile = join(__dirname, 'fixtures', 'shapes.ttl');
@@ -21,19 +22,15 @@ function parseFixture(filename: string): Quad[] {
   return parser.parse(content);
 }
 
+async function collectQuads(iterable: AsyncIterable<Quad>): Promise<Quad[]> {
+  const quads: Quad[] = [];
+  for await (const quad of iterable) quads.push(quad);
+  return quads;
+}
+
 describe('ShaclValidator', () => {
-  let reportDir: string;
-
-  beforeEach(async () => {
-    reportDir = await mkdtemp(join(tmpdir(), 'shacl-validator-test-'));
-  });
-
-  afterEach(async () => {
-    await rm(reportDir, { recursive: true, force: true });
-  });
-
   it('returns conforms:true for valid data', async () => {
-    const validator = new ShaclValidator({ shapesFile, reportDir });
+    const validator = new ShaclValidator({ shapesFile });
     const quads = parseFixture('valid.ttl');
 
     const result = await validator.validate(quads, dataset);
@@ -43,7 +40,7 @@ describe('ShaclValidator', () => {
   });
 
   it('returns violations for invalid data', async () => {
-    const validator = new ShaclValidator({ shapesFile, reportDir });
+    const validator = new ShaclValidator({ shapesFile });
     const quads = parseFixture('invalid.ttl');
 
     const result = await validator.validate(quads, dataset);
@@ -52,33 +49,102 @@ describe('ShaclValidator', () => {
     expect(result.violations).toBeGreaterThan(0);
   });
 
-  it('writes a report file for invalid data', async () => {
-    const validator = new ShaclValidator({ shapesFile, reportDir });
-    const quads = parseFixture('invalid.ttl');
+  it('streams report quads to every configured writer on violations', async () => {
+    const writer1: Writer = {
+      write: vi.fn(async (_dataset, quads) => {
+        await collectQuads(quads);
+      }),
+    };
+    const writer2: Writer = {
+      write: vi.fn(async (_dataset, quads) => {
+        await collectQuads(quads);
+      }),
+    };
+    const validator = new ShaclValidator({
+      shapesFile,
+      reportWriters: [writer1, writer2],
+    });
 
-    const result = await validator.validate(quads, dataset);
+    await validator.validate(parseFixture('invalid.ttl'), dataset);
 
-    const files = await readdir(reportDir);
-    expect(files.some((f) => f.endsWith('.validation.ttl'))).toBe(true);
-
-    expect(result.message).toMatch(/\.validation\.ttl$/);
-
-    const content = await readFile(join(reportDir, files[0]), 'utf-8');
-    expect(content).toContain('shacl');
+    expect(writer1.write).toHaveBeenCalledOnce();
+    expect(writer2.write).toHaveBeenCalledOnce();
+    const [received1] = (writer1.write as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(received1.iri.toString()).toBe(dataset.iri.toString());
   });
 
-  it('does not write a report file for valid data', async () => {
-    const validator = new ShaclValidator({ shapesFile, reportDir });
-    const quads = parseFixture('valid.ttl');
+  it('does not call writers when there are no violations', async () => {
+    const writer: Writer = { write: vi.fn() };
+    const validator = new ShaclValidator({
+      shapesFile,
+      reportWriters: [writer],
+    });
 
-    await validator.validate(quads, dataset);
+    await validator.validate(parseFixture('valid.ttl'), dataset);
 
-    const entries = await readdir(reportDir);
-    expect(entries).toHaveLength(0);
+    expect(writer.write).not.toHaveBeenCalled();
+  });
+
+  it('passes report quads (sh:ValidationResult triples) to writers', async () => {
+    let received: Quad[] = [];
+    const writer: Writer = {
+      write: async (_dataset, quads) => {
+        received = await collectQuads(quads);
+      },
+    };
+    const validator = new ShaclValidator({
+      shapesFile,
+      reportWriters: [writer],
+    });
+
+    await validator.validate(parseFixture('invalid.ttl'), dataset);
+
+    expect(received.length).toBeGreaterThan(0);
+    expect(
+      received.some((q) =>
+        q.predicate.value.startsWith('http://www.w3.org/ns/shacl#'),
+      ),
+    ).toBe(true);
+  });
+
+  it('flushes each writer when report() is called', async () => {
+    const writer: Writer = {
+      write: vi.fn(),
+      flush: vi.fn(),
+    };
+    const validator = new ShaclValidator({
+      shapesFile,
+      reportWriters: [writer],
+    });
+
+    await validator.validate(parseFixture('invalid.ttl'), dataset);
+    await validator.report(dataset);
+
+    expect(writer.flush).toHaveBeenCalledOnce();
+    expect(writer.flush).toHaveBeenCalledWith(dataset);
+  });
+
+  it('flushes writers even when no violations were emitted for the dataset', async () => {
+    // Reports a still-conformant dataset: flush is the lifecycle hook for
+    // "this dataset is done", independent of whether violations occurred.
+    const writer: Writer = {
+      write: vi.fn(),
+      flush: vi.fn(),
+    };
+    const validator = new ShaclValidator({
+      shapesFile,
+      reportWriters: [writer],
+    });
+
+    await validator.validate(parseFixture('valid.ttl'), dataset);
+    await validator.report(dataset);
+
+    expect(writer.flush).toHaveBeenCalledOnce();
   });
 
   it('accumulates results across validate calls', async () => {
-    const validator = new ShaclValidator({ shapesFile, reportDir });
+    const validator = new ShaclValidator({ shapesFile });
     const validQuads = parseFixture('valid.ttl');
     const invalidQuads = parseFixture('invalid.ttl');
 
@@ -92,7 +158,7 @@ describe('ShaclValidator', () => {
   });
 
   it('returns empty report for unseen dataset', async () => {
-    const validator = new ShaclValidator({ shapesFile, reportDir });
+    const validator = new ShaclValidator({ shapesFile });
     const other = new Dataset({
       iri: new URL('http://example.org/other'),
       distributions: [],
@@ -105,7 +171,7 @@ describe('ShaclValidator', () => {
   });
 
   it('returns conforms:true for empty quads', async () => {
-    const validator = new ShaclValidator({ shapesFile, reportDir });
+    const validator = new ShaclValidator({ shapesFile });
 
     const result = await validator.validate([], dataset);
 
@@ -113,28 +179,8 @@ describe('ShaclValidator', () => {
     expect(result.violations).toBe(0);
   });
 
-  it('truncates report file on first write per dataset', async () => {
-    const invalidQuads = parseFixture('invalid.ttl');
-
-    // First run: validate with one validator instance.
-    const validator1 = new ShaclValidator({ shapesFile, reportDir });
-    await validator1.validate(invalidQuads, dataset);
-    const files = await readdir(reportDir);
-    const firstContent = await readFile(join(reportDir, files[0]), 'utf-8');
-
-    // Second run: a fresh validator instance writes to the same reportDir.
-    const validator2 = new ShaclValidator({ shapesFile, reportDir });
-    await validator2.validate(invalidQuads, dataset);
-    const secondContent = await readFile(join(reportDir, files[0]), 'utf-8');
-
-    // The second run should have truncated the file, not appended to it.
-    // Blank node IDs differ between runs (global counter), so exact string
-    // equality isn't possible. A non-truncated (appended) file would be ~2×.
-    expect(secondContent.length).toBeLessThan(firstContent.length * 1.1);
-  });
-
   it('caches shapes across validate calls', async () => {
-    const validator = new ShaclValidator({ shapesFile, reportDir });
+    const validator = new ShaclValidator({ shapesFile });
     const quads = parseFixture('valid.ttl');
 
     await validator.validate(quads, dataset);
@@ -143,5 +189,47 @@ describe('ShaclValidator', () => {
     const report = await validator.report(dataset);
     expect(report.conforms).toBe(true);
     expect(report.quadsValidated).toBe(quads.length * 2);
+  });
+
+  describe('with FileWriter', () => {
+    let outputDir: string;
+
+    beforeEach(async () => {
+      outputDir = await mkdtemp(join(tmpdir(), 'shacl-validator-test-'));
+    });
+
+    afterEach(async () => {
+      await rm(outputDir, { recursive: true, force: true });
+    });
+
+    it('writes a report file when configured with a FileWriter', async () => {
+      const fileWriter = new FileWriter({ outputDir, format: 'turtle' });
+      const validator = new ShaclValidator({
+        shapesFile,
+        reportWriters: [fileWriter],
+      });
+
+      await validator.validate(parseFixture('invalid.ttl'), dataset);
+      await validator.report(dataset);
+
+      const files = await readdir(outputDir);
+      expect(files).toHaveLength(1);
+      const content = await readFile(join(outputDir, files[0]), 'utf-8');
+      expect(content).toContain('shacl');
+    });
+
+    it('does not write a file when there are no violations', async () => {
+      const fileWriter = new FileWriter({ outputDir, format: 'turtle' });
+      const validator = new ShaclValidator({
+        shapesFile,
+        reportWriters: [fileWriter],
+      });
+
+      await validator.validate(parseFixture('valid.ttl'), dataset);
+      await validator.report(dataset);
+
+      const entries = await readdir(outputDir);
+      expect(entries).toHaveLength(0);
+    });
   });
 });

--- a/packages/pipeline-shacl-validator/vite.config.ts
+++ b/packages/pipeline-shacl-validator/vite.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 100,
-          lines: 97.72,
-          branches: 93.75,
-          statements: 97.77,
+          lines: 100,
+          branches: 100,
+          statements: 100,
         },
       },
     },

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -218,6 +218,7 @@ Quads are buffered, validated, and then written or discarded based on the `onInv
 
 ```typescript
 import { ShaclValidator } from '@lde/pipeline-shacl-validator';
+import { FileWriter } from '@lde/pipeline';
 
 new Stage({
   name: 'transform',
@@ -225,7 +226,9 @@ new Stage({
   validation: {
     validator: new ShaclValidator({
       shapesFile: './shapes.ttl',
-      reportDir: './validation',
+      reportWriters: [
+        new FileWriter({ outputDir: './validation', format: 'turtle' }),
+      ],
     }),
     onInvalid: 'write', // 'write' (default) | 'skip' | 'halt'
   },

--- a/packages/pipeline/tsconfig.lib.json
+++ b/packages/pipeline/tsconfig.lib.json
@@ -10,6 +10,9 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
+      "path": "../local-sparql-endpoint/tsconfig.lib.json"
+    },
+    {
       "path": "../sparql-server/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
## Summary

Drop the file-only output coupling on `ShaclValidator`. The validator no longer writes reports to `<reportDir>/<dataset>.validation.<ext>` internally; instead, the per-dataset SHACL validation report is streamed to any number of configured `Writer`s through the existing `Writer.write(dataset, quads)` contract.

```ts
new ShaclValidator({
  shapesFile,
  reportWriters: [
    new FileWriter({ outputDir: 'validation', format: 'turtle' }),
    new SparqlUpdateWriter({ endpoint, auth }),
  ],
});
```

## Why

The previous shape forced reports into a directory and hid the report quads inside `private writeReportFile()`. Downstream callers (e.g. the Dataset Knowledge Graph) want the same data in a SPARQL named graph so it's queryable — currently the only way to get there is parsing `node_modules`-coupled filenames, which is brittle.

The pipeline already has a `Writer[]` extension model (`FileWriter`, `SparqlUpdateWriter`), with `write(dataset, quads)` + optional `flush(dataset)`. Routing report output through the same model means:

- **Composability** — file + SPARQL + custom analyzer in one call by passing multiple writers.
- **Reuses CLEAR-once + INSERT DATA batching** from `SparqlUpdateWriter` (the cross-call lifecycle was already there, just unused by the validator).
- **Single responsibility** — the validator runs SHACL, writers move bytes. File-format options (`outputDir`, `format`, `replacementCharacter`, prefixes) move out of the validator and live on `FileWriter`, where they belonged.

## Behaviour

- `validate(quads, dataset)`: runs SHACL. If there are violations and any `reportWriters` are configured, the report quads are streamed to each writer via `Writer.write(dataset, …)`.
- `report(dataset)`: returns the accumulator (`conforms` / `violations` / `quadsValidated`) and additionally calls `writer.flush?.(dataset)` on each configured writer. This is the "this dataset is done" signal — `FileWriter` closes its stream here; `SparqlUpdateWriter` finishes any final batch.
- Empty `quads` short-circuits before any writer call (unchanged).
- Validators with no `reportWriters` only produce aggregate counts; the report quads are discarded.

## API change

`ShaclValidatorOptions`:

- **removed**: `reportDir` (was required), `reportFormat`
- **added**: `reportWriters?: Writer[]`

Existing callers preserve the previous on-disk behaviour by composing a `FileWriter`:

```ts
// Before
new ShaclValidator({ shapesFile, reportDir: 'validation' });

// After
new ShaclValidator({
  shapesFile,
  reportWriters: [new FileWriter({ outputDir: 'validation', format: 'turtle' })],
});
```

Drops the now-unused `filenamify-url` dependency (filename derivation lives in `FileWriter`).

## Other changes

- README for `pipeline-shacl-validator` rewritten around the new shape.
- Example snippets in `packages/pipeline/README.md` and `packages/pipeline-shacl-sampler/README.md` migrated.
- `tsconfig.lib.json` adjustments under `dataset-registry-client` and `pipeline` are collateral from `nx sync` regenerating project references during the worktree build — same kind of churn as #398.

## Tests

13 tests pass, 100 % coverage in `shacl-validator.ts`. Direct writer-fan-out behaviour is covered with `vi.fn()` mocks; integration with the real `FileWriter` is covered under `describe('with FileWriter')` to make sure the most common configuration still produces the expected files.

BREAKING CHANGE: `reportDir` is no longer accepted and was required; pass `reportWriters: [new FileWriter({ outputDir: ... })]` to preserve the previous on-disk behaviour.
