### PR TITLE
fix(distribution-probe): accept SPARQL results as JSON or XML

### DIFF
--- a/packages/distribution-probe/src/probe.ts
+++ b/packages/distribution-probe/src/probe.ts
@@ -74,29 +74,41 @@ abstract class ProbeResult {
 }
 
 const SPARQL_RESULTS_JSON = 'application/sparql-results+json';
+const SPARQL_RESULTS_XML = 'application/sparql-results+xml';
 const SPARQL_RDF_RESULTS = 'application/n-triples';
 
 /**
  * Result of probing a SPARQL endpoint.
  */
 export class SparqlProbeResult extends ProbeResult {
-  public readonly acceptedContentType: string;
+  /**
+   * Content types the probe was prepared to accept as a valid answer. A SELECT or
+   * ASK query may be answered with SPARQL results in JSON or XML; the endpoint
+   * chooses, so success is not tied to a single serialization. A single string is
+   * accepted and normalized to a one-element list for backwards compatibility.
+   */
+  public readonly acceptedContentTypes: readonly string[];
 
   constructor(
     url: string,
     response: Response,
     responseTimeMs: number,
-    acceptedContentType: string,
+    acceptedContentTypes: string | readonly string[],
     failureReason: string | null = null,
   ) {
     super(url, response, responseTimeMs, failureReason);
-    this.acceptedContentType = acceptedContentType;
+    this.acceptedContentTypes =
+      typeof acceptedContentTypes === 'string'
+        ? [acceptedContentTypes]
+        : acceptedContentTypes;
   }
 
   override isSuccess(): boolean {
     return (
       super.isSuccess() &&
-      (this.contentType?.startsWith(this.acceptedContentType) ?? false)
+      this.acceptedContentTypes.some(
+        (type) => this.contentType?.startsWith(type) ?? false,
+      )
     );
   }
 }
@@ -222,11 +234,27 @@ function detectSparqlQueryType(query: string): SparqlQueryType {
   return (match?.[1].toUpperCase() ?? 'SELECT') as SparqlQueryType;
 }
 
