### PR TITLE
fix(sparql-qlever): shell-escape data filenames in the QLever index command

### DIFF
--- a/packages/sparql-qlever/src/importer.ts
+++ b/packages/sparql-qlever/src/importer.ts
@@ -252,13 +252,28 @@ export class Importer implements ImporterInterface {
     const metadataFile = `${this.options.indexName}.meta-data.json`;
     const localName = basename(file);
     const decompressCommand = localName.toLowerCase().endsWith('.zip')
-      ? `unzip -p '${localName}'`
-      : `(gunzip -c '${localName}' 2>/dev/null || cat '${localName}')`;
+      ? `unzip -p ${shellQuote(localName)}`
+      : `(gunzip -c ${shellQuote(localName)} 2>/dev/null || cat ${shellQuote(localName)})`;
     const indexTask = await this.options.taskRunner.run(
-      `${decompressCommand} | qlever-index ${flags} && cat ${metadataFile}`,
+      `${decompressCommand} | qlever-index ${flags} && cat ${shellQuote(metadataFile)}`,
     );
     return await this.options.taskRunner.wait(indexTask);
   }
+}
+
+/**
+ * POSIX-quote a value for safe interpolation into a shell command: wrap it in
+ * single quotes and escape any embedded single quote as `'\''`.
+ *
+ * Without this, a data filename containing an apostrophe — e.g. a dataset
+ * titled `'s-Hertogenbosch`, whose distribution URL maps to a local file like
+ * `…Erfgoed+'s-Hertogenbosch.nt` — would terminate the surrounding quotes, so
+ * `cat`/`gunzip` would read a non-existent path and feed `qlever-index` empty
+ * input. The index then "succeeds" with 0 triples, the import is treated as
+ * failed, and every distribution (and the JSON-LD fallback) fails the same way.
+ */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 type fileFormat = 'nt' | 'nq' | 'ttl';

--- a/packages/sparql-qlever/test/importer.test.ts
+++ b/packages/sparql-qlever/test/importer.test.ts
@@ -13,6 +13,7 @@ import {
   utimes,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 import { TaskRunner } from '@lde/task-runner';
 
 function makeDistributions(): Distribution[] {
@@ -329,6 +330,48 @@ describe('Importer', () => {
       expect((result as ImportSuccessful).warnings).toEqual([
         'Server Content-Type application/n-quads does not match declared media type application/n-triples; using nq format',
       ]);
+    });
+
+    it('shell-escapes data filenames containing single quotes', async () => {
+      // A dataset titled e.g. "'s-Hertogenbosch" maps to a local filename with
+      // an apostrophe. Naive single-quoting (`cat '<name>'`) lets the apostrophe
+      // terminate the quote, so cat/gunzip read a non-existent path and feed
+      // qlever-index empty input — silently indexing 0 triples.
+      const trickyFile = join(
+        tempDir,
+        "Dataset+Beeldbank+Erfgoed+'s-Hertogenbosch.ttl",
+      );
+      await copyFile(dataFile, trickyFile);
+
+      const runner = stubTaskRunner(42);
+      const importer = new Importer({
+        taskRunner: runner,
+        indexName,
+        downloader: {
+          async download() {
+            return { path: trickyFile, headers: new Headers() };
+          },
+        },
+      });
+
+      const result = await importer.import(makeDistributions());
+
+      expect(result).toBeInstanceOf(ImportSuccessful);
+
+      const command = runner.commands[0];
+      // The apostrophe is POSIX-escaped, not left to break the quoting.
+      expect(command).toContain(
+        "Dataset+Beeldbank+Erfgoed+'\\''s-Hertogenbosch.ttl",
+      );
+      expect(command).not.toContain("Erfgoed+'s"); // the broken, unescaped form
+
+      // And the decompress sub-command actually reads the real file when a shell
+      // runs it — this is what produced empty input (0 triples) before the fix.
+      const decompress = command.slice(0, command.indexOf('| qlever-index'));
+      const output = execFileSync('sh', ['-c', decompress], {
+        cwd: tempDir,
+      }).toString();
+      expect(output).toContain('http://example.com/source');
     });
 
     it('falls back to file extension when Content-Type is a compression type', async () => {

--- a/packages/sparql-qlever/vite.config.ts
+++ b/packages/sparql-qlever/vite.config.ts
@@ -13,10 +13,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 93.81,
+          lines: 95.55,
           functions: 100,
-          branches: 80.64,
-          statements: 93.87,
+          branches: 83.87,
+          statements: 95.6,
         },
       },
     },


### PR DESCRIPTION
## Problem

`Importer.index()` builds the QLever index command by interpolating the local data filename into a shell pipeline **inside single quotes**:

```js
`(gunzip -c '${localName}' 2>/dev/null || cat '${localName}') | qlever-index … && cat ${metadataFile}`
```

If `localName` contains a single quote, the quoting breaks. This is not hypothetical: a Dataset Register entry titled “Beeldbank Erfgoed ’s-Hertogenbosch” has distribution URLs whose `%27` decodes to an apostrophe, so the downloaded file is `…Erfgoed+'s-Hertogenbosch.nt`. The apostrophe terminates the single-quoted argument, `cat`/`gunzip` receive a mangled, non-existent path, and `qlever-index` is fed **empty input**.

The result: QLever reports **0 triples**, the import is marked failed, and the importer falls through **every** distribution (they all share the apostrophe filename) – including the JSON-LD fallback, whose `.preprocessed.nq` also keeps the apostrophe and fails the same way after a long Node-side conversion. Net effect observed in production: a dataset whose native `.nt` indexes to **1.24 M triples in seconds** instead burned **~3 hours** and was skipped entirely.

It is also a latent shell-injection vector: a crafted distribution URL mapping to a filename with shell metacharacters would inject into `taskRunner.run`.

## Fix

Add a small POSIX `shellQuote` helper – wrap in single quotes and escape embedded single quotes as `'\''` – and apply it to the data filename (both the `unzip` and `gunzip`/`cat` branches) and the metadata file.

POSIX single-quote semantics are identical across every POSIX shell, so this is correct regardless of which shell runs the command – important here because the Docker task runner executes it inside the QLever container, not the host shell. (For that reason a host-shell-detecting library such as `shescape` would be the wrong tool; this needs no dependency.)

## Test

`test/importer.test.ts` adds a regression test that:
- feeds a distribution whose local filename contains an apostrophe,
- asserts the generated command POSIX-escapes it (and not the broken unescaped form), and
- runs the generated decompress sub-command through `sh` and verifies it reads the real file’s contents.

The test fails on the previous code and passes with the fix. Full package suite: 37/37 pass (incl. the Docker-based tests); coverage thresholds auto-updated upward.

## Follow-up (not in this PR)

Separately, JSON-LD preprocessing is impractically slow for large dumps (~100 MB JSON-LD took hours of single-threaded `jsonld` parsing). Worth tracking on its own – but with this fix the native formats index directly and the JSON-LD path is rarely reached.
