### PR TITLE
fix(distribution-probe): tolerate servers that 406 on specific Accept headers

### DIFF
--- a/packages/distribution-probe/src/probe.ts
+++ b/packages/distribution-probe/src/probe.ts
@@ -316,8 +316,16 @@ async function probeDataDump(
   authHeaders: Headers,
   start: number,
 ): Promise<DataDumpProbeResult | NetworkError> {
+  // Express a preference for the declared media type, but accept anything as a
+  // fallback. Servers that implement RFC 9110 §12.5.1 content negotiation will
+  // pick the declared type (preserving our ability to detect real Content-Type
+  // mismatches). Servers that reject any non-*/* Accept with 406 — notably
+  // Dataverse's /api/access/datafile/ endpoint — fall back to */* and return
+  // the file unchanged.
   const headers = new Headers({
-    Accept: distribution.mimeType ?? '*/*',
+    Accept: distribution.mimeType
+      ? `${distribution.mimeType}, */*;q=0.5`
+      : '*/*',
     'Accept-Encoding': 'identity',
   });
   for (const [key, value] of authHeaders) {

--- a/packages/distribution-probe/src/probe.ts
+++ b/packages/distribution-probe/src/probe.ts
@@ -320,8 +320,8 @@ async function probeDataDump(
   // fallback. Servers that implement RFC 9110 §12.5.1 content negotiation will
   // pick the declared type (preserving our ability to detect real Content-Type
   // mismatches). Servers that reject any non-*/* Accept with 406 — notably
-  // Dataverse's /api/access/datafile/ endpoint — fall back to */* and return
-  // the file unchanged.
+  // Dataverse's /api/access/datafile/ endpoint (IQSS/dataverse#12410) — fall
+  // back to */* and return the file unchanged.
   const headers = new Headers({
     Accept: distribution.mimeType
       ? `${distribution.mimeType}, */*;q=0.5`

--- a/packages/distribution-probe/test/probe.test.ts
+++ b/packages/distribution-probe/test/probe.test.ts
@@ -166,6 +166,51 @@ describe('probe', () => {
       expect(dumpResult.lastModified).toBeInstanceOf(Date);
     });
 
+    it('sends the declared mime type with a */* fallback in Accept', async () => {
+      // Some servers (notably Dataverse's /api/access/datafile/) reject any
+      // non-*/* Accept with 406, even when they would happily serve the
+      // declared type by default. Sending `<declared>, */*;q=0.5` lets
+      // compliant servers honour the preference and lets quirky servers fall
+      // back to */* so the probe doesn't false-positive a ContentTypeMismatch.
+      let capturedAccept: string | null = null;
+      vi.mocked(fetch).mockImplementation(async (_input, init) => {
+        capturedAccept = new Headers(init?.headers).get('Accept');
+        return new Response('', {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/markdown',
+            'Content-Length': '12345',
+          },
+        });
+      });
+
+      const distribution = new Distribution(
+        new URL('http://example.org/file.md'),
+        'text/markdown',
+      );
+
+      await probe(distribution);
+
+      expect(capturedAccept).toBe('text/markdown, */*;q=0.5');
+    });
+
+    it('sends Accept: */* when no mime type is declared', async () => {
+      let capturedAccept: string | null = null;
+      vi.mocked(fetch).mockImplementation(async (_input, init) => {
+        capturedAccept = new Headers(init?.headers).get('Accept');
+        return new Response('', {
+          status: 200,
+          headers: { 'Content-Length': '12345' },
+        });
+      });
+
+      const distribution = new Distribution(new URL('http://example.org/file'));
+
+      await probe(distribution);
+
+      expect(capturedAccept).toBe('*/*');
+    });
+
     it('does not mutate the distribution', async () => {
       vi.mocked(fetch).mockResolvedValue(
         new Response('', {

--- a/packages/distribution-probe/vite.config.ts
+++ b/packages/distribution-probe/vite.config.ts
@@ -13,7 +13,7 @@ export default mergeConfig(
           autoUpdate: true,
           lines: 99.15,
           functions: 100,
-          branches: 86.36,
+          branches: 87.5,
           statements: 98.36,
         },
       },


### PR DESCRIPTION
## Summary

`probeDataDump` now sends:

```
Accept: <declared-type>, */*;q=0.5
```

instead of just `Accept: <declared-type>`.

## Why

Some servers — notably Dataverse's `/api/access/datafile/` endpoint — reject **any** non-`*/*` Accept with HTTP `406 Not Acceptable`, even when they would happily serve the declared media type by default. The previous code sent just the declared mime (e.g. `text/markdown`), so:

- A compliant server sees `Accept: text/markdown`, returns 200 + `Content-Type: text/markdown` (good).
- Dataverse sees `Accept: text/markdown` and returns 406 (bug on their end), even though `curl -I` (which sends `Accept: */*`) gets 200 + `Content-Type: text/markdown; name="…";charset=UTF-8`.

The probe's downstream classifier in the dataset-register then catches the 406 in its "unknown HTTP failure" branch and mislabels the outcome as `ContentTypeMismatch`. In NDE production today, that misfire accounts for ~13,000 of 14,379 currently-failing distribution probes (across ~414 datasets), all of which would promote to `sh:Violation` and invalidate their datasets on 2026-05-30 (the 7-day streak threshold from `firstFailureAt: 2026-05-23`).

Empirical reproduction against IISG (Dataverse instance):

```
$ curl -sI -H 'Accept: text/markdown'      …/api/access/datafile/14249 | head -1
HTTP/2 406
$ curl -sI -H 'Accept: */*'                 …/api/access/datafile/14249 | head -1
HTTP/2 200
$ curl -sI -H 'Accept: text/plain'          …/api/access/datafile/14249 | head -1
HTTP/2 406   ← would happily serve text/plain otherwise
$ curl -sI -H 'Accept: application/json'    …/api/access/datafile/14249 | head -1
HTTP/2 406
```

So Dataverse rejects any specific Accept, no matter how reasonable. RFC 9110 §12.5.1 says the server should select a matching representation; Dataverse isn't doing that. This will be filed upstream at IQSS/dataverse separately, but the probe needs to be defensive about quirky servers regardless.

## Behaviour preserved

- Compliant servers honour the `q=1.0` preference for the declared type, so the probe still detects real Content-Type mismatches when the server returns a different default representation.
- The `*/*;q=0.5` fallback only kicks in for servers that won't negotiate properly; in that case the probe gets the file as the server's default representation, and `checkContentTypeMismatch` compares the base media type (already parameter-tolerant via `split(';')[0]`).
- Distributions with no declared mime type still get `Accept: */*` (unchanged).

## Tests

Two new tests:

1. With a declared mime, Accept header is `text/markdown, */*;q=0.5`.
2. With no declared mime, Accept header is `*/*`.