-function acceptHeaderForQueryType(queryType: SparqlQueryType): string {
+/**
+ * Content types a SPARQL endpoint may legitimately answer with, in preference
+ * order, for the given query type. SELECT and ASK return a results document
+ * (JSON or XML – the endpoint chooses); CONSTRUCT and DESCRIBE return RDF.
+ */
+function acceptableContentTypes(queryType: SparqlQueryType): string[] {
   if (queryType === 'ASK' || queryType === 'SELECT') {
-    return SPARQL_RESULTS_JSON;
+    return [SPARQL_RESULTS_JSON, SPARQL_RESULTS_XML];
   }
-  return SPARQL_RDF_RESULTS;
+  return [SPARQL_RDF_RESULTS];
+}
+
+/**
+ * Build an `Accept` header that prefers the first content type but still accepts
+ * the rest at a lower q-value, so an endpoint that only serves a later type is
+ * not rejected with a 406.
+ */
+function acceptHeader(contentTypes: readonly string[]): string {
+  return contentTypes
+    .map((type, index) => (index === 0 ? type : `${type};q=0.9`))
+    .join(', ');
 }
 
 async function probeSparqlEndpoint(
@@ -237,10 +265,10 @@ async function probeSparqlEndpoint(
   start: number,
 ): Promise<SparqlProbeResult | NetworkError> {
   const queryType = detectSparqlQueryType(options.sparqlQuery);
-  const accept = acceptHeaderForQueryType(queryType);
+  const acceptedContentTypes = acceptableContentTypes(queryType);
   const headers = new Headers({
     'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-    Accept: accept,
+    Accept: acceptHeader(acceptedContentTypes),
   });
   for (const [key, value] of authHeaders) {
     headers.set(key, value);
@@ -254,10 +282,16 @@ async function probeSparqlEndpoint(
   });
 
   const actualContentType = response.headers.get('Content-Type');
-  const contentTypeMatches = actualContentType?.startsWith(accept) ?? false;
+  const matchedContentType = acceptedContentTypes.find(
+    (type) => actualContentType?.startsWith(type) ?? false,
+  );
   let failureReason: string | null = null;
-  if (response.ok && contentTypeMatches) {
-    failureReason = await validateSparqlResponse(response, queryType);
+  if (response.ok && matchedContentType !== undefined) {
+    failureReason = await validateSparqlResponse(
+      response,
+      queryType,
+      matchedContentType,
+    );
   } else {
     // Drain unconsumed body to release the underlying connection.
     await response.body?.cancel();
@@ -268,7 +302,7 @@ async function probeSparqlEndpoint(
     url,
     response,
     responseTimeMs,
-    accept,
+    acceptedContentTypes,
     failureReason,
   );
 }
@@ -276,6 +310,7 @@ async function probeSparqlEndpoint(
 async function validateSparqlResponse(
   response: Response,
   queryType: SparqlQueryType,
+  contentType: string,
 ): Promise<string | null> {
   const body = await response.text();
   if (body.length === 0) {
@@ -288,6 +323,15 @@ async function validateSparqlResponse(
     return null;
   }
 
+  return contentType.startsWith(SPARQL_RESULTS_XML)
+    ? validateSparqlXmlResults(body, queryType)
+    : validateSparqlJsonResults(body, queryType);
+}
+
+function validateSparqlJsonResults(
+  body: string,
+  queryType: SparqlQueryType,
+): string | null {
   let json: Record<string, unknown>;
   try {
     json = JSON.parse(body) as Record<string, unknown>;
@@ -304,6 +348,33 @@ async function validateSparqlResponse(
 
   // SELECT
   if (!json.results || typeof json.results !== 'object') {
+    return 'SPARQL endpoint did not return a valid results object';
+  }
+  return null;
+}
+
+/**
+ * Lightweight structural check on a SPARQL Query Results XML document. Mirrors
+ * the JSON path’s intent – confirm the endpoint answered with the expected shape
+ * – without pulling in a full XML parser.
+ */
+function validateSparqlXmlResults(
+  body: string,
+  queryType: SparqlQueryType,
+): string | null {
+  if (!/<sparql[\s>]/i.test(body)) {
+    return 'SPARQL endpoint returned invalid XML';
+  }
+
+  if (queryType === 'ASK') {
+    if (!/<boolean>\s*(true|false)\s*<\/boolean>/i.test(body)) {
+      return 'SPARQL endpoint did not return a valid ASK result';
+    }
+    return null;
+  }
+
+  // SELECT
+  if (!/<results[\s/>]/i.test(body)) {
     return 'SPARQL endpoint did not return a valid results object';
   }
   return null;

--- a/packages/distribution-probe/test/probe.test.ts
+++ b/packages/distribution-probe/test/probe.test.ts
@@ -137,6 +137,152 @@ describe('probe', () => {
       expect((result as SparqlProbeResult).isSuccess()).toBe(false);
       expect((result as SparqlProbeResult).statusCode).toBe(500);
     });
+
+    it('returns a successful SparqlProbeResult when SELECT results are XML', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(
+          '<?xml version="1.0"?><sparql xmlns="http://www.w3.org/2005/sparql-results#"><head/><results><result/></results></sparql>',
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/sparql-results+xml' },
+          },
+        ),
+      );
+
+      const distribution = Distribution.sparql(
+        new URL('http://example.org/sparql'),
+      );
+
+      const result = await probe(distribution);
+
+      expect(result).toBeInstanceOf(SparqlProbeResult);
+      const sparqlResult = result as SparqlProbeResult;
+      expect(sparqlResult.isSuccess()).toBe(true);
+      expect(sparqlResult.failureReason).toBeNull();
+    });
+
+    it('returns an unsuccessful SparqlProbeResult when XML is not a SPARQL document', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        new Response('<?xml version="1.0"?><html></html>', {
+          status: 200,
+          headers: { 'Content-Type': 'application/sparql-results+xml' },
+        }),
+      );
+
+      const distribution = Distribution.sparql(
+        new URL('http://example.org/sparql'),
+      );
+
+      const result = await probe(distribution);
+
+      const sparqlResult = result as SparqlProbeResult;
+      expect(sparqlResult.isSuccess()).toBe(false);
+      expect(sparqlResult.failureReason).toBe(
+        'SPARQL endpoint returned invalid XML',
+      );
+    });
+
+    it('returns an unsuccessful SparqlProbeResult when XML SELECT results lack a results element', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(
+          '<?xml version="1.0"?><sparql xmlns="http://www.w3.org/2005/sparql-results#"><head/></sparql>',
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/sparql-results+xml' },
+          },
+        ),
+      );
+
+      const distribution = Distribution.sparql(
+        new URL('http://example.org/sparql'),
+      );
+
+      const result = await probe(distribution);
+
+      const sparqlResult = result as SparqlProbeResult;
+      expect(sparqlResult.isSuccess()).toBe(false);
+      expect(sparqlResult.failureReason).toBe(
+        'SPARQL endpoint did not return a valid results object',
+      );
+    });
+
+    it('accepts an XML ASK result and rejects one without a boolean', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(
+          '<?xml version="1.0"?><sparql xmlns="http://www.w3.org/2005/sparql-results#"><head/><boolean>true</boolean></sparql>',
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/sparql-results+xml' },
+          },
+        ),
+      );
+
+      const distribution = Distribution.sparql(
+        new URL('http://example.org/sparql'),
+      );
+
+      const valid = await probe(distribution, {
+        sparqlQuery: 'ASK { ?s ?p ?o }',
+      });
+      expect((valid as SparqlProbeResult).isSuccess()).toBe(true);
+
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(
+          '<?xml version="1.0"?><sparql xmlns="http://www.w3.org/2005/sparql-results#"><head/></sparql>',
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/sparql-results+xml' },
+          },
+        ),
+      );
+
+      const invalid = await probe(distribution, {
+        sparqlQuery: 'ASK { ?s ?p ?o }',
+      });
+      const invalidResult = invalid as SparqlProbeResult;
+      expect(invalidResult.isSuccess()).toBe(false);
+      expect(invalidResult.failureReason).toBe(
+        'SPARQL endpoint did not return a valid ASK result',
+      );
+    });
+
+    it('sends an Accept header that allows both JSON and XML results', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        new Response('{"results": {"bindings": []}}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/sparql-results+json' },
+        }),
+      );
+
+      const distribution = Distribution.sparql(
+        new URL('http://example.org/sparql'),
+      );
+
+      await probe(distribution);
+
+      const accept = (
+        vi.mocked(fetch).mock.calls[0][1]?.headers as Headers
+      ).get('Accept');
+      expect(accept).toContain('application/sparql-results+json');
+      expect(accept).toContain('application/sparql-results+xml');
+    });
+
+    it('normalizes a single accepted content type to a one-element list', () => {
+      const result = new SparqlProbeResult(
+        'http://example.org/sparql',
+        new Response('{"results": {"bindings": []}}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/sparql-results+json' },
+        }),
+        0,
+        'application/sparql-results+json',
+      );
+
+      expect(result.acceptedContentTypes).toEqual([
+        'application/sparql-results+json',
+      ]);
+      expect(result.isSuccess()).toBe(true);
+    });
   });
 
   describe('data dump', () => {
@@ -536,7 +682,7 @@ describe('probe', () => {
 
       expect(capturedHeaders?.get('User-Agent')).toBe('TestAgent/1.0');
       expect(capturedHeaders?.get('Accept')).toBe(
-        'application/sparql-results+json',
+        'application/sparql-results+json, application/sparql-results+xml;q=0.9',
       );
     });
 
@@ -651,7 +797,7 @@ describe('probe', () => {
       });
 
       expect(capturedHeaders?.get('Accept')).toBe(
-        'application/sparql-results+json',
+        'application/sparql-results+json, application/sparql-results+xml;q=0.9',
       );
     });
   });

