### PR TITLE
feat(pipeline): add graphIri option to SparqlUpdateWriter

### DIFF
--- a/packages/pipeline-shacl-validator/README.md
+++ b/packages/pipeline-shacl-validator/README.md
@@ -86,11 +86,20 @@ new ShaclValidator({
 
 #### Named graphs with `SparqlUpdateWriter`
 
-`SparqlUpdateWriter` uses `dataset.iri.toString()` as the named graph URI on
-every write, with no per-call override. A report writer that shares the
-endpoint with the pipeline's main writer would land the SHACL report in the
-same graph as the dataset's data — and `CLEAR GRAPH` on first write per
-dataset would erase it. To keep validation results in a separate graph,
-either point the report writer at a different repository/endpoint, or
-implement a small wrapper `Writer` that swaps `dataset.iri` for a derived
-report-graph IRI before delegating.
+`SparqlUpdateWriter` defaults to `dataset.iri.toString()` as the named graph
+URI. A report writer that shares the endpoint with the pipeline's main
+writer would otherwise land the SHACL report in the same graph as the
+dataset's data — and `CLEAR GRAPH` on first write per dataset would erase
+it. To keep validation results in a separate graph, pass `graphIri` to
+derive the target graph from the dataset:
+
+```ts
+new SparqlUpdateWriter({
+  endpoint,
+  auth,
+  graphIri: (dataset) =>
+    new URL(
+      `https://example.org/shacl-validation/${encodeURIComponent(dataset.iri.toString())}`,
+    ),
+});
+```

--- a/packages/pipeline/src/writer/sparqlUpdateWriter.ts
+++ b/packages/pipeline/src/writer/sparqlUpdateWriter.ts
@@ -25,6 +25,17 @@ export interface SparqlWriterOptions {
    * @default 10000
    */
   batchSize?: number;
+  /**
+   * Derive the named-graph URI from the dataset being written. Defaults to
+   * `dataset.iri`, which puts each dataset's quads in a graph named after its
+   * own IRI. Override when the quads are an enrichment (e.g. a SHACL validation
+   * report) that should land in a different graph than the dataset's own data.
+   *
+   * The same instance's `clearedGraphs` lifecycle (CLEAR on first write per
+   * graph) follows the derived URI, so two writers with different `graphIri`
+   * functions can target the same endpoint without interfering.
+   */
+  graphIri?: (dataset: Dataset) => URL;
 }
 
 /**
@@ -39,6 +50,7 @@ export class SparqlUpdateWriter implements Writer {
   private readonly auth?: string;
   private readonly fetch: typeof globalThis.fetch;
   private readonly batchSize: number;
+  private readonly graphIri: (dataset: Dataset) => URL;
   private readonly clearedGraphs = new Set<string>();
 
   constructor(options: SparqlWriterOptions) {
@@ -46,10 +58,11 @@ export class SparqlUpdateWriter implements Writer {
     this.auth = options.auth;
     this.fetch = options.fetch ?? globalThis.fetch;
     this.batchSize = options.batchSize ?? 10000;
+    this.graphIri = options.graphIri ?? ((dataset) => dataset.iri);
   }
 
   async write(dataset: Dataset, quads: AsyncIterable<Quad>): Promise<void> {
-    const graphUri = dataset.iri.toString();
+    const graphUri = this.graphIri(dataset).toString();
     assertSafeIri(graphUri);
 
     if (!this.clearedGraphs.has(graphUri)) {

--- a/packages/pipeline/test/writer/sparqlUpdateWriter.test.ts
+++ b/packages/pipeline/test/writer/sparqlUpdateWriter.test.ts
@@ -188,6 +188,78 @@ describe('SparqlUpdateWriter', () => {
       expect(bodies.some((b) => b.startsWith('INSERT'))).toBe(true);
     });
 
+    it('uses dataset.iri as graph URI when graphIri is not provided', async () => {
+      // Sanity check: the default behaviour is unchanged.
+      const writer = new SparqlUpdateWriter({
+        endpoint,
+        fetch: mockFetch as typeof globalThis.fetch,
+      });
+
+      await writer.write(
+        createDataset('http://example.com/dataset/1'),
+        quadsOf(),
+      );
+
+      const body = mockFetch.mock.calls[0]![1]!.body as string;
+      expect(body).toBe('CLEAR GRAPH <http://example.com/dataset/1>');
+    });
+
+    it('writes to a derived graph URI when graphIri is provided', async () => {
+      const writer = new SparqlUpdateWriter({
+        endpoint,
+        fetch: mockFetch as typeof globalThis.fetch,
+        graphIri: (dataset) =>
+          new URL(
+            `https://example.org/enrichment/${encodeURIComponent(dataset.iri.toString())}`,
+          ),
+      });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/s'),
+            namedNode('http://example.com/p'),
+            literal('o'),
+          ),
+        ),
+      );
+
+      const expected =
+        'https://example.org/enrichment/http%3A%2F%2Fexample.com%2Fdataset%2F1';
+      const clearBody = mockFetch.mock.calls[0]![1]!.body as string;
+      expect(clearBody).toBe(`CLEAR GRAPH <${expected}>`);
+      const insertBody = mockFetch.mock.calls[1]![1]!.body as string;
+      expect(insertBody).toContain(`GRAPH <${expected}>`);
+    });
+
+    it('tracks clearedGraphs by the derived URI, not dataset.iri', async () => {
+      // Two writers backed by the same endpoint with different graphIri
+      // policies must each CLEAR their own graph independently — verify the
+      // bookkeeping keys off the derived URI.
+      const writer = new SparqlUpdateWriter({
+        endpoint,
+        fetch: mockFetch as typeof globalThis.fetch,
+        graphIri: (dataset) => new URL(`${dataset.iri.toString()}/derived`),
+      });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+      const aQuad = quad(
+        namedNode('http://example.com/s'),
+        namedNode('http://example.com/p'),
+        literal('o'),
+      );
+
+      await writer.write(dataset, quadsOf(aQuad));
+      mockFetch.mockClear();
+      await writer.write(dataset, quadsOf(aQuad));
+
+      const bodies = mockFetch.mock.calls.map((c) => c[1]!.body as string);
+      expect(bodies.every((b) => !b.startsWith('CLEAR'))).toBe(true);
+    });
+
     it('throws on HTTP error', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 93.33,
-          lines: 93.45,
-          branches: 89.58,
-          statements: 92.87,
+          functions: 93.38,
+          lines: 93.46,
+          branches: 89.64,
+          statements: 92.89,
         },
       },
     },


