### PR TITLE
fix(iiif-validator): request manifests with Accept: */*

### DIFF
--- a/packages/iiif-validator/README.md
+++ b/packages/iiif-validator/README.md
@@ -28,7 +28,7 @@ interface ManifestValidation {
 
 ## Behaviour
 
-- **Dereference over HTTP** with `Accept: application/ld+json, application/json`, following redirects, using the global `fetch` with an `AbortSignal` timeout (default 10 000 ms). Both are injectable via the options argument (`fetch`, `timeoutMs`).
+- **Dereference over HTTP** with `Accept: */*`, following redirects, using the global `fetch` with an `AbortSignal` timeout (default 10 000 ms). The wildcard mirrors what real IIIF viewers send (the browser `fetch` default); a JSON-specific `Accept` would be more correct but trips up hosts that do backwards content negotiation – serving the manifest to `*/*` while returning 404 for a JSON-specific request. Both `fetch` and `timeoutMs` are injectable via the options argument.
 - **Lightweight, version-aware structural check.** A document is valid when the response is HTTP 2xx, the body parses as JSON, its `@context` references an IIIF Presentation context, and its `type`/`@type` indicates a manifest – accepting both v3 (`Manifest`) and v2 (`sc:Manifest`). The `@context` value may be a string, an array, or an object; all forms are handled. The version segment of the context is accepted version-agnostically.
 - **Strict failure semantics, no retries.** A timeout, network error, non-2xx status, unparseable body, missing IIIF `@context`, or wrong `type` all yield `valid: false` with the corresponding coarse `reason`. There is no deep JSON Schema validation and no dependency on the hosted IIIF Presentation Validator service.
 

--- a/packages/iiif-validator/src/validateManifest.ts
+++ b/packages/iiif-validator/src/validateManifest.ts
@@ -53,7 +53,13 @@ export async function validateManifest(
   let response: Response;
   try {
     response = await doFetch(url, {
-      headers: { Accept: 'application/ld+json, application/json' },
+      // Request with `Accept: */*`, matching what real IIIF viewers (Mirador,
+      // Universal Viewer) send via the browser `fetch` default. A more specific
+      // `application/ld+json` is technically correct, but some manifest hosts do
+      // backwards content negotiation: they serve the manifest to `*/*` yet 404
+      // a JSON-specific request. Asking for anything keeps the validator as
+      // permissive as the viewers whose access it stands in for.
+      headers: { Accept: '*/*' },
       signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (error) {

--- a/packages/iiif-validator/test/validateManifest.test.ts
+++ b/packages/iiif-validator/test/validateManifest.test.ts
@@ -79,6 +79,25 @@ describe('validateManifest', () => {
     expect(verdict).toEqual({ valid: true, reason: 'valid-manifest' });
   });
 
+  it('requests with `Accept: */*` so backwards-content-negotiating hosts still serve the manifest', async () => {
+    let sentAccept: string | null = null;
+    const fetch = (async (_url: string, init?: RequestInit) => {
+      sentAccept = new Headers(init?.headers).get('Accept');
+      return new Response(
+        JSON.stringify({
+          '@context': 'http://iiif.io/api/presentation/3/context.json',
+          id: URL,
+          type: 'Manifest',
+        }),
+        { headers: { 'Content-Type': 'application/ld+json' } },
+      );
+    }) as typeof globalThis.fetch;
+
+    await validateManifest(URL, { fetch });
+
+    expect(sentAccept).toBe('*/*');
+  });
+
   it('reports http-error for a non-2xx response', async () => {
     const fetch = fetchReturning('Not Found', { status: 404 });
 


### PR DESCRIPTION
## Problem

The dataset register reported a dataset's IIIF manifests as **failed** even though the manifests load fine in a browser. Example: the 32 manifests under `https://n2t.net/ark:/50965/dataset` (Noord-Brabants Museum), e.g. `https://n2t.net/ark:/50965/86adba86089043a2bf6003bc3a2cd399/iiif.json`.

The root cause is **backwards content negotiation** on the provider's host (`www.ldmax.nl`, reached via the `n2t.net` → `arks.org` → `data.hetnoordbrabantsmuseum.nl` ARK redirect chain). The server serves the valid IIIF v3 manifest — correctly typed `application/ld+json` — to clients sending `Accept: */*` or no `Accept`, but returns a **404 HTML page** the moment `application/json` or `application/ld+json` appears anywhere in the `Accept` header:

| `Accept` sent | Result |
|---|---|
| `*/*` | 200 ✅ |
| *(none)* | 200 ✅ |
| `text/html` | 200 ✅ |
| `application/json` | 404 ❌ |
| `application/ld+json` | 404 ❌ |
| `application/ld+json, application/json, */*` | 404 ❌ |

`validateManifest()` sent exactly `Accept: application/ld+json, application/json`, so every manifest 404'd → `http-error` → `validated = 0` → the register's `iiifState()` resolved to `failed`. Browsers and real IIIF viewers (Mirador, Universal Viewer use the browser `fetch` default, `Accept: */*`) get the 200 — hence the discrepancy.

## Change

Request manifests with `Accept: */*`, matching what real IIIF viewers actually send. A JSON-specific `Accept` is technically more correct, but the validator stands in for the viewers whose access it measures, so it should be as permissive as they are. This fixes this provider and any other host with the same quirk.

- `validateManifest.ts` — `Accept` header changed to `*/*`, with an explanatory comment.
- `README.md` — behaviour doc updated to match.
- `test/validateManifest.test.ts` — added a test asserting `Accept: */*` is sent.

Verified end-to-end against the live failing manifest: the built validator now returns `{ valid: true, reason: 'valid-manifest' }`.

## Follow-up

To reach production, release a new `@lde/iiif-validator`, bump it in `dataset-knowledge-graph`, and re-run the DKG pipeline so the dataset's `manifests-validated` metric updates.
