### PR TITLE
fix(distribution-probe): match distribution content type case-insensitively

### DIFF
--- a/packages/distribution-probe/src/probe.ts
+++ b/packages/distribution-probe/src/probe.ts
@@ -477,7 +477,10 @@ async function validateBody(
     return 'Distribution is empty';
   }
 
-  const serialization = contentType?.split(';')[0].trim();
+  // Media types are case-insensitive (RFC 9110 §8.3.1), so normalise before
+  // matching the lower-case allow-list — a server sending `Application/LD+JSON`
+  // must still have its body validated.
+  const serialization = contentType?.split(';')[0].trim().toLowerCase();
   if (!serialization || !rdfContentTypes.includes(serialization)) {
     return null;
   }

--- a/packages/distribution-probe/test/probe.test.ts
+++ b/packages/distribution-probe/test/probe.test.ts
@@ -531,6 +531,32 @@ describe('probe', () => {
       );
     });
 
+    it('matches the content type case-insensitively', async () => {
+      const body = '{}';
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(new Response('', { status: 200 })) // HEAD
+        .mockResolvedValueOnce(
+          new Response(body, {
+            status: 200,
+            headers: { 'Content-Type': 'Application/LD+JSON' },
+          }),
+        ); // GET
+
+      const distribution = new Distribution(
+        new URL('http://example.org/data.jsonld'),
+        'application/ld+json',
+      );
+
+      const result = await probe(distribution);
+
+      expect(result).toBeInstanceOf(DataDumpProbeResult);
+      const dumpResult = result as DataDumpProbeResult;
+      expect(dumpResult.isSuccess()).toBe(false);
+      expect(dumpResult.failureReason).toBe(
+        'Distribution contains no RDF triples',
+      );
+    });
+
     it('marks empty RDF/XML as failure', async () => {
       const body =
         '<?xml version="1.0"?>\n<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"></rdf:RDF>';


### PR DESCRIPTION
## Why

The empty-distribution check added in #441 matches the served `Content-Type` against a lower-case allow-list of RDF serializations. Media types are case-insensitive (RFC 9110 §8.3.1), so a server sending e.g. `Application/LD+JSON` failed the match, skipped the emptiness check, and an empty graph passed as healthy — the exact gap #441 closes, but case-dependent.

## What

- Lower-case the served `Content-Type` (after stripping parameters) before matching the allow-list, so mixed-case media types are validated like their canonical lower-case form.

## Test

- An empty JSON-LD body served as `Application/LD+JSON` is now flagged `Distribution contains no RDF triples`.