--- a/packages/distribution-probe/vite.config.ts
+++ b/packages/distribution-probe/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 99.15,
+          lines: 99.25,
           functions: 100,
-          branches: 87.5,
-          statements: 98.36,
+          branches: 89.32,
+          statements: 98.54,
         },
       },
     },


### PR DESCRIPTION
## Problem

When probing a SPARQL endpoint, `SparqlProbeResult.isSuccess()` required the response `Content-Type` to start with the single `Accept` header we send for SELECT/ASK queries (`application/sparql-results+json`). An endpoint that answers in `application/sparql-results+xml` – a perfectly valid SPARQL Query Results serialization – was therefore classified as a failure even on an HTTP 200, and its body was never validated.

Downstream (e.g. the Dataset Register), that healthy endpoint surfaced as a spurious content-type violation (“HTTP 200 OK”).

This also matters because publishers are asked to declare SPARQL endpoints via `dct:conformsTo`, not a media type, so success must not hinge on a declared or negotiated serialization.

## Change

- SELECT/ASK probes now negotiate both serializations: `Accept: application/sparql-results+json, application/sparql-results+xml;q=0.9`.
- Success is granted when the endpoint answers with any recognized results serialization (JSON or XML); the body is validated with a lightweight structural check per serialization.
- `SparqlProbeResult` now carries `acceptedContentTypes` (a list). The constructor still accepts a single `string` and normalizes it, so existing consumers remain source-compatible.

## Tests

- New cases: XML SELECT success, XML SELECT without a `results` element, XML ASK valid/invalid, non-SPARQL XML, the negotiated `Accept` header, and single-string constructor normalization.
- Full `@lde/distribution-probe` suite passes (37 tests); `pipeline` and `distribution-monitor` typecheck cleanly against the widened API.
