### PR TITLE
fix(iiif-validator): skip downloading non-manifest binary media

### DIFF
--- a/packages/iiif-validator/src/validateManifest.ts
+++ b/packages/iiif-validator/src/validateManifest.ts
@@ -9,6 +9,7 @@ export type ManifestValidationReason =
   | 'network-error'
   | 'http-error'
   | 'invalid-json'
+  | 'binary-content'
   | 'not-a-manifest';
 
 /**
@@ -63,6 +64,17 @@ export async function validateManifest(
     return { valid: false, reason: 'http-error' };
   }
 
+  // A manifest is JSON. When the server announces a binary media type, skip
+  // reading the body: a sampled `schema:contentUrl` can dereference to the
+  // full-resolution image, audio or video asset, and `response.json()` would
+  // buffer the whole thing before failing to parse it — wasting bandwidth and
+  // time in the pipeline that calls this for every sampled manifest. Cancel the
+  // stream so the connection is freed without the download.
+  if (isBinaryMedia(response.headers.get('content-type'))) {
+    await response.body?.cancel();
+    return { valid: false, reason: 'binary-content' };
+  }
+
   let body: unknown;
   try {
     body = await response.json();
@@ -74,6 +86,22 @@ export async function validateManifest(
     return { valid: true, reason: 'valid-manifest' };
   }
   return { valid: false, reason: 'not-a-manifest' };
+}
+
+/**
+ * Whether a `Content-Type` header announces a binary media asset (image, audio
+ * or video) rather than a JSON document. Used to skip downloading non-manifest
+ * media. A missing or ambiguous type (e.g. `text/plain`, `application/octet-stream`)
+ * returns `false` so a manifest served with an odd type is still parsed.
+ */
+function isBinaryMedia(contentType: string | null): boolean {
+  if (contentType === null) return false;
+  const mediaType = contentType.toLowerCase();
+  return (
+    mediaType.startsWith('image/') ||
+    mediaType.startsWith('audio/') ||
+    mediaType.startsWith('video/')
+  );
 }
 
 /**

--- a/packages/iiif-validator/test/validateManifest.test.ts
+++ b/packages/iiif-validator/test/validateManifest.test.ts
@@ -123,6 +123,71 @@ describe('validateManifest', () => {
     expect(verdict).toEqual({ valid: false, reason: 'not-a-manifest' });
   });
 
+  it('reports binary-content without reading the body when the server announces an image', async () => {
+    // The body’s `json()` throws, so reaching it would surface as invalid-json;
+    // getting binary-content proves the content-type gate short-circuited before
+    // the body was buffered. `body.cancel()` frees the connection.
+    let bodyCancelled = false;
+    const fetch = (async () =>
+      ({
+        ok: true,
+        headers: new Headers({ 'Content-Type': 'image/jpeg' }),
+        body: {
+          cancel: async () => {
+            bodyCancelled = true;
+          },
+        },
+        json: async () => {
+          throw new Error('the body must not be read for binary media');
+        },
+      }) as unknown as Response) as typeof globalThis.fetch;
+
+    const verdict = await validateManifest(URL, { fetch });
+
+    expect(verdict).toEqual({ valid: false, reason: 'binary-content' });
+    expect(bodyCancelled).toBe(true);
+  });
+
+  it('reports binary-content for audio and video too, case-insensitively', async () => {
+    for (const contentType of ['audio/mpeg', 'video/mp4', 'IMAGE/PNG']) {
+      const fetch = fetchReturning('binary', { contentType });
+      const verdict = await validateManifest(URL, { fetch });
+      expect(verdict).toEqual({ valid: false, reason: 'binary-content' });
+    }
+  });
+
+  it('still parses a manifest served with an ambiguous content type', async () => {
+    const fetch = fetchReturning(
+      JSON.stringify({
+        '@context': 'http://iiif.io/api/presentation/3/context.json',
+        id: URL,
+        type: 'Manifest',
+      }),
+      { contentType: 'application/octet-stream' },
+    );
+
+    const verdict = await validateManifest(URL, { fetch });
+
+    expect(verdict).toEqual({ valid: true, reason: 'valid-manifest' });
+  });
+
+  it('parses the manifest when the server sends no content type', async () => {
+    const fetch = (async () =>
+      ({
+        ok: true,
+        headers: new Headers(),
+        json: async () => ({
+          '@context': 'http://iiif.io/api/presentation/3/context.json',
+          id: URL,
+          type: 'Manifest',
+        }),
+      }) as unknown as Response) as typeof globalThis.fetch;
+
+    const verdict = await validateManifest(URL, { fetch });
+
+    expect(verdict).toEqual({ valid: true, reason: 'valid-manifest' });
+  });
+
   it('reports timeout when the request aborts', async () => {
     const fetch = (async () => {
       throw new DOMException('The operation timed out.', 'TimeoutError');

--- a/packages/iiif-validator/vite.config.ts
+++ b/packages/iiif-validator/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 96.96,
+          lines: 97.43,
           functions: 100,
-          branches: 87.09,
-          statements: 94.59,
+          branches: 89.47,
+          statements: 95.45,
         },
       },
     },


### PR DESCRIPTION
## What

`validateManifest` dereferences a URL and checks whether it is a IIIF Presentation Manifest. It read the whole response body via `await response.json()` before deciding — so when the URL pointed at a binary asset (a full-resolution image, audio or video file) the entire payload was downloaded only to fail parsing.

This matters because the Dataset Knowledge Graph now samples `schema:contentUrl` IRIs (which routinely point at the asset itself) and calls this validator for every sampled manifest. Buffering full images on each probe wastes bandwidth and pipeline time.

## How

Gate on the `Content-Type` response header *before* reading the body. When the server announces a binary media type (`image/`, `audio/`, `video/`), cancel the response stream and return a new `binary-content` reason — no body is downloaded. A missing or ambiguous type (e.g. `text/plain`, `application/octet-stream`) still falls through to JSON parsing, so a manifest served with an odd content type is not rejected.

## Notes

- Additive change to the public `ManifestValidationReason` union (`binary-content`).
- New tests cover the gate (image/audio/video, case-insensitive), that the body is not read on the binary path, and that a manifest without a content type still parses. Coverage thresholds bumped upward by autoUpdate.
- Consumed by the DKG IIIF decoupling work (netwerk-digitaal-erfgoed/dataset-knowledge-graph#314).
