### PR TITLE
feat: add executor decorator seam for VoID stages

### DIFF
--- a/packages/pipeline-void/README.md
+++ b/packages/pipeline-void/README.md
@@ -10,14 +10,15 @@ Returns all VoID stages in their recommended execution order. The ordering is op
 
 Accepts an optional `VoidStagesOptions` object:
 
-| Option           | Default | Description                                                           |
-| ---------------- | ------- | --------------------------------------------------------------------- |
-| `timeout`        | 60 000  | SPARQL query timeout in milliseconds                                  |
-| `batchSize`      | 10      | Maximum class bindings per executor call (per-class stages only)      |
-| `maxConcurrency` | 10      | Maximum concurrent in-flight executor batches (per-class stages only) |
-| `perClass`       | —       | Override per-class iteration for all five per-class stages            |
-| `uriSpaces`      | —       | When provided, includes the object URI space stage                    |
-| `vocabularies`   | —       | Additional vocabulary namespace URIs to detect beyond the built-in defaults |
+| Option           | Default | Description                                                                      |
+| ---------------- | ------- | -------------------------------------------------------------------------------- |
+| `timeout`        | 60 000  | SPARQL query timeout in milliseconds                                             |
+| `batchSize`      | 10      | Maximum class bindings per executor call (per-class stages only)                 |
+| `maxConcurrency` | 10      | Maximum concurrent in-flight executor batches (per-class stages only)            |
+| `perClass`       | —       | Override per-class iteration for all five per-class stages                       |
+| `uriSpaces`      | —       | When provided, includes the object URI space stage                               |
+| `vocabularies`   | —       | Additional vocabulary namespace URIs to detect beyond the built-in defaults      |
+| `decorators`     | —       | Per-stage executor decorators, keyed by `VoidStageName` (use `VOID_STAGE_NAMES`) |
 
 ```typescript
 import { voidStages } from '@lde/pipeline-void';
@@ -38,6 +39,8 @@ await new Pipeline({
 ### Individual stage factories
 
 Global and domain-specific factories accept `VoidStageOptions` (`timeout`) and return `Promise<Stage>`. Per-class factories accept `PerClassVoidStageOptions` (`timeout`, `batchSize`, `maxConcurrency`, `perClass`) — they default `perClass` to `true`; set it to `false` to run them as monolithic queries instead.
+
+Every factory additionally accepts `DecoratableStageOptions` with an optional `decorate?: ExecutorDecorator`, letting a single stage be decorated in isolation. The factory always builds its own default executor (including any built-in decorator such as `UriSpaceExecutor` or `VocabularyExecutor`); `decorate` wraps that from the outside, so it composes over the built-in behaviour rather than replacing it. The `voidStages()` bundle exposes the same capability per stage through its `decorators` map.
 
 #### Global stages (one CONSTRUCT query per dataset):
 
@@ -65,12 +68,14 @@ Global and domain-specific factories accept `VoidStageOptions` (`timeout`) and r
 
 #### Domain-specific stages:
 
-| Factory                  | Description                                                                                                                       |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| Factory                  | Description                                                                                                                                                                                                                       |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `detectVocabularies()`   | [`entity-properties.rq`](queries/entity-properties.rq) — Entity properties with automatic `void:vocabulary` detection. Accepts `DetectVocabulariesOptions` with an optional `vocabularies` array to extend the built-in defaults. |
-| `uriSpaces(uriSpaceMap)` | [`object-uri-space.rq`](queries/object-uri-space.rq) — Object URI namespace linksets, aggregated against a provided URI space map |
+| `uriSpaces(uriSpaceMap)` | [`object-uri-space.rq`](queries/object-uri-space.rq) — Object URI namespace linksets, aggregated against a provided URI space map                                                                                                 |
 
 ## Executor decorators
 
 - `VocabularyExecutor` — Wraps an executor; detects known vocabulary namespace prefixes in `void:property` quads and appends `void:vocabulary` triples. The built-in defaults are exported as `defaultVocabularies` (sourced from `@zazuko/prefixes`).
 - `UriSpaceExecutor` — Wraps an executor; consumes `void:Linkset` quads, matches each `void:objectsTarget` against configured URI space prefixes using `startsWith`, and aggregates triple counts per matched space. Emits `void:objectsTarget` pointing to the target dataset IRI (taken from the metadata quad subjects), not the raw prefix. Unmatched linksets are discarded.
+
+Both are plain `ExecutorDecorator`s. To attach your own — for example to harvest a stage's output and append extra measurements — pass a decorator via a factory's `decorate` option or the `voidStages()` `decorators` map. The decorator receives the stage's executor as its `inner` and returns a replacement; the stage's `execute()` call gives it the dataset endpoint, so it can fire its own follow-up queries. See [`composeDecorators`](../pipeline) in `@lde/pipeline` for the composition order.

--- a/packages/pipeline-void/src/stage.ts
+++ b/packages/pipeline-void/src/stage.ts
@@ -120,7 +120,7 @@ export interface VoidStagesOptions extends PerClassVoidStageOptions {
 }
 
 async function createVoidStage(
-  filename: string,
+  filename: VoidStageName,
   options?: VoidStageOptions &
     DecoratableStageOptions & {
       /** Decorator the stage itself applies, e.g. URI space or vocabulary detection. */
@@ -182,49 +182,49 @@ function classSelector(): ItemSelector {
 export function subjectUriSpaces(
   options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('subject-uri-space.rq', options);
+  return createVoidStage(VOID_STAGE_NAMES.subjectUriSpace, options);
 }
 
 export function classPartitions(
   options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('class-partition.rq', options);
+  return createVoidStage(VOID_STAGE_NAMES.classPartition, options);
 }
 
 export function countObjectLiterals(
   options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('object-literals.rq', options);
+  return createVoidStage(VOID_STAGE_NAMES.objectLiterals, options);
 }
 
 export function countObjectUris(
   options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('object-uris.rq', options);
+  return createVoidStage(VOID_STAGE_NAMES.objectUris, options);
 }
 
 export function countProperties(
   options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('properties.rq', options);
+  return createVoidStage(VOID_STAGE_NAMES.properties, options);
 }
 
 export function countSubjects(
   options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('subjects.rq', options);
+  return createVoidStage(VOID_STAGE_NAMES.subjects, options);
 }
 
 export function countTriples(
   options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('triples.rq', options);
+  return createVoidStage(VOID_STAGE_NAMES.triples, options);
 }
 
 export function classPropertySubjects(
   options?: PerClassVoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('class-properties-subjects.rq', {
+  return createVoidStage(VOID_STAGE_NAMES.classPropertiesSubjects, {
     ...options,
     perClass: options?.perClass ?? true,
   });
@@ -233,7 +233,7 @@ export function classPropertySubjects(
 export function classPropertyObjects(
   options?: PerClassVoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('class-properties-objects.rq', {
+  return createVoidStage(VOID_STAGE_NAMES.classPropertiesObjects, {
     ...options,
     perClass: options?.perClass ?? true,
   });
@@ -242,13 +242,13 @@ export function classPropertyObjects(
 export function countDatatypes(
   options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('datatypes.rq', options);
+  return createVoidStage(VOID_STAGE_NAMES.datatypes, options);
 }
 
 export function detectLicenses(
   options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('licenses.rq', options);
+  return createVoidStage(VOID_STAGE_NAMES.licenses, options);
 }
 
 // Per-class stages
@@ -256,7 +256,7 @@ export function detectLicenses(
 export function perClassObjectClasses(
   options?: PerClassVoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('class-property-object-classes.rq', {
+  return createVoidStage(VOID_STAGE_NAMES.classPropertyObjectClasses, {
     ...options,
     perClass: options?.perClass ?? true,
   });
@@ -265,7 +265,7 @@ export function perClassObjectClasses(
 export function perClassDatatypes(
   options?: PerClassVoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('class-property-datatypes.rq', {
+  return createVoidStage(VOID_STAGE_NAMES.classPropertyDatatypes, {
     ...options,
     perClass: options?.perClass ?? true,
   });
@@ -274,7 +274,7 @@ export function perClassDatatypes(
 export function perClassLanguages(
   options?: PerClassVoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('class-property-languages.rq', {
+  return createVoidStage(VOID_STAGE_NAMES.classPropertyLanguages, {
     ...options,
     perClass: options?.perClass ?? true,
   });
@@ -286,7 +286,7 @@ export function uriSpaces(
   uriSpaceMap: ReadonlyMap<string, readonly Quad[]>,
   options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('object-uri-space.rq', {
+  return createVoidStage(VOID_STAGE_NAMES.objectUriSpace, {
     ...options,
     builtIn: (inner) => new UriSpaceExecutor(inner, uriSpaceMap),
   });
@@ -300,7 +300,7 @@ export interface DetectVocabulariesOptions extends VoidStageOptions {
 export function detectVocabularies(
   options?: DetectVocabulariesOptions & DecoratableStageOptions,
 ): Promise<Stage> {
-  return createVoidStage('entity-properties.rq', {
+  return createVoidStage(VOID_STAGE_NAMES.entityProperties, {
     ...options,
     builtIn: (inner) =>
       new VocabularyExecutor(
@@ -330,46 +330,69 @@ export async function voidStages(
     ...stageOptions
   } = options ?? {};
 
-  // Route the bundle's per-stage decorator into the matching stage's `decorate`.
-  const withDecorator = (name: VoidStageName) => ({
-    ...stageOptions,
-    decorate: decorators?.[name],
-  });
-
-  return Promise.all([
+  // Single ordered source of truth for the bundle: each entry pairs a stage
+  // name with the factory that builds it. The decorator is routed by the same
+  // `name` the factory is bound to, so a consumer decorator can never reach the
+  // wrong stage. Order matters — `classPartition` warms the `?s a ?class` cache
+  // before the per-class stages run.
+  const builders: {
+    name: VoidStageName;
+    build: (
+      perStageOptions: PerClassVoidStageOptions & DecoratableStageOptions,
+    ) => Promise<Stage>;
+  }[] = [
     // Global counting stages.
-    countSubjects(withDecorator(VOID_STAGE_NAMES.subjects)),
-    countProperties(withDecorator(VOID_STAGE_NAMES.properties)),
-    countObjectLiterals(withDecorator(VOID_STAGE_NAMES.objectLiterals)),
-    countObjectUris(withDecorator(VOID_STAGE_NAMES.objectUris)),
-    countDatatypes(withDecorator(VOID_STAGE_NAMES.datatypes)),
-    countTriples(withDecorator(VOID_STAGE_NAMES.triples)),
+    { name: VOID_STAGE_NAMES.subjects, build: countSubjects },
+    { name: VOID_STAGE_NAMES.properties, build: countProperties },
+    { name: VOID_STAGE_NAMES.objectLiterals, build: countObjectLiterals },
+    { name: VOID_STAGE_NAMES.objectUris, build: countObjectUris },
+    { name: VOID_STAGE_NAMES.datatypes, build: countDatatypes },
+    { name: VOID_STAGE_NAMES.triples, build: countTriples },
 
     // Cache warming — must precede per-class stages.
-    classPartitions(withDecorator(VOID_STAGE_NAMES.classPartition)),
+    { name: VOID_STAGE_NAMES.classPartition, build: classPartitions },
 
     // Per-class stages.
-    classPropertySubjects(
-      withDecorator(VOID_STAGE_NAMES.classPropertiesSubjects),
-    ),
-    classPropertyObjects(
-      withDecorator(VOID_STAGE_NAMES.classPropertiesObjects),
-    ),
-    perClassDatatypes(withDecorator(VOID_STAGE_NAMES.classPropertyDatatypes)),
-    perClassObjectClasses(
-      withDecorator(VOID_STAGE_NAMES.classPropertyObjectClasses),
-    ),
-    perClassLanguages(withDecorator(VOID_STAGE_NAMES.classPropertyLanguages)),
+    {
+      name: VOID_STAGE_NAMES.classPropertiesSubjects,
+      build: classPropertySubjects,
+    },
+    {
+      name: VOID_STAGE_NAMES.classPropertiesObjects,
+      build: classPropertyObjects,
+    },
+    { name: VOID_STAGE_NAMES.classPropertyDatatypes, build: perClassDatatypes },
+    {
+      name: VOID_STAGE_NAMES.classPropertyObjectClasses,
+      build: perClassObjectClasses,
+    },
+    {
+      name: VOID_STAGE_NAMES.classPropertyLanguages,
+      build: perClassLanguages,
+    },
 
     // Other stages.
-    detectLicenses(withDecorator(VOID_STAGE_NAMES.licenses)),
-    detectVocabularies({
-      ...withDecorator(VOID_STAGE_NAMES.entityProperties),
-      vocabularies,
-    }),
-    subjectUriSpaces(withDecorator(VOID_STAGE_NAMES.subjectUriSpace)),
+    { name: VOID_STAGE_NAMES.licenses, build: detectLicenses },
+    {
+      name: VOID_STAGE_NAMES.entityProperties,
+      build: (perStageOptions) =>
+        detectVocabularies({ ...perStageOptions, vocabularies }),
+    },
+    { name: VOID_STAGE_NAMES.subjectUriSpace, build: subjectUriSpaces },
     ...(uriSpaceMap
-      ? [uriSpaces(uriSpaceMap, withDecorator(VOID_STAGE_NAMES.objectUriSpace))]
+      ? [
+          {
+            name: VOID_STAGE_NAMES.objectUriSpace,
+            build: (perStageOptions: DecoratableStageOptions) =>
+              uriSpaces(uriSpaceMap, perStageOptions),
+          },
+        ]
       : []),
-  ]);
+  ];
+
+  return Promise.all(
+    builders.map(({ name, build }) =>
+      build({ ...stageOptions, decorate: decorators?.[name] }),
+    ),
+  );
 }

--- a/packages/pipeline-void/src/stage.ts
+++ b/packages/pipeline-void/src/stage.ts
@@ -121,13 +121,10 @@ export interface VoidStagesOptions extends PerClassVoidStageOptions {
 
 async function createVoidStage(
   filename: VoidStageName,
-  options?: VoidStageOptions &
+  options?: PerClassVoidStageOptions &
     DecoratableStageOptions & {
       /** Decorator the stage itself applies, e.g. URI space or vocabulary detection. */
       builtIn?: ExecutorDecorator;
-      perClass?: boolean;
-      batchSize?: number;
-      maxConcurrency?: number;
     },
 ): Promise<Stage> {
   const query = await readQueryFile(resolve(queriesDir, filename));

--- a/packages/pipeline-void/src/stage.ts
+++ b/packages/pipeline-void/src/stage.ts
@@ -2,8 +2,9 @@ import {
   Stage,
   SparqlConstructExecutor,
   SparqlItemSelector,
+  composeDecorators,
   readQueryFile,
-  type Executor,
+  type ExecutorDecorator,
   type ItemSelector,
 } from '@lde/pipeline';
 import { assertSafeIri } from '@lde/dataset';
@@ -23,6 +24,38 @@ const queriesDir = resolve(
 );
 
 /**
+ * Stable names of the individual VoID stages, keyed by a readable identifier
+ * and valued by the query filename used as the stage name.
+ *
+ * Consumers reference these keys when targeting a specific stage — for example
+ * to route an {@link ExecutorDecorator} through {@link VoidStagesOptions.decorators}
+ * — so they never have to hard-code a `.rq` filename and an invalid key becomes
+ * a compile error rather than a silent no-op.
+ */
+export const VOID_STAGE_NAMES = {
+  subjects: 'subjects.rq',
+  properties: 'properties.rq',
+  objectLiterals: 'object-literals.rq',
+  objectUris: 'object-uris.rq',
+  datatypes: 'datatypes.rq',
+  triples: 'triples.rq',
+  classPartition: 'class-partition.rq',
+  classPropertiesSubjects: 'class-properties-subjects.rq',
+  classPropertiesObjects: 'class-properties-objects.rq',
+  classPropertyDatatypes: 'class-property-datatypes.rq',
+  classPropertyObjectClasses: 'class-property-object-classes.rq',
+  classPropertyLanguages: 'class-property-languages.rq',
+  licenses: 'licenses.rq',
+  entityProperties: 'entity-properties.rq',
+  subjectUriSpace: 'subject-uri-space.rq',
+  objectUriSpace: 'object-uri-space.rq',
+} as const;
+
+/** The name (query filename) of one VoID stage. */
+export type VoidStageName =
+  (typeof VOID_STAGE_NAMES)[keyof typeof VOID_STAGE_NAMES];
+
+/**
  * Options for configuring VoID stage execution.
  *
  * Per-request timeouts are configured at the {@link Pipeline} level via
@@ -32,6 +65,24 @@ const queriesDir = resolve(
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
 export interface VoidStageOptions {}
+
+/**
+ * Mix-in for the standalone per-stage functions, letting a single stage be
+ * decorated in isolation.
+ *
+ * Kept off the base {@link VoidStageOptions} on purpose: {@link VoidStagesOptions}
+ * extends that base, and a lone `decorate` there would be ambiguous about which
+ * of the many stages it targets. The bundle uses {@link VoidStagesOptions.decorators}
+ * — keyed per stage — instead.
+ */
+export interface DecoratableStageOptions {
+  /**
+   * Wraps this stage's executor. The stage always builds its own default
+   * executor (including any built-in decorator); this wraps it from the
+   * outside. See {@link ExecutorDecorator} for the scope contract.
+   */
+  decorate?: ExecutorDecorator;
+}
 
 /**
  * Options for per-class VoID stages that iterate over classes.
@@ -56,20 +107,34 @@ export interface VoidStagesOptions extends PerClassVoidStageOptions {
   uriSpaces?: ReadonlyMap<string, readonly Quad[]>;
   /** Additional vocabulary namespace URIs to detect beyond the built-in defaults. */
   vocabularies?: readonly string[];
+  /**
+   * Per-stage executor decorators, keyed by {@link VoidStageName}.
+   *
+   * Each decorator wraps the matching stage's executor from the outside,
+   * composing over any built-in decorator the stage applies (e.g. the URI space
+   * aggregator or vocabulary detector) rather than replacing it. Use
+   * {@link VOID_STAGE_NAMES} for the keys so an invalid stage name is a compile
+   * error.
+   */
+  decorators?: Partial<Record<VoidStageName, ExecutorDecorator>>;
 }
 
 async function createVoidStage(
   filename: string,
-  options?: VoidStageOptions & {
-    executor?: (query: string) => Executor;
-    perClass?: boolean;
-    batchSize?: number;
-    maxConcurrency?: number;
-  },
+  options?: VoidStageOptions &
+    DecoratableStageOptions & {
+      /** Decorator the stage itself applies, e.g. URI space or vocabulary detection. */
+      builtIn?: ExecutorDecorator;
+      perClass?: boolean;
+      batchSize?: number;
+      maxConcurrency?: number;
+    },
 ): Promise<Stage> {
   const query = await readQueryFile(resolve(queriesDir, filename));
-  const executor =
-    options?.executor?.(query) ?? new SparqlConstructExecutor({ query });
+  // Built-in decorator wraps the base executor; the consumer's decorator wraps
+  // that, so it composes over (never clobbers) any built-in behaviour.
+  const decorate = composeDecorators(options?.builtIn, options?.decorate);
+  const executor = decorate(new SparqlConstructExecutor({ query }));
 
   if (options?.perClass) {
     return new Stage({
@@ -114,38 +179,50 @@ function classSelector(): ItemSelector {
 
 // Global stages
 
-export function subjectUriSpaces(options?: VoidStageOptions): Promise<Stage> {
+export function subjectUriSpaces(
+  options?: VoidStageOptions & DecoratableStageOptions,
+): Promise<Stage> {
   return createVoidStage('subject-uri-space.rq', options);
 }
 
-export function classPartitions(options?: VoidStageOptions): Promise<Stage> {
+export function classPartitions(
+  options?: VoidStageOptions & DecoratableStageOptions,
+): Promise<Stage> {
   return createVoidStage('class-partition.rq', options);
 }
 
 export function countObjectLiterals(
-  options?: VoidStageOptions,
+  options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
   return createVoidStage('object-literals.rq', options);
 }
 
-export function countObjectUris(options?: VoidStageOptions): Promise<Stage> {
+export function countObjectUris(
+  options?: VoidStageOptions & DecoratableStageOptions,
+): Promise<Stage> {
   return createVoidStage('object-uris.rq', options);
 }
 
-export function countProperties(options?: VoidStageOptions): Promise<Stage> {
+export function countProperties(
+  options?: VoidStageOptions & DecoratableStageOptions,
+): Promise<Stage> {
   return createVoidStage('properties.rq', options);
 }
 
-export function countSubjects(options?: VoidStageOptions): Promise<Stage> {
+export function countSubjects(
+  options?: VoidStageOptions & DecoratableStageOptions,
+): Promise<Stage> {
   return createVoidStage('subjects.rq', options);
 }
 
-export function countTriples(options?: VoidStageOptions): Promise<Stage> {
+export function countTriples(
+  options?: VoidStageOptions & DecoratableStageOptions,
+): Promise<Stage> {
   return createVoidStage('triples.rq', options);
 }
 
 export function classPropertySubjects(
-  options?: PerClassVoidStageOptions,
+  options?: PerClassVoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
   return createVoidStage('class-properties-subjects.rq', {
     ...options,
@@ -154,7 +231,7 @@ export function classPropertySubjects(
 }
 
 export function classPropertyObjects(
-  options?: PerClassVoidStageOptions,
+  options?: PerClassVoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
   return createVoidStage('class-properties-objects.rq', {
     ...options,
@@ -162,18 +239,22 @@ export function classPropertyObjects(
   });
 }
 
-export function countDatatypes(options?: VoidStageOptions): Promise<Stage> {
+export function countDatatypes(
+  options?: VoidStageOptions & DecoratableStageOptions,
+): Promise<Stage> {
   return createVoidStage('datatypes.rq', options);
 }
 
-export function detectLicenses(options?: VoidStageOptions): Promise<Stage> {
+export function detectLicenses(
+  options?: VoidStageOptions & DecoratableStageOptions,
+): Promise<Stage> {
   return createVoidStage('licenses.rq', options);
 }
 
 // Per-class stages
 
 export function perClassObjectClasses(
-  options?: PerClassVoidStageOptions,
+  options?: PerClassVoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
   return createVoidStage('class-property-object-classes.rq', {
     ...options,
@@ -182,7 +263,7 @@ export function perClassObjectClasses(
 }
 
 export function perClassDatatypes(
-  options?: PerClassVoidStageOptions,
+  options?: PerClassVoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
   return createVoidStage('class-property-datatypes.rq', {
     ...options,
@@ -191,7 +272,7 @@ export function perClassDatatypes(
 }
 
 export function perClassLanguages(
-  options?: PerClassVoidStageOptions,
+  options?: PerClassVoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
   return createVoidStage('class-property-languages.rq', {
     ...options,
@@ -203,12 +284,11 @@ export function perClassLanguages(
 
 export function uriSpaces(
   uriSpaceMap: ReadonlyMap<string, readonly Quad[]>,
-  options?: VoidStageOptions,
+  options?: VoidStageOptions & DecoratableStageOptions,
 ): Promise<Stage> {
   return createVoidStage('object-uri-space.rq', {
     ...options,
-    executor: (query) =>
-      new UriSpaceExecutor(new SparqlConstructExecutor({ query }), uriSpaceMap),
+    builtIn: (inner) => new UriSpaceExecutor(inner, uriSpaceMap),
   });
 }
 
@@ -218,13 +298,13 @@ export interface DetectVocabulariesOptions extends VoidStageOptions {
 }
 
 export function detectVocabularies(
-  options?: DetectVocabulariesOptions,
+  options?: DetectVocabulariesOptions & DecoratableStageOptions,
 ): Promise<Stage> {
   return createVoidStage('entity-properties.rq', {
     ...options,
-    executor: (query) =>
+    builtIn: (inner) =>
       new VocabularyExecutor(
-        new SparqlConstructExecutor({ query }),
+        inner,
         options?.vocabularies
           ? [...defaultVocabularies, ...options.vocabularies]
           : undefined,
@@ -246,32 +326,50 @@ export async function voidStages(
   const {
     uriSpaces: uriSpaceMap,
     vocabularies,
+    decorators,
     ...stageOptions
   } = options ?? {};
 
+  // Route the bundle's per-stage decorator into the matching stage's `decorate`.
+  const withDecorator = (name: VoidStageName) => ({
+    ...stageOptions,
+    decorate: decorators?.[name],
+  });
+
   return Promise.all([
     // Global counting stages.
-    countSubjects(stageOptions),
-    countProperties(stageOptions),
-    countObjectLiterals(stageOptions),
-    countObjectUris(stageOptions),
-    countDatatypes(stageOptions),
-    countTriples(stageOptions),
+    countSubjects(withDecorator(VOID_STAGE_NAMES.subjects)),
+    countProperties(withDecorator(VOID_STAGE_NAMES.properties)),
+    countObjectLiterals(withDecorator(VOID_STAGE_NAMES.objectLiterals)),
+    countObjectUris(withDecorator(VOID_STAGE_NAMES.objectUris)),
+    countDatatypes(withDecorator(VOID_STAGE_NAMES.datatypes)),
+    countTriples(withDecorator(VOID_STAGE_NAMES.triples)),
 
     // Cache warming — must precede per-class stages.
-    classPartitions(stageOptions),
+    classPartitions(withDecorator(VOID_STAGE_NAMES.classPartition)),
 
     // Per-class stages.
-    classPropertySubjects(stageOptions),
-    classPropertyObjects(stageOptions),
-    perClassDatatypes(stageOptions),
-    perClassObjectClasses(stageOptions),
-    perClassLanguages(stageOptions),
+    classPropertySubjects(
+      withDecorator(VOID_STAGE_NAMES.classPropertiesSubjects),
+    ),
+    classPropertyObjects(
+      withDecorator(VOID_STAGE_NAMES.classPropertiesObjects),
+    ),
+    perClassDatatypes(withDecorator(VOID_STAGE_NAMES.classPropertyDatatypes)),
+    perClassObjectClasses(
+      withDecorator(VOID_STAGE_NAMES.classPropertyObjectClasses),
+    ),
+    perClassLanguages(withDecorator(VOID_STAGE_NAMES.classPropertyLanguages)),
 
     // Other stages.
-    detectLicenses(stageOptions),
-    detectVocabularies({ ...stageOptions, vocabularies }),
-    subjectUriSpaces(stageOptions),
-    ...(uriSpaceMap ? [uriSpaces(uriSpaceMap, stageOptions)] : []),
+    detectLicenses(withDecorator(VOID_STAGE_NAMES.licenses)),
+    detectVocabularies({
+      ...withDecorator(VOID_STAGE_NAMES.entityProperties),
+      vocabularies,
+    }),
+    subjectUriSpaces(withDecorator(VOID_STAGE_NAMES.subjectUriSpace)),
+    ...(uriSpaceMap
+      ? [uriSpaces(uriSpaceMap, withDecorator(VOID_STAGE_NAMES.objectUriSpace))]
+      : []),
   ]);
 }

--- a/packages/pipeline-void/test/stage.test.ts
+++ b/packages/pipeline-void/test/stage.test.ts
@@ -1,0 +1,112 @@
+import {
+  voidStages,
+  countSubjects,
+  uriSpaces,
+  detectVocabularies,
+  classPropertySubjects,
+  UriSpaceExecutor,
+  VocabularyExecutor,
+  VOID_STAGE_NAMES,
+} from '../src/index.js';
+import { SparqlConstructExecutor } from '@lde/pipeline';
+import type { Executor } from '@lde/pipeline';
+import { describe, it, expect, vi } from 'vitest';
+import { DataFactory } from 'n3';
+
+const { namedNode, quad, literal } = DataFactory;
+
+const uriSpaceMap = new Map([
+  [
+    'http://vocab.getty.edu/aat/',
+    [
+      quad(
+        namedNode('https://data.getty.edu/'),
+        namedNode('http://purl.org/dc/terms/title'),
+        literal('Art & Architecture Thesaurus', 'en'),
+      ),
+    ],
+  ],
+]);
+
+describe('voidStages', () => {
+  it('builds a stage per query, named after the query file', async () => {
+    const stages = await voidStages();
+    const names = stages.map((stage) => stage.name);
+
+    expect(names).toContain(VOID_STAGE_NAMES.subjects);
+    expect(names).toContain(VOID_STAGE_NAMES.entityProperties);
+    // The object URI space stage is only added when a URI space map is given.
+    expect(names).not.toContain(VOID_STAGE_NAMES.objectUriSpace);
+  });
+
+  it('includes the object URI space stage when a URI space map is given', async () => {
+    const stages = await voidStages({ uriSpaces: uriSpaceMap });
+    expect(stages.map((stage) => stage.name)).toContain(
+      VOID_STAGE_NAMES.objectUriSpace,
+    );
+  });
+
+  it('routes a per-stage decorator to the matching stage only', async () => {
+    const decorate = vi.fn((inner: Executor) => inner);
+
+    await voidStages({
+      decorators: { [VOID_STAGE_NAMES.subjects]: decorate },
+    });
+
+    expect(decorate).toHaveBeenCalledTimes(1);
+    // The decorator wraps the stage's own SparqlConstructExecutor.
+    expect(decorate.mock.calls[0][0]).toBeInstanceOf(SparqlConstructExecutor);
+  });
+
+  it('composes a consumer decorator outside the built-in URI space decorator', async () => {
+    const decorate = vi.fn((inner: Executor) => inner);
+
+    await voidStages({
+      uriSpaces: uriSpaceMap,
+      decorators: { [VOID_STAGE_NAMES.objectUriSpace]: decorate },
+    });
+
+    expect(decorate).toHaveBeenCalledTimes(1);
+    // Consumer is outermost: its inner is the built-in UriSpaceExecutor.
+    expect(decorate.mock.calls[0][0]).toBeInstanceOf(UriSpaceExecutor);
+  });
+
+  it('composes a consumer decorator outside the built-in vocabulary decorator', async () => {
+    const decorate = vi.fn((inner: Executor) => inner);
+
+    await voidStages({
+      decorators: { [VOID_STAGE_NAMES.entityProperties]: decorate },
+    });
+
+    expect(decorate).toHaveBeenCalledTimes(1);
+    expect(decorate.mock.calls[0][0]).toBeInstanceOf(VocabularyExecutor);
+  });
+});
+
+describe('standalone stage functions', () => {
+  it('decorate wraps the plain CONSTRUCT executor of a global stage', async () => {
+    const decorate = vi.fn((inner: Executor) => inner);
+    await countSubjects({ decorate });
+
+    expect(decorate.mock.calls[0][0]).toBeInstanceOf(SparqlConstructExecutor);
+  });
+
+  it('decorate wraps the built-in URI space decorator', async () => {
+    const decorate = vi.fn((inner: Executor) => inner);
+    await uriSpaces(uriSpaceMap, { decorate });
+
+    expect(decorate.mock.calls[0][0]).toBeInstanceOf(UriSpaceExecutor);
+  });
+
+  it('decorate wraps the built-in vocabulary decorator', async () => {
+    const decorate = vi.fn((inner: Executor) => inner);
+    await detectVocabularies({ decorate });
+
+    expect(decorate.mock.calls[0][0]).toBeInstanceOf(VocabularyExecutor);
+  });
+
+  it('builds a per-class stage by default', async () => {
+    const stage = await classPropertySubjects();
+    expect(stage.name).toBe(VOID_STAGE_NAMES.classPropertiesSubjects);
+  });
+});

--- a/packages/pipeline-void/vite.config.ts
+++ b/packages/pipeline-void/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
     test: {
       coverage: {
         thresholds: {
-          functions: 96.77,
-          lines: 93.33,
+          functions: 96.96,
+          lines: 93.51,
           branches: 87.8,
-          statements: 93.51,
+          statements: 93.63,
         },
       },
     },

--- a/packages/pipeline-void/vite.config.ts
+++ b/packages/pipeline-void/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
     test: {
       coverage: {
         thresholds: {
-          functions: 50,
-          lines: 78.43,
-          branches: 67.44,
-          statements: 78.84,
+          functions: 96.77,
+          lines: 93.33,
+          branches: 87.8,
+          statements: 93.51,
         },
       },
     },

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -208,6 +208,16 @@ new Stage({
 
 This keeps SPARQL doing the heavy lifting while TypeScript handles the edge cases. See [@lde/pipeline-void](../pipeline-void)'s `VocabularyExecutor` for a real-world example of this pattern.
 
+When a stage applies its own decorator and also exposes the seam to consumers, both should wrap the same executor rather than clobber one another. An `ExecutorDecorator` is just `(inner: Executor) => Executor`, and `composeDecorators(...)` folds several into one, applied innermost-first so the last argument ends up outermost. `undefined` entries are skipped, so optional decorators pass straight through:
+
+```typescript
+import { composeDecorators } from '@lde/pipeline';
+
+// base → built-in → consumer (consumer outermost, undefined is a no-op)
+const decorate = composeDecorators(builtIn, consumer);
+const executor = decorate(new SparqlConstructExecutor({ query }));
+```
+
 #### Adaptive timeouts
 
 By default, every SPARQL request uses the same 5-minute budget. When a pipeline runs against many third-party endpoints, that fixed budget can cost ~80 minutes on a single dataset whose endpoint times out repeatedly on heavy queries — light stages on the same endpoint then sit behind the heavy ones that will never succeed.

--- a/packages/pipeline/src/sparql/executorDecorator.ts
+++ b/packages/pipeline/src/sparql/executorDecorator.ts
@@ -1,0 +1,56 @@
+import type { Executor } from './executor.js';
+
+/**
+ * Wraps an {@link Executor} to augment its behaviour.
+ *
+ * A decorator receives the inner executor it wraps and returns a new executor.
+ * It never reads the underlying query — its capabilities are the inner
+ * executor plus the {@link Dataset}/{@link Distribution}/{@link ExecuteOptions}
+ * handed to `execute()` at call time. That `Distribution` is what gives a
+ * decorator reach beyond a plain quad transform: it can fire its own queries
+ * against the dataset endpoint, honour the named graph and subject filter, and
+ * thread the per-call {@link TimeoutPolicy} through.
+ *
+ * **Scope contract.** A decorator wraps a single `execute()` call. For a global
+ * (non-per-class) stage that one call yields the whole stage output, so the
+ * decorator sees the complete result set — the aggregation window needed to,
+ * for example, pick the single most common namespace. For a per-class stage
+ * each call covers one batch of class bindings, so a decorator there sees only
+ * that batch. Per-class decoration is permitted but caveated: aggregate across
+ * the whole dataset only in a global stage.
+ *
+ * The framework hands the decorator its capabilities; it does not police what
+ * the decorator emits. A decorator may pass the inner output through and append
+ * (additive, like the vocabulary detector) or replace it entirely (like the URI
+ * space aggregator).
+ */
+export type ExecutorDecorator = (inner: Executor) => Executor;
+
+/**
+ * Fold several {@link ExecutorDecorator}s into one, applied innermost-first.
+ *
+ * Decorators are applied left to right, so the first argument wraps the base
+ * executor and each later decorator wraps the result of the previous one. The
+ * last argument therefore ends up outermost. This makes the composition order
+ * explicit and well-defined: a consumer decorator passed after a built-in one
+ * wraps the built-in rather than silently clobbering it.
+ *
+ * `undefined` entries are skipped, so optional decorators can be passed
+ * straight through without guarding each one at the call site.
+ *
+ * @example
+ * ```typescript
+ * // base → built-in → consumer (consumer outermost)
+ * const decorate = composeDecorators(builtIn, consumer);
+ * const executor = decorate(new SparqlConstructExecutor({ query }));
+ * ```
+ */
+export function composeDecorators(
+  ...decorators: (ExecutorDecorator | undefined)[]
+): ExecutorDecorator {
+  return (inner) =>
+    decorators.reduce<Executor>(
+      (executor, decorate) => (decorate ? decorate(executor) : executor),
+      inner,
+    );
+}

--- a/packages/pipeline/src/sparql/index.ts
+++ b/packages/pipeline/src/sparql/index.ts
@@ -10,6 +10,10 @@ export {
   type VariableBindings,
 } from './executor.js';
 export {
+  composeDecorators,
+  type ExecutorDecorator,
+} from './executorDecorator.js';
+export {
   SparqlItemSelector,
   type SparqlItemSelectorOptions,
 } from './selector.js';

--- a/packages/pipeline/test/sparql/executorDecorator.test.ts
+++ b/packages/pipeline/test/sparql/executorDecorator.test.ts
@@ -1,0 +1,58 @@
+import { composeDecorators } from '../../src/index.js';
+import type { Executor, ExecutorDecorator } from '../../src/index.js';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * A trivial executor whose identity we can track through decoration. Its
+ * `execute()` is never called in these tests — composition only rewires which
+ * executor wraps which, so identity is all we need to assert on.
+ */
+function namedExecutor(name: string): Executor & { name: string } {
+  return {
+    name,
+    async execute() {
+      return new (class {
+        message = name;
+      })() as never;
+    },
+  };
+}
+
+/** Records the order in which decorators see their inner executor. */
+function tagging(tag: string, order: string[]): ExecutorDecorator {
+  return (inner) => {
+    order.push(tag);
+    return { ...inner, execute: inner.execute.bind(inner) };
+  };
+}
+
+describe('composeDecorators', () => {
+  it('returns the base executor unchanged when no decorators are given', () => {
+    const base = namedExecutor('base');
+    expect(composeDecorators()(base)).toBe(base);
+  });
+
+  it('applies decorators innermost-first, last argument outermost', () => {
+    const order: string[] = [];
+    const base = namedExecutor('base');
+
+    composeDecorators(tagging('inner', order), tagging('outer', order))(base);
+
+    // The first argument wraps the base first, then the second wraps that.
+    expect(order).toEqual(['inner', 'outer']);
+  });
+
+  it('skips undefined decorators', () => {
+    const order: string[] = [];
+    const base = namedExecutor('base');
+
+    composeDecorators(undefined, tagging('only', order), undefined)(base);
+
+    expect(order).toEqual(['only']);
+  });
+
+  it('returns the base executor untouched when every decorator is undefined', () => {
+    const base = namedExecutor('base');
+    expect(composeDecorators(undefined, undefined)(base)).toBe(base);
+  });
+});

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 94.3,
-          lines: 93.66,
-          branches: 88.97,
-          statements: 93.19,
+          functions: 94.4,
+          lines: 93.69,
+          branches: 89.02,
+          statements: 93.21,
         },
       },
     },


### PR DESCRIPTION
Implements the design agreed in the authoritative comment on the issue: a typed **executor decorator seam** for VoID stages, with the reusable vocabulary living in the pipeline core. The seam is a decorator `(inner) => inner`, not a query factory; stage keying is type-checked; and the framework composes a consumer decorator *over* any built-in one instead of letting it clobber.

## `@lde/pipeline` (core)

- Add `ExecutorDecorator` (`(inner: Executor) => Executor`) and `composeDecorators(...)`, which folds decorators innermost-first — the last argument ends up outermost — and skips `undefined` entries. JSDoc documents the scope contract: a decorator wraps a single `execute()` call (whole output for a global stage, one batch for a per-class stage) and gets the dataset endpoint via the `Distribution`, so it can fire its own follow-up queries.

## `@lde/pipeline-void`

- Add `VOID_STAGE_NAMES` constants and the `VoidStageName` type so a stage is targeted by a type-checked key — an invalid key is a compile error and consumers never hard-code a `.rq` filename.
- Add `DecoratableStageOptions` (`decorate?`) to every per-stage factory, kept *off* the base `VoidStageOptions` so it does not leak onto the bundle surface.
- Add a `decorators?: Partial<Record<VoidStageName, ExecutorDecorator>>` map to `VoidStagesOptions`; `voidStages()` routes each entry into the matching stage's `decorate`.
- `createVoidStage` now always builds its own `SparqlConstructExecutor` and applies `composeDecorators(builtIn, consumer)` — consumer outermost.
- Move `uriSpaces` and `detectVocabularies` onto `ExecutorDecorator` built-ins, so decorating those stages wraps `UriSpaceExecutor` / `VocabularyExecutor` rather than replacing it.

## Why not a `QuadTransform` / `PipelinePlugin`

A `QuadTransform` has no `Distribution` (no endpoint reach) and no stage identity (it fires on every stage). A decorator that needs the endpoint or one specific stage belongs here; cross-cutting, pipeline-wide concerns stay with `PipelinePlugin`.

Both package READMEs document the seam, and the wiring is covered by new tests (pipeline-void `stage.ts` coverage rose from ~37% to ~95%).

The consumer side (`SubjectUriResolutionExecutor` in the dataset-knowledge-graph repo) lives elsewhere and is out of scope here — this PR lands the framework seam it needs.

Fix #434
