### PR TITLE
feat(sparql-qlever): support RDF/XML distributions on import

### DIFF
--- a/packages/sparql-qlever/src/importer.ts
+++ b/packages/sparql-qlever/src/importer.ts
@@ -291,8 +291,8 @@ const nativeFormats = new Map<string, fileFormat>([
 
 /**
  * Accepted distribution media types, in preference order: the first match is
- * tried first. Native formats win over JSON-LD because they skip the Node-side
- * preprocessor.
+ * tried first. Native formats win over JSON-LD and RDF/XML because they skip
+ * the Node-side preprocessor.
  *
  * `application/zip` is intentionally absent — the inner RDF format must be
  * declared via `mediaType` with `application/zip` appearing only as the
@@ -303,6 +303,7 @@ const acceptedMediaTypes: readonly string[] = [
   'application/n-triples',
   'text/turtle',
   'application/ld+json',
+  'application/rdf+xml',
 ];
 
 const defaultQleverIndexOptions = {

--- a/packages/sparql-qlever/src/preprocess.ts
+++ b/packages/sparql-qlever/src/preprocess.ts
@@ -11,11 +11,27 @@ import { promisify } from 'node:util';
 import yauzl from 'yauzl';
 
 const JSONLD_MIME = 'application/ld+json';
+const RDFXML_MIME = 'application/rdf+xml';
 const ZIP_MIME = 'application/zip';
 const GZIP_MIME = 'application/gzip';
 const GZIP_MIME_LEGACY = 'application/x-gzip';
 
-const JSONLD_ZIP_EXTENSIONS = ['.jsonld', '.json'];
+interface PreprocessFormat {
+  /** Human-readable label used in warnings and error messages. */
+  label: string;
+  /** Filename extensions that identify this format inside a zip container. */
+  zipExtensions: string[];
+}
+
+/**
+ * RDF media types that `qlever-index` cannot read natively, so they are streamed
+ * through `rdf-parse` → N-Quads first. The map key is the `rdf-parse`
+ * `contentType`; the value carries the metadata needed to handle zip containers.
+ */
+const preprocessFormats = new Map<string, PreprocessFormat>([
+  [JSONLD_MIME, { label: 'JSON-LD', zipExtensions: ['.jsonld', '.json'] }],
+  [RDFXML_MIME, { label: 'RDF/XML', zipExtensions: ['.rdf', '.xml', '.owl'] }],
+]);
 
 export interface PreprocessResult {
   /** Path to the file ready for `qlever-index`. Always N-Quads. */
@@ -28,8 +44,8 @@ export interface PreprocessResult {
  * Whether a distribution needs Node-side preprocessing before `qlever-index`
  * can read it.
  *
- * Only JSON-LD distributions return `true`: `qlever-index` cannot parse
- * JSON-LD, so we stream it through a JSON-LD parser into N-Quads first.
+ * JSON-LD and RDF/XML distributions return `true`: `qlever-index` cannot parse
+ * either, so we stream them through `rdf-parse` into N-Quads first.
  *
  * Native RDF formats (`nt`, `nq`, `ttl`) — including when wrapped in
  * `application/gzip` or `application/zip` — go straight through the shell
@@ -38,16 +54,20 @@ export interface PreprocessResult {
  * format must be declared.
  */
 export function needsPreprocessing(distribution: Distribution): boolean {
-  return distribution.mimeType === JSONLD_MIME;
+  return (
+    distribution.mimeType !== undefined &&
+    preprocessFormats.has(distribution.mimeType)
+  );
 }
 
 /**
- * Convert a JSON-LD distribution to N-Quads alongside the source file.
+ * Convert a JSON-LD or RDF/XML distribution to N-Quads alongside the source
+ * file.
  *
  * Streams the source through `rdf-parse` → `rdf-serialize` so memory use
  * stays bounded regardless of input size. Handles gzip transparently
  * (declared `compressFormat` or `.gz` filename) and zip containers (folds
- * each JSON-LD entry into the output stream in order).
+ * each matching entry into the output stream in order).
  *
  * Cached: if the output is newer than the input, it is reused as-is.
  */
@@ -55,7 +75,12 @@ export async function preprocess(
   localFile: string,
   distribution: Distribution,
 ): Promise<PreprocessResult> {
-  if (!needsPreprocessing(distribution)) {
+  const contentType = distribution.mimeType;
+  const format =
+    contentType === undefined
+      ? undefined
+      : preprocessFormats.get(contentType);
+  if (contentType === undefined || format === undefined) {
     throw new Error(
       `preprocess called for distribution that does not need preprocessing: mediaType=${distribution.mimeType}`,
     );
@@ -70,9 +95,9 @@ export async function preprocess(
   const warnings: string[] = [];
 
   if (distribution.compressMimeType === ZIP_MIME) {
-    await streamJsonldZip(localFile, outputFile, warnings);
+    await streamRdfZip(localFile, outputFile, contentType, format, warnings);
   } else {
-    await streamJsonldFile(localFile, outputFile, distribution);
+    await streamRdfFile(localFile, outputFile, contentType, distribution);
   }
 
   return { path: outputFile, format: 'nq', warnings };
@@ -94,15 +119,16 @@ async function outputIsUpToDate(
 }
 
 /**
- * Pipe one JSON-LD source through parse → N-Quads serialize into an already
+ * Pipe one RDF source through parse → N-Quads serialize into an already
  * open writable, without closing it. Back-pressure is handled by Node's
  * built-in `.pipe()`; the caller manages `output`'s lifecycle.
  */
-async function pipeJsonldToWritable(
+async function pipeRdfToWritable(
   input: Readable,
   output: WriteStream,
+  contentType: string,
 ): Promise<void> {
-  const quads = rdfParser.parse(input, { contentType: JSONLD_MIME });
+  const quads = rdfParser.parse(input, { contentType });
   const bytes = rdfSerializer.serialize(quads, {
     contentType: 'application/n-quads',
   }) as unknown as Readable;
@@ -118,9 +144,10 @@ async function closeWritable(output: WriteStream): Promise<void> {
   });
 }
 
-async function streamJsonldFile(
+async function streamRdfFile(
   localFile: string,
   outputFile: string,
+  contentType: string,
   distribution: Distribution,
 ): Promise<void> {
   const isGzipped =
@@ -131,7 +158,7 @@ async function streamJsonldFile(
   const input = isGzipped ? source.pipe(createGunzip()) : source;
   const output = createWriteStream(outputFile);
   try {
-    await pipeJsonldToWritable(input, output);
+    await pipeRdfToWritable(input, output, contentType);
   } finally {
     await closeWritable(output);
   }
@@ -142,9 +169,11 @@ const openZip = promisify(yauzl.open) as (
   options: yauzl.Options,
 ) => Promise<yauzl.ZipFile>;
 
-async function streamJsonldZip(
+async function streamRdfZip(
   zipFile: string,
   outputFile: string,
+  contentType: string,
+  format: PreprocessFormat,
   warnings: string[],
 ): Promise<void> {
   const zip = await openZip(zipFile, { lazyEntries: true });
@@ -162,15 +191,15 @@ async function streamJsonldZip(
               return;
             }
             const extension = extname(entry.fileName).toLowerCase();
-            if (!JSONLD_ZIP_EXTENSIONS.includes(extension)) {
+            if (!format.zipExtensions.includes(extension)) {
               warnings.push(
-                `Skipping zip entry ${entry.fileName}: extension ${extension || '(none)'} is not JSON-LD`,
+                `Skipping zip entry ${entry.fileName}: extension ${extension || '(none)'} is not ${format.label}`,
               );
               zip.readEntry();
               return;
             }
             const stream = await openZipEntry(zip, entry);
-            await pipeJsonldToWritable(stream, output);
+            await pipeRdfToWritable(stream, output, contentType);
             entriesProcessed++;
             zip.readEntry();
           } catch (error) {
@@ -186,7 +215,7 @@ async function streamJsonldZip(
   }
 
   if (entriesProcessed === 0) {
-    throw new Error(`Zip ${zipFile} contains no JSON-LD entries`);
+    throw new Error(`Zip ${zipFile} contains no ${format.label} entries`);
   }
 }
 

--- a/packages/sparql-qlever/test/fixtures/preprocess/data.rdf
+++ b/packages/sparql-qlever/test/fixtures/preprocess/data.rdf
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:schema="https://schema.org/">
+  <rdf:Description rdf:about="https://example.org/utrecht/story/1">
+    <rdf:type rdf:resource="https://schema.org/CreativeWork"/>
+    <schema:name>Een verhaal uit Utrecht</schema:name>
+    <schema:inLanguage>nl</schema:inLanguage>
+  </rdf:Description>
+</rdf:RDF>

--- a/packages/sparql-qlever/test/importer.test.ts
+++ b/packages/sparql-qlever/test/importer.test.ts
@@ -510,6 +510,33 @@ describe('Importer', () => {
       expect(runner.commands[0]).toContain('-F nq');
     });
 
+    it('runs RDF/XML through the preprocessor and indexes the resulting N-Quads', async () => {
+      const runner = stubTaskRunner(42);
+      const rdfFile = join(tempDir, 'data.rdf');
+      await copyFile(resolve('test/fixtures/preprocess/data.rdf'), rdfFile);
+      const importer = new Importer({
+        taskRunner: runner,
+        indexName,
+        downloader: {
+          async download() {
+            return { path: rdfFile, headers: new Headers() };
+          },
+        },
+      });
+
+      const result = await importer.import([
+        new Distribution(
+          new URL('https://example.com/data.rdf'),
+          'application/rdf+xml',
+        ),
+      ]);
+
+      expect(result).toBeInstanceOf(ImportSuccessful);
+      // The preprocessed N-Quads file is what reaches qlever-index.
+      expect(runner.commands[0]).toContain('data.rdf.preprocessed.nq');
+      expect(runner.commands[0]).toContain('-F nq');
+    });
+
     it('uses unzip -p in the shell pipeline for .zip files', async () => {
       const runner = stubTaskRunner(42);
       const zipFile = join(tempDir, 'data.nt.zip');

--- a/packages/sparql-qlever/test/preprocess.test.ts
+++ b/packages/sparql-qlever/test/preprocess.test.ts
@@ -58,6 +58,23 @@ describe('needsPreprocessing', () => {
     ).toBe(true);
   });
 
+  it('returns true for RDF/XML (plain or gzipped)', () => {
+    expect(needsPreprocessing(makeDistribution('application/rdf+xml'))).toBe(
+      true,
+    );
+    expect(
+      needsPreprocessing(
+        makeDistribution('application/rdf+xml', 'application/gzip'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when the distribution has no declared media type', () => {
+    expect(
+      needsPreprocessing(new Distribution(new URL('https://example.com/data'))),
+    ).toBe(false);
+  });
+
   it('returns false for native RDF wrapped in a zip — handled by the shell pipeline', () => {
     expect(
       needsPreprocessing(
@@ -90,6 +107,24 @@ describe('preprocess', () => {
     const result = await preprocess(
       file,
       makeDistribution('application/ld+json'),
+    );
+
+    expect(result.format).toBe('nq');
+    expect(result.path).toBe(`${file}.preprocessed.nq`);
+    const nquads = await readFile(result.path, 'utf-8');
+    expect(nquads).toContain('<https://example.org/utrecht/story/1>');
+    expect(nquads).toContain('Een verhaal uit Utrecht');
+    // N-Quads triples end with " ." on each line.
+    expect(nquads.trim().split('\n').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('converts plain RDF/XML to N-Quads', async () => {
+    const file = join(tempDir, 'data.rdf');
+    await copyFile(resolve('test/fixtures/preprocess/data.rdf'), file);
+
+    const result = await preprocess(
+      file,
+      makeDistribution('application/rdf+xml'),
     );
 
     expect(result.format).toBe('nq');
@@ -187,6 +222,15 @@ describe('preprocess', () => {
 
     await expect(
       preprocess(file, makeDistribution('application/n-triples')),
+    ).rejects.toThrow(/does not need preprocessing/);
+  });
+
+  it('throws when called for a distribution without a media type', async () => {
+    const file = join(tempDir, 'data');
+    await (await import('node:fs/promises')).writeFile(file, '');
+
+    await expect(
+      preprocess(file, new Distribution(new URL('https://example.com/data'))),
     ).rejects.toThrow(/does not need preprocessing/);
   });
 

--- a/packages/sparql-qlever/vite.config.ts
+++ b/packages/sparql-qlever/vite.config.ts
@@ -13,10 +13,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 95.55,
+          lines: 95.62,
           functions: 100,
-          branches: 83.87,
-          statements: 95.6,
+          branches: 84.84,
+          statements: 95.67,
         },
       },
     },


### PR DESCRIPTION
## Why

`@lde/sparql-qlever` only accepted `application/n-quads`, `application/n-triples`, `text/turtle` and `application/ld+json` on import. Any dataset whose only data dump is **RDF/XML** was silently dropped as `NotSupported`, so no VoID summary (Linked Data Summary) could be generated for it – even though RDF/XML is a perfectly valid, common RDF serialization.

This surfaced while investigating a dataset-register data-quality report (netwerk-digitaal-erfgoed/dataset-register#2029): the DAF Museum dataset publishes a valid 6.4 MB / ~74k-triple RDF/XML dump (its declared SPARQL endpoint is broken), but the DKG produced no summary purely because of the missing format support.

## What

- Add `application/rdf+xml` to the importer’s accepted media types (last in preference order, since like JSON-LD it needs Node-side preprocessing rather than native `qlever-index` parsing).
- Generalise the JSON-LD-only preprocessing path into a format-keyed map (`application/ld+json` → JSON-LD, `application/rdf+xml` → RDF/XML), each carrying its label and zip-entry extensions. The `rdf-parse` → `rdf-serialize` → N-Quads streaming pipeline is now driven by the distribution’s media type, so memory stays bounded regardless of input size.
- Handle plain, gzipped and zipped RDF/XML, mirroring the existing JSON-LD handling.
- Add tests (plain RDF/XML → N-Quads through both `preprocess` and the importer, plus media-type guards) and an RDF/XML fixture; refresh coverage thresholds.

## Notes

- No new dependencies: `rdf-parse` already ships the streaming RDF/XML parser.
- Refs netwerk-digitaal-erfgoed/dataset-register#2029 (cross-repo; DAF is fixed once the DKG re-runs with this release).
