### PR TITLE
feat(distribution-probe): detect empty RDF distributions across serializations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40882,8 +40882,525 @@
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.4",
-        "n3": "^2.0.1",
+        "rdf-parse": "^5.0.0",
         "tslib": "^2.3.0"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-abstract-mediatyped": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-5.2.3.tgz",
+      "integrity": "sha512-9zgeR4U8cdB10Mb9VSOuhzJGiufSmjb1N+CwVMQY65gOjXPmfXcybFjzGFKPFbmYOsB2mmL1aht/AXzODlJcaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-abstract-parse": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-5.2.3.tgz",
+      "integrity": "sha512-/eEGBmJzbasYjjl+PVgCLQYNQXMt0Ni+sD9Xg+JQf+3oTa7MpfHSMZ6ZV++H3OufJaNid3gkUxZrufFm+k0giA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3",
+        "readable-stream": "^4.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-http-fetch": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-5.2.3.tgz",
+      "integrity": "sha512-VeTCcDVZdz+8cjNeuFO28eIP/HnWkLZmy+sm4i/juXzvBY5gS6LavFj+c1g0F7Foyu0i74rdIay5zMHbbGkrUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-time": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@types/http-cache-semantics": "^4.0.4",
+        "http-cache-semantics": "^4.2.0",
+        "undici": "^7.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-http-proxy": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-5.2.3.tgz",
+      "integrity": "sha512-x32prW0HYDBcl+b183twO6+XcC5I0jy2R5DuXRB2L1t57FMz60BLzmbjehPMHLb8XGPNY3gx5cNaezfFpbaoUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-time": "^5.2.3",
+        "@comunica/types": "^5.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-rdf-parse-html": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-5.2.3.tgz",
+      "integrity": "sha512-OwTATauDXLCFT1BALiF5XLbEm3V/SqKSYlO2TmJWnVyEKYs/smYOSfD+Vlh4Zy86goq7iSHPgJhnzL8EWlkj9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/bus-rdf-parse-html": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@rdfjs/types": "*",
+        "htmlparser2": "^10.0.0",
+        "readable-stream": "^4.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-rdf-parse-html-microdata": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-5.2.3.tgz",
+      "integrity": "sha512-XJOiNfb47AbYKZSv/mjCoDEd745JSiBTjwm/bHEO7tQuUgDCJPSSLVyNjfVEulsQKpqacF9ZGWQ8+iZyuGm2uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "microdata-rdf-streaming-parser": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-5.2.3.tgz",
+      "integrity": "sha512-8NnVJX/f1sv9WzHwMjFgfuhi2m1NLPa7eo/0N/4YpZWu4F6O1V62NC8NCZV5tKOYFKhFMmgdv9R9kW1qDOMhGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "rdfa-streaming-parser": "^3.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-rdf-parse-html-script": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-5.2.3.tgz",
+      "integrity": "sha512-rftfcqzi9qxGXpgGu0F7dWYToxG4YsXiCVtuXGggzo/0oIQNkiz+/m90l3JRLh1IkFyfZ9XBvbz0zjdCYFtN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/bus-rdf-parse-html": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.7.0",
+        "relative-to-absolute-iri": "^1.0.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-5.2.3.tgz",
+      "integrity": "sha512-eqUhugeUDqH0fvlqL5LvH0OVVCk2U6PT/oHKeqSs9fGnbcFGRXQLo5Bua7+w4Yp+YIA0kMkfFGLa0dFgh4MvAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@jeswr/stream-to-string": "^2.0.0",
+        "jsonld-context-parser": "^2.2.2",
+        "jsonld-streaming-parser": "^5.0.0",
+        "lru-cache": "^11.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-rdf-parse-n3": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-5.2.3.tgz",
+      "integrity": "sha512-r0JhUmD0sIljM3StVn9u0cuOqMUkms7uCLX2ouym+stsFfarJmLeXejEfsK5sNfZvg/jdmGTFZWXIvbb4eTe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "n3": "^2.0.0"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-rdf-parse-rdfxml": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-5.2.3.tgz",
+      "integrity": "sha512-7/0smzkWOoI06tQ2WbDJe0AoT4ZFceRJtjHlN/vfAVrOoAG74nQIEt4ktHyo4+bhxAzePn0s/fAdpeDmWnju0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "rdfxml-streaming-parser": "^3.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-rdf-parse-shaclc": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-5.2.3.tgz",
+      "integrity": "sha512-Kw9x55+4yIjEhbOfDWKadTDz0AYzN9qJsE4jomptPnZsbrfWpWRu9A7T768onMjzWR5S8kkV2x8vSoE3AAczVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@jeswr/stream-to-string": "^2.0.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.10.0",
+        "readable-stream": "^4.7.0",
+        "shaclc-parse": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-5.2.3.tgz",
+      "integrity": "sha512-cEHFeBOYLmFr1Vacv6xfqyX5aQFppu53CQndGIciTEjAvKD2hCU0lBCdvbSySn8SBOd3tZ0obGowXVGfRQsdCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "rdfa-streaming-parser": "^3.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/bus-http": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-5.2.3.tgz",
+      "integrity": "sha512-1xQVWj0UEScLYc2ah0LiiLdNPEG8yjcyuHl3kyDy+TLjifhNMoMjhv2vFRdB28s8B6Y05K6Zz6Jl7tnoWxNMwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@jeswr/stream-to-string": "^2.0.0",
+        "is-stream": "^2.0.1",
+        "readable-from-web": "^1.0.0",
+        "readable-stream-node-to-web": "^1.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/bus-init": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-5.2.3.tgz",
+      "integrity": "sha512-I2eP9JiK5WVv5vUY9QbHAbXD7NRTBP66CkW8MJ5KKswNPdsFBPJaeXW/ekcEKEm4aUsj/80zIO/eE4M0vzo2KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3",
+        "readable-stream": "^4.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/bus-rdf-parse": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-5.2.3.tgz",
+      "integrity": "sha512-7227U+KefLev3zr7Nq/g3IDCSS+Qvvt7tN4MLF8QZICZBdDviTE1ctafQr2rGOUW+FL5PKpqtOoO+vAiw1DS4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^5.2.3",
+        "@comunica/actor-abstract-parse": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/bus-rdf-parse-html": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-5.2.3.tgz",
+      "integrity": "sha512-ceOamxkmIMY2xVz8FXkBOiD9jrVf+FmZhpxL6k69YjseouK1CTUXKnejuC36ge7I13XuS+veNp/WOgfh0ZSoag==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/config-query-sparql": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-5.2.1.tgz",
+      "integrity": "sha512-zCfogBq5IK+GrgX/mBEltzdVDWLOBnyzpUXBLQdd6LTgfjRVYjAQjbZEAtUZ36mh6EDG5QGUbE4SnedQFvRMVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/context-entries": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-5.2.3.tgz",
+      "integrity": "sha512-HGImR7IN70Dh/3k7PqyLPWsc8AddenrzH3Ns6oFuru6GdzbokdPaoe/G08818u3GAXimrMAKcM22xNPEMrEFsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/core": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-5.2.3.tgz",
+      "integrity": "sha512-+ZpuwERjRAMRCdkxBJbUHSdHpZAxU3fHGW7tA6JpJbYryneEIU7IFlEDgP/NbfmdD5O5HfO2/0GbThiMMWgOFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^5.2.3",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/mediator-combine-pipeline": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-5.2.3.tgz",
+      "integrity": "sha512-Tu5fkk1wO9mqYhLo8P8gqw6ZM+QlrG5YcemSNNxpyOWYBaZUzllppa3c01B4TczAcNteg1sIavf4DF3w7wo4fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/mediator-combine-union": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-5.2.3.tgz",
+      "integrity": "sha512-KeTyRBT9ZLn151eV1UQgDruYoXWKl1jr28q/Rfo9+M6xHXU93ySQCjv9Y0ckaDPKTXNQVo2Q95tI49R3XD+vww==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/mediator-number": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-5.2.3.tgz",
+      "integrity": "sha512-QgMjmHdsOFPepgFOa6pX5pbGgYrxGPTRZ5cy0Az0eNxit034a4lUKdCH4+ShFID3kUXrLZ6FdjUbHxdDNTh7Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/mediator-race": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-5.2.3.tgz",
+      "integrity": "sha512-lN6OO7eG5n/pivpXriK4P6g0G25Gzg3lz2eCI9n7m52g7SqcOYFwY8r68sAxLGuT1KM1KXLJwm1ie2ymp6VWCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/mediatortype-time": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-5.2.3.tgz",
+      "integrity": "sha512-LPZjj/s/9R4jGDj8U5c8txyxfFTqqVeQ0ociQPRVtQSK0qUHJGsUHYqTUQqu2e9MCW6qFIlSInZ6a/7IOQmUEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^5.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@comunica/types": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-5.2.3.tgz",
+      "integrity": "sha512-/28Wr3OZEgNlLcdJ5IRnrambic7iYmrrm9eO2NqF2Vo8rDokSdrAwzEVr29peWwW/0gbLmGerclSxFj7lPI4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/utils-algebra": "^5.2.0",
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.10.0",
+        "lru-cache": "^11.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "packages/distribution-probe/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "packages/distribution-probe/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "packages/distribution-probe/node_modules/jsonld-streaming-parser": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-5.0.1.tgz",
+      "integrity": "sha512-Rf230DRAWe5p1H4e7phk1vo4FHEMOmC5xVcIywKJBBcwy6zaJWFcAvPcwngufNTdJs7dpTMbKQDjp4TYDpMKUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^3.1.0",
+        "rdf-data-factory": "^2.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "packages/distribution-probe/node_modules/jsonld-streaming-parser/node_modules/jsonld-context-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-3.1.0.tgz",
+      "integrity": "sha512-BfgNJ/t9jjK7Lun9XRCJM6YeNqDk8B6/lg+KS8rzhXAOtS0FvoClSmtLvF24V1M2CDYRy2LcEBt0ilxqSX93WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "packages/distribution-probe/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/distribution-probe/node_modules/microdata-rdf-streaming-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-3.0.0.tgz",
+      "integrity": "sha512-CgdDaKqKAc/4gVhzUX7b1H0dKtnydqNu7dCMcvUceCZpAxX/6EO9w/U1Po195/F9fZY/oQakEREz8U1X7yrhAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^9.0.0",
+        "rdf-data-factory": "^2.0.0",
+        "readable-stream": "^4.1.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "packages/distribution-probe/node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "packages/distribution-probe/node_modules/n3": {
@@ -40898,6 +41415,136 @@
       "engines": {
         "node": ">=12.0"
       }
+    },
+    "packages/distribution-probe/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "packages/distribution-probe/node_modules/rdf-parse": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-5.0.0.tgz",
+      "integrity": "sha512-q2UO1DCP9IbcX1Yvv+FJCd6c2PmFRpWVYuG8nuTPhOqcS2QYvP0cs6UOaHr0Lhoh7jbrvVbPx3Pb4mdwBrF8bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-http-fetch": "^5.0.0",
+        "@comunica/actor-http-proxy": "^5.0.0",
+        "@comunica/actor-rdf-parse-html": "^5.0.0",
+        "@comunica/actor-rdf-parse-html-microdata": "^5.0.0",
+        "@comunica/actor-rdf-parse-html-rdfa": "^5.0.0",
+        "@comunica/actor-rdf-parse-html-script": "^5.0.0",
+        "@comunica/actor-rdf-parse-jsonld": "^5.0.0",
+        "@comunica/actor-rdf-parse-n3": "^5.0.0",
+        "@comunica/actor-rdf-parse-rdfxml": "^5.0.0",
+        "@comunica/actor-rdf-parse-shaclc": "^5.0.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^5.0.0",
+        "@comunica/bus-http": "^5.0.0",
+        "@comunica/bus-init": "^5.0.0",
+        "@comunica/bus-rdf-parse": "^5.0.0",
+        "@comunica/bus-rdf-parse-html": "^5.0.0",
+        "@comunica/config-query-sparql": "^5.0.0",
+        "@comunica/context-entries": "^5.0.0",
+        "@comunica/core": "^5.0.0",
+        "@comunica/mediator-combine-pipeline": "^5.0.0",
+        "@comunica/mediator-combine-union": "^5.0.0",
+        "@comunica/mediator-number": "^5.0.0",
+        "@comunica/mediator-race": "^5.0.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^2.0.2",
+        "readable-stream": "^4.7.0",
+        "stream-to-string": "^1.2.1"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "packages/distribution-probe/node_modules/rdfa-streaming-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-3.0.2.tgz",
+      "integrity": "sha512-1MEkALT5PYjucVo6lNHXd9DbkgW0hSfPOJOs/TpUFe9zoZvkoreKcGIFnMFkbMmYTNLCiGFo/74LviIUnWLkIw==",
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^9.0.0",
+        "rdf-data-factory": "^2.0.0",
+        "readable-stream": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "packages/distribution-probe/node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "packages/distribution-probe/node_modules/rdfxml-streaming-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-3.2.0.tgz",
+      "integrity": "sha512-SgQGK0EkbXd0jQ1PZk7dEpfDxf4CZpezkO6cTuGWesa9twdWaaW5elMoNBcbMT+2tOZC1EYZjs0JaXx0HnifcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^4.0.18",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^2.0.2",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.0",
+        "validate-iri": "^1.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "packages/distribution-probe/node_modules/shaclc-parse": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-2.0.0.tgz",
+      "integrity": "sha512-YEznPru7QmcIR1lF/lCvvrrcjZ8vWfKBMAketPb2CRWkrA0LUffTzrW0tOepue/evUREkJyl8LeVpcmyyKF+ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0",
+        "n3": "^2.0.0"
+      }
+    },
+    "packages/distribution-probe/node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "packages/distribution-probe/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "packages/docgen": {
       "name": "@lde/docgen",
@@ -41610,7 +42257,7 @@
     },
     "packages/iiif-validator": {
       "name": "@lde/iiif-validator",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -41631,7 +42278,7 @@
     },
     "packages/pipeline": {
       "name": "@lde/pipeline",
-      "version": "0.30.4",
+      "version": "0.30.5",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.4",
@@ -41654,7 +42301,7 @@
     },
     "packages/pipeline-console-reporter": {
       "name": "@lde/pipeline-console-reporter",
-      "version": "0.21.4",
+      "version": "0.21.5",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -41665,7 +42312,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "0.7.4",
-        "@lde/pipeline": "0.30.4"
+        "@lde/pipeline": "0.30.5"
       }
     },
     "packages/pipeline-console-reporter/node_modules/ansi-regex": {
@@ -41845,7 +42492,7 @@
     },
     "packages/pipeline-shacl-sampler": {
       "name": "@lde/pipeline-shacl-sampler",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -41855,7 +42502,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "0.7.4",
-        "@lde/pipeline": "0.30.4"
+        "@lde/pipeline": "0.30.5"
       }
     },
     "packages/pipeline-shacl-sampler/node_modules/n3": {
@@ -41873,7 +42520,7 @@
     },
     "packages/pipeline-shacl-validator": {
       "name": "@lde/pipeline-shacl-validator",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -41887,7 +42534,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "0.7.4",
-        "@lde/pipeline": "0.30.4"
+        "@lde/pipeline": "0.30.5"
       }
     },
     "packages/pipeline-shacl-validator/node_modules/n3": {
@@ -41906,7 +42553,7 @@
     },
     "packages/pipeline-void": {
       "name": "@lde/pipeline-void",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -41916,7 +42563,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "0.7.4",
-        "@lde/pipeline": "0.30.4"
+        "@lde/pipeline": "0.30.5"
       }
     },
     "packages/pipeline-void/node_modules/n3": {
@@ -41995,7 +42642,7 @@
     },
     "packages/sparql-qlever": {
       "name": "@lde/sparql-qlever",
-      "version": "0.14.5",
+      "version": "0.14.6",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.4",

--- a/packages/distribution-probe/package.json
+++ b/packages/distribution-probe/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@lde/dataset": "0.7.4",
-    "n3": "^2.0.1",
+    "rdf-parse": "^5.0.0",
     "tslib": "^2.3.0"
   }
 }