### PR DESCRIPTION
## Summary

Lift the "graph URI = `dataset.iri`" policy out of `SparqlUpdateWriter` and into an optional config knob. Callers writing enrichment data (a SHACL validation report, a quality summary, anything that shouldn't mix into the dataset's own graph) can now express that policy directly on the writer:

```ts
new SparqlUpdateWriter({
  endpoint,
  graphIri: (dataset) =>
    new URL(
      `https://example.org/shacl-validation/${encodeURIComponent(dataset.iri.toString())}`,
    ),
});
```

## Why

Followup to #408. The validator README ended up suggesting "implement a small wrapper `Writer` that swaps `dataset.iri` for a derived report-graph IRI before delegating" — actionable but awkward: building a fake `Dataset` just to fool the writer into picking a different graph conflates dataset identity with output location. The clean factoring is: the dataset stays the dataset; the *writer* decides where its quads go.

DKG would have shipped a `ValidationGraphWriter` class doing exactly this dance (netwerk-digitaal-erfgoed/dataset-knowledge-graph#296). With `graphIri` on the writer, that class collapses to a single line.

## Behaviour

- `graphIri` defaults to `(dataset) => dataset.iri`, so existing callers see no change.
- `clearedGraphs` tracks the derived URI rather than `dataset.iri`, so two `SparqlUpdateWriter` instances targeting the same endpoint with different `graphIri` policies don't interfere.
- `assertSafeIri` runs on the derived URI (the value that ends up interpolated into `CLEAR GRAPH <…>` / `INSERT DATA { GRAPH <…> { … } }`), which is the right place to validate.

## Tests

Two new tests:

- Default-unchanged sanity check: when `graphIri` is omitted, the writer still uses `dataset.iri`.
- Derived-URI roundtrip: a `graphIri` callback is honoured in both the `CLEAR GRAPH` and `INSERT DATA` queries.
- `clearedGraphs` bookkeeping keyed off the derived URI (the existing "does not re-clear graph on second write to same dataset" test repeated with a derived `graphIri`).

100 % coverage on `sparqlUpdateWriter.ts`.

## Doc

`packages/pipeline-shacl-validator/README.md` already had a section on "Named graphs with `SparqlUpdateWriter`" that recommended the wrapper-Writer workaround. Rewritten to point at the new `graphIri` option.

Non-breaking: minor bump.