--- a/packages/distribution-probe/src/probe.ts
+++ b/packages/distribution-probe/src/probe.ts
@@ -1,5 +1,6 @@
 import { compressionMediaTypes, Distribution } from '@lde/dataset';
-import { Parser } from 'n3';
+import { rdfParser } from 'rdf-parse';
+import { Readable } from 'node:stream';
 
 /**
  * Options for {@link probe}.
@@ -426,7 +427,12 @@ async function probeDataDump(
     const body = await getResponse.text();
     const isHttpSuccess = getResponse.status >= 200 && getResponse.status < 400;
     const failureReason = isHttpSuccess
-      ? validateBody(body, getResponse.headers.get('Content-Type'))
+      ? await validateBody(
+          body,
+          getResponse.headers.get('Content-Type'),
+          url,
+          options.timeoutMs,
+        )
       : null;
     const responseTimeMs = Math.round(performance.now() - start);
     const result = new DataDumpProbeResult(
@@ -445,30 +451,112 @@ async function probeDataDump(
   return result;
 }
 
+// The RDF serializations whose bodies we parse to confirm they carry triples. A
+// non-empty body in one of these formats that yields zero triples — an empty
+// graph such as a JSON-LD `{}`, an `<rdf:RDF/>`, or prefix-only Turtle — is a
+// faulty distribution, not a usable one, so it must be caught here. Other
+// content types (CSV, HTML, …) are left untouched: the probe is not the place
+// to assert what a non-RDF body should contain.
 const rdfContentTypes = [
   'text/turtle',
   'application/n-triples',
   'application/n-quads',
+  'application/trig',
+  'text/n3',
+  'application/ld+json',
+  'application/rdf+xml',
 ];
 
-function validateBody(body: string, contentType: string | null): string | null {
+async function validateBody(
+  body: string,
+  contentType: string | null,
+  baseIRI: string,
+  timeoutMs: number,
+): Promise<string | null> {
   if (body.length === 0) {
     return 'Distribution is empty';
   }
 
-  if (contentType && rdfContentTypes.some((t) => contentType.startsWith(t))) {
-    try {
-      const parser = new Parser();
-      const quads = parser.parse(body);
-      if (quads.length === 0) {
-        return 'Distribution contains no RDF triples';
-      }
-    } catch (e) {
-      return e instanceof Error ? e.message : String(e);
-    }
+  const serialization = contentType?.split(';')[0].trim();
+  if (!serialization || !rdfContentTypes.includes(serialization)) {
+    return null;
   }
 
-  return null;
+  const outcome = await classifyRdfBody(
+    body,
+    serialization,
+    baseIRI,
+    timeoutMs,
+  );
+  switch (outcome.type) {
+    case 'empty':
+      return 'Distribution contains no RDF triples';
+    case 'parseError':
+      return outcome.message;
+    // 'hasTriples' proves content. 'inconclusive' means the parse timed out or a
+    // remote JSON-LD @context could not be loaded — a third-party hiccup, not
+    // evidence the distribution is faulty — so neither is reported as a failure.
+    default:
+      return null;
+  }
+}
+
+type RdfBodyOutcome =
+  | { type: 'hasTriples' }
+  | { type: 'empty' }
+  | { type: 'parseError'; message: string }
+  | { type: 'inconclusive' };
+
+/**
+ * Parse an RDF body just far enough to tell whether it carries any triples:
+ * resolve on the first triple (presence is all we need, not a full count), on a
+ * clean end with none ('empty'), or on a parse error. The parse is bounded by
+ * `timeoutMs` because a JSON-LD `@context` is fetched from its origin, and a
+ * slow or hanging context host would otherwise stall the probe past its budget;
+ * on expiry — and likewise when a remote `@context` is unreachable — the outcome
+ * is 'inconclusive', so a valid distribution is never flagged faulty for a
+ * context host's failure. `baseIRI` resolves any relative IRIs in the document.
+ */
+function classifyRdfBody(
+  body: string,
+  contentType: string,
+  baseIRI: string,
+  timeoutMs: number,
+): Promise<RdfBodyOutcome> {
+  return new Promise<RdfBodyOutcome>((resolve) => {
+    const quads = rdfParser.parse(Readable.from([body]), {
+      contentType,
+      baseIRI,
+    });
+    const timer = setTimeout(() => settle({ type: 'inconclusive' }), timeoutMs);
+    let settled = false;
+    function settle(outcome: RdfBodyOutcome): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      quads.destroy();
+      resolve(outcome);
+    }
+    quads
+      .on('data', () => settle({ type: 'hasTriples' }))
+      .on('error', (error: Error) =>
+        settle(
+          isRemoteContextError(error)
+            ? { type: 'inconclusive' }
+            : { type: 'parseError', message: error.message },
+        ),
+      )
+      .on('end', () => settle({ type: 'empty' }));
+  });
+}
+
+/**
+ * Whether a parse error is the RDF parser failing to load a remote JSON-LD
+ * `@context` (an unreachable or broken third-party context host) rather than a
+ * defect in the distribution body itself.
+ */
+function isRemoteContextError(error: Error): boolean {
+  return /remote context/i.test(error.message);
 }
 
 /**

--- a/packages/distribution-probe/test/probe.test.ts
+++ b/packages/distribution-probe/test/probe.test.ts
@@ -6,6 +6,8 @@ import {
 } from '../src/index.js';
 import { Distribution } from '@lde/dataset';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
 
 describe('probe', () => {
   beforeEach(() => {
@@ -503,6 +505,134 @@ describe('probe', () => {
       expect(dumpResult.failureReason).toBeNull();
     });
 
+    it('marks empty JSON-LD as failure', async () => {
+      const body = '{}';
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(new Response('', { status: 200 })) // HEAD
+        .mockResolvedValueOnce(
+          new Response(body, {
+            status: 200,
+            headers: { 'Content-Type': 'application/ld+json' },
+          }),
+        ); // GET
+
+      const distribution = new Distribution(
+        new URL('http://example.org/data.jsonld'),
+        'application/ld+json',
+      );
+
+      const result = await probe(distribution);
+
+      expect(result).toBeInstanceOf(DataDumpProbeResult);
+      const dumpResult = result as DataDumpProbeResult;
+      expect(dumpResult.isSuccess()).toBe(false);
+      expect(dumpResult.failureReason).toBe(
+        'Distribution contains no RDF triples',
+      );
+    });
+
+    it('marks empty RDF/XML as failure', async () => {
+      const body =
+        '<?xml version="1.0"?>\n<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"></rdf:RDF>';
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(new Response('', { status: 200 })) // HEAD
+        .mockResolvedValueOnce(
+          new Response(body, {
+            status: 200,
+            headers: { 'Content-Type': 'application/rdf+xml' },
+          }),
+        ); // GET
+
+      const distribution = new Distribution(
+        new URL('http://example.org/data.rdf'),
+        'application/rdf+xml',
+      );
+
+      const result = await probe(distribution);
+
+      expect(result).toBeInstanceOf(DataDumpProbeResult);
+      const dumpResult = result as DataDumpProbeResult;
+      expect(dumpResult.isSuccess()).toBe(false);
+      expect(dumpResult.failureReason).toBe(
+        'Distribution contains no RDF triples',
+      );
+    });
+
+    it('marks prefix-only N3 as failure', async () => {
+      const body = '@prefix ex: <http://example.org/> .\n';
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(new Response('', { status: 200 })) // HEAD
+        .mockResolvedValueOnce(
+          new Response(body, {
+            status: 200,
+            headers: { 'Content-Type': 'text/n3' },
+          }),
+        ); // GET
+
+      const distribution = new Distribution(
+        new URL('http://example.org/data.n3'),
+        'text/n3',
+      );
+
+      const result = await probe(distribution);
+
+      expect(result).toBeInstanceOf(DataDumpProbeResult);
+      const dumpResult = result as DataDumpProbeResult;
+      expect(dumpResult.isSuccess()).toBe(false);
+      expect(dumpResult.failureReason).toBe(
+        'Distribution contains no RDF triples',
+      );
+    });
+
+    it('marks JSON-LD with triples as success', async () => {
+      const body =
+        '{"@id": "http://example.org/s", "http://example.org/p": {"@id": "http://example.org/o"}}';
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(new Response('', { status: 200 })) // HEAD
+        .mockResolvedValueOnce(
+          new Response(body, {
+            status: 200,
+            headers: { 'Content-Type': 'application/ld+json' },
+          }),
+        ); // GET
+
+      const distribution = new Distribution(
+        new URL('http://example.org/data.jsonld'),
+        'application/ld+json',
+      );
+
+      const result = await probe(distribution);
+
+      expect(result).toBeInstanceOf(DataDumpProbeResult);
+      const dumpResult = result as DataDumpProbeResult;
+      expect(dumpResult.isSuccess()).toBe(true);
+      expect(dumpResult.failureReason).toBeNull();
+    });
+
+    it('does not validate a non-RDF body', async () => {
+      const body = 'id,name\n1,Alice\n';
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(new Response('', { status: 200 })) // HEAD
+        .mockResolvedValueOnce(
+          new Response(body, {
+            status: 200,
+            headers: { 'Content-Type': 'text/csv' },
+          }),
+        ); // GET
+
+      const distribution = new Distribution(
+        new URL('http://example.org/data.csv'),
+        'text/csv',
+      );
+
+      const result = await probe(distribution);
+
+      expect(result).toBeInstanceOf(DataDumpProbeResult);
+      const dumpResult = result as DataDumpProbeResult;
+      expect(dumpResult.isSuccess()).toBe(true);
+      expect(dumpResult.failureReason).toBeNull();
+    });
+
     it('skips body validation for large files', async () => {
       vi.mocked(fetch).mockResolvedValueOnce(
         new Response('', {
@@ -524,6 +654,117 @@ describe('probe', () => {
       expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1); // HEAD only
       expect(result).toBeInstanceOf(DataDumpProbeResult);
       expect((result as DataDumpProbeResult).isSuccess()).toBe(true);
+    });
+  });
+
+  describe('JSON-LD remote @context', () => {
+    // These exercise the real RDF parser fetching a JSON-LD @context over the
+    // network, so they need the real global fetch rather than the suite stub and
+    // their own origin servers.
+    beforeEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    async function startServer(
+      handler: http.RequestListener,
+    ): Promise<{ server: http.Server; origin: string }> {
+      const server = http.createServer(handler);
+      await new Promise<void>((resolve) =>
+        server.listen(0, '127.0.0.1', resolve),
+      );
+      const { port } = server.address() as AddressInfo;
+      return { server, origin: `http://127.0.0.1:${port}` };
+    }
+
+    it('treats a body with a resolvable remote context as success', async () => {
+      const { server, origin } = await startServer((request, response) => {
+        response.setHeader('Content-Type', 'application/ld+json');
+        if (request.url === '/ctx') {
+          response.end(JSON.stringify({ '@context': { ex: 'http://ex/' } }));
+          return;
+        }
+        response.end(
+          JSON.stringify({
+            '@context': `${origin}/ctx`,
+            '@id': 'http://ex/s',
+            'ex:p': 'value',
+          }),
+        );
+      });
+      try {
+        const result = await probe(
+          new Distribution(
+            new URL(`${origin}/data.jsonld`),
+            'application/ld+json',
+          ),
+        );
+        const dumpResult = result as DataDumpProbeResult;
+        expect(dumpResult.isSuccess()).toBe(true);
+        expect(dumpResult.failureReason).toBeNull();
+      } finally {
+        server.close();
+      }
+    });
+
+    it('does not flag a body whose remote context is unreachable', async () => {
+      // Body resolves, but its @context points at a closed port.
+      const { server, origin } = await startServer((_request, response) => {
+        response.setHeader('Content-Type', 'application/ld+json');
+        response.end(
+          JSON.stringify({
+            '@context': 'http://127.0.0.1:1/never',
+            '@id': 'http://ex/s',
+            'ex:p': 'value',
+          }),
+        );
+      });
+      try {
+        const result = await probe(
+          new Distribution(
+            new URL(`${origin}/data.jsonld`),
+            'application/ld+json',
+          ),
+        );
+        const dumpResult = result as DataDumpProbeResult;
+        expect(dumpResult.isSuccess()).toBe(true);
+        expect(dumpResult.failureReason).toBeNull();
+      } finally {
+        server.close();
+      }
+    });
+
+    it('does not flag a body whose remote context times out', async () => {
+      const heldResponses: http.ServerResponse[] = [];
+      const { server, origin } = await startServer((request, response) => {
+        if (request.url === '/ctx') {
+          heldResponses.push(response); // never answered
+          return;
+        }
+        response.setHeader('Content-Type', 'application/ld+json');
+        response.end(
+          JSON.stringify({
+            '@context': `${origin}/ctx`,
+            '@id': 'http://ex/s',
+            'ex:p': 'value',
+          }),
+        );
+      });
+      try {
+        const result = await probe(
+          new Distribution(
+            new URL(`${origin}/data.jsonld`),
+            'application/ld+json',
+          ),
+          { timeoutMs: 200 },
+        );
+        const dumpResult = result as DataDumpProbeResult;
+        expect(dumpResult.isSuccess()).toBe(true);
+        expect(dumpResult.failureReason).toBeNull();
+      } finally {
+        heldResponses.forEach((response) => response.destroy());
+        server.closeAllConnections?.();
+        server.close();
+      }
     });
   });
 

--- a/packages/distribution-probe/vite.config.ts
+++ b/packages/distribution-probe/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 99.25,
+          lines: 99.32,
           functions: 100,
-          branches: 89.32,
-          statements: 98.54,
+          branches: 91.5,
+          statements: 98.68,
         },
       },
     },


### PR DESCRIPTION
## Why

The distribution probe only validated Turtle, N-Triples, and N-Quads bodies for emptiness. A non-empty body in any other RDF serialization was accepted without checking that it actually carried triples, so distributions that serve an empty graph — a JSON-LD `{}`, an `<rdf:RDF/>`, or prefix-only N3 — passed as healthy even though they contain no data. (This came up while investigating a dataset whose distributions are all empty yet were not flagged.)

## What

- Validate JSON-LD, RDF/XML, N3, and TriG bodies in addition to Turtle/N-Triples/N-Quads, by parsing with `rdf-parse` (the workspace’s standard content-type-driven parser) and reporting bodies that yield zero triples.
- Resolve on the first triple — presence is all the probe needs, not a full count.
- Bound the parse with the probe’s `timeoutMs`. A JSON-LD `@context` is dereferenced from its origin, on an HTTP path the fetch-level `AbortSignal` does not cover, so a slow or hanging context host would otherwise stall the probe past its budget.
- Treat a parse timeout or an unreachable remote `@context` as **inconclusive**, not faulty: we only report “no RDF triples” when we can prove it, so a valid distribution is never flagged because a third-party context host is slow or down. Genuine syntax errors and clean empty graphs are still flagged.
- Replace the `n3` dependency with `rdf-parse`.

## Tests

- Empty JSON-LD (`{}`), empty RDF/XML, and prefix-only N3 are flagged; JSON-LD with a triple is not.
- A resolvable remote `@context` succeeds; an unreachable or hanging (timeout) remote `@context` is not flagged.
- Non-RDF bodies (e.g. CSV) are left untouched.
