### PR TITLE
fix(iiif-validator): gate validity on loading in a real viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25093,6 +25093,45 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iiif/parser": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-2.2.10.tgz",
+      "integrity": "sha512-gzMJprpo8zLIi79hVejoZ7PvNkXLDxwHzGtIJMz4FA6KlLPij5vEIzg/rsJluIOOM5enNCan54Eit5U8YrLfKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@iiif/presentation-2": "^1.0.4",
+        "@iiif/presentation-3": "^2.2.2",
+        "@iiif/presentation-3-normalized": "^0.9.7",
+        "@types/geojson": "^7946.0.10"
+      }
+    },
+    "node_modules/@iiif/presentation-2": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-2/-/presentation-2-1.0.4.tgz",
+      "integrity": "sha512-hJakpq62VBajesLJrYPtFm6hcn6c/HkKP7CmKZ5atuzu40m0nifWYsqigR1l9sZGvhhHb/DRshPmiW/0GNrJoA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@iiif/presentation-3": "*"
+      }
+    },
+    "node_modules/@iiif/presentation-3": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-2.2.3.tgz",
+      "integrity": "sha512-xCLbUr9euqegsrxGe65M2fWbv6gKpiUhHXCpOn+V+qtawkMbOSNWbYOISo2aLQdYVg4DGYD0g2bMzSCF33uNOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10"
+      }
+    },
+    "node_modules/@iiif/presentation-3-normalized": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-3-normalized/-/presentation-3-normalized-0.9.7.tgz",
+      "integrity": "sha512-Aqk0sYBFIH5W3wmVxW02tnAFbNzUU5oPygGQjvszB3PP2nSkFQ1skVjqJhQPPZTyi/de1qcJUrgSy0vp6s+c5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@iiif/presentation-3": "^2.0.5"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -27686,6 +27725,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
@@ -40847,11 +40892,11 @@
     },
     "packages/distribution-monitor": {
       "name": "@lde/distribution-monitor",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.4",
-        "@lde/distribution-probe": "0.1.5",
+        "@lde/distribution-probe": "0.1.7",
         "c12": "^3.3.4",
         "commander": "^15.0.0",
         "cron": "^4.1.0",
@@ -40878,7 +40923,7 @@
     },
     "packages/distribution-probe": {
       "name": "@lde/distribution-probe",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.4",
@@ -42257,9 +42302,10 @@
     },
     "packages/iiif-validator": {
       "name": "@lde/iiif-validator",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
+        "@iiif/parser": "^2.2.10",
         "tslib": "^2.3.0"
       }
     },
@@ -42278,12 +42324,12 @@
     },
     "packages/pipeline": {
       "name": "@lde/pipeline",
-      "version": "0.30.5",
+      "version": "0.30.7",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.4",
         "@lde/dataset-registry-client": "0.8.0",
-        "@lde/distribution-probe": "0.1.5",
+        "@lde/distribution-probe": "0.1.7",
         "@lde/sparql-importer": "0.6.2",
         "@lde/sparql-server": "0.4.11",
         "@rdfjs/types": "^2.0.1",
@@ -42301,7 +42347,7 @@
     },
     "packages/pipeline-console-reporter": {
       "name": "@lde/pipeline-console-reporter",
-      "version": "0.21.5",
+      "version": "0.21.7",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -42312,7 +42358,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "0.7.4",
-        "@lde/pipeline": "0.30.5"
+        "@lde/pipeline": "0.30.7"
       }
     },
     "packages/pipeline-console-reporter/node_modules/ansi-regex": {
@@ -42492,7 +42538,7 @@
     },
     "packages/pipeline-shacl-sampler": {
       "name": "@lde/pipeline-shacl-sampler",
-      "version": "0.4.5",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -42502,7 +42548,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "0.7.4",
-        "@lde/pipeline": "0.30.5"
+        "@lde/pipeline": "0.30.7"
       }
     },
     "packages/pipeline-shacl-sampler/node_modules/n3": {
@@ -42520,7 +42566,7 @@
     },
     "packages/pipeline-shacl-validator": {
       "name": "@lde/pipeline-shacl-validator",
-      "version": "0.12.5",
+      "version": "0.12.7",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -42534,7 +42580,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "0.7.4",
-        "@lde/pipeline": "0.30.5"
+        "@lde/pipeline": "0.30.7"
       }
     },
     "packages/pipeline-shacl-validator/node_modules/n3": {
@@ -42553,7 +42599,7 @@
     },
     "packages/pipeline-void": {
       "name": "@lde/pipeline-void",
-      "version": "0.28.5",
+      "version": "0.28.7",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -42563,7 +42609,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "0.7.4",
-        "@lde/pipeline": "0.30.5"
+        "@lde/pipeline": "0.30.7"
       }
     },
     "packages/pipeline-void/node_modules/n3": {

--- a/packages/iiif-validator/README.md
+++ b/packages/iiif-validator/README.md
@@ -1,6 +1,6 @@
 # IIIF Validator
 
-Validates that a URL dereferences to a valid [IIIF Presentation](https://iiif.io/api/presentation/) Manifest. A small, dependency-light building block for Linked Data tooling that needs to tell a _declared_ IIIF manifest apart from one that actually resolves and parses.
+Validates that a URL dereferences to a valid [IIIF Presentation](https://iiif.io/api/presentation/) Manifest. A small building block for Linked Data tooling that needs to tell a _declared_ IIIF manifest apart from one that actually resolves, parses, and loads in a real viewer.
 
 ```ts
 import { validateManifest } from '@lde/iiif-validator';
@@ -22,15 +22,18 @@ interface ManifestValidation {
     | 'network-error'
     | 'http-error'
     | 'invalid-json'
-    | 'not-a-manifest';
+    | 'binary-content'
+    | 'not-a-manifest'
+    | 'does-not-load';
 }
 ```
 
 ## Behaviour
 
 - **Dereference over HTTP** with `Accept: */*`, following redirects, using the global `fetch` with an `AbortSignal` timeout (default 10 000 ms). The wildcard mirrors what real IIIF viewers send (the browser `fetch` default); a JSON-specific `Accept` would be more correct but trips up hosts that do backwards content negotiation – serving the manifest to `*/*` while returning 404 for a JSON-specific request. Both `fetch` and `timeoutMs` are injectable via the options argument.
-- **Lightweight, version-aware structural check.** A document is valid when the response is HTTP 2xx, the body parses as JSON, its `@context` references an IIIF Presentation context, and its `type`/`@type` indicates a manifest – accepting both v3 (`Manifest`) and v2 (`sc:Manifest`). The `@context` value may be a string, an array, or an object; all forms are handled. The version segment of the context is accepted version-agnostically.
-- **Strict failure semantics, no retries.** A timeout, network error, non-2xx status, unparseable body, missing IIIF `@context`, or wrong `type` all yield `valid: false` with the corresponding coarse `reason`. There is no deep JSON Schema validation and no dependency on the hosted IIIF Presentation Validator service.
+- **Version-aware structural check.** A document is manifest-shaped when the response is HTTP 2xx, the body parses as JSON, its `@context` references an IIIF Presentation context, and its `type`/`@type` indicates a manifest – accepting both v3 (`Manifest`) and v2 (`sc:Manifest`). The `@context` value may be a string, an array, or an object; all forms are handled. The version segment of the context is accepted version-agnostically.
+- **Viewer-load gate.** Being manifest-shaped is not enough: a document can pass every structural check yet fail to load in the dominant Vault/`@iiif/parser`-based viewers (Mirador 4, Clover, Theseus), which eagerly upgrade every manifest to Presentation 3 and normalise the whole tree on load. A single structural slip – e.g. a `null` where an `AnnotationPage` belongs – crashes that pass, so the manifest renders in no such viewer. The validator reproduces that load path with `@iiif/parser` (`upgrade()` then `normalize()`); if it throws, the verdict is `does-not-load`. `upgrade()` is a no-op for v3, so this one path covers both v2 and v3. There are only two tiers – valid or invalid; cosmetic deviations that still load (a non-canonical `rights` URI, `image/jpg` instead of `image/jpeg`) stay valid.
+- **Strict failure semantics, no retries.** A timeout, network error, non-2xx status, unparseable body, binary media type, missing IIIF `@context`, wrong `type`, or a document that does not load all yield `valid: false` with the corresponding coarse `reason`. There is no deep JSON Schema validation and no dependency on the hosted IIIF Presentation Validator service.
 
 ## Options
 

--- a/packages/iiif-validator/package.json
+++ b/packages/iiif-validator/package.json
@@ -24,6 +24,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
+    "@iiif/parser": "^2.2.10",
     "tslib": "^2.3.0"
   }
 }

--- a/packages/iiif-validator/src/validateManifest.ts
+++ b/packages/iiif-validator/src/validateManifest.ts
@@ -1,3 +1,6 @@
+import { normalize } from '@iiif/parser/presentation-3';
+import { upgrade } from '@iiif/parser/upgrader';
+
 /**
  * Coarse outcome of a manifest validation. On failure the reason describes
  * *what kind* of failure occurred, not a detailed diagnosis — only enough to
@@ -10,7 +13,8 @@ export type ManifestValidationReason =
   | 'http-error'
   | 'invalid-json'
   | 'binary-content'
-  | 'not-a-manifest';
+  | 'not-a-manifest'
+  | 'does-not-load';
 
 /**
  * Verdict returned by {@link validateManifest}.
@@ -88,10 +92,36 @@ export async function validateManifest(
     return { valid: false, reason: 'invalid-json' };
   }
 
-  if (isPresentationManifest(body)) {
-    return { valid: true, reason: 'valid-manifest' };
+  if (!isPresentationManifest(body)) {
+    return { valid: false, reason: 'not-a-manifest' };
   }
-  return { valid: false, reason: 'not-a-manifest' };
+
+  if (!loadsInViewer(body)) {
+    return { valid: false, reason: 'does-not-load' };
+  }
+
+  return { valid: true, reason: 'valid-manifest' };
+}
+
+/**
+ * Whether a manifest-shaped document survives the load path that real IIIF
+ * viewers run. The dominant Vault/`@iiif/parser`-based viewers (Mirador 4,
+ * Clover, Theseus) eagerly upgrade every manifest to Presentation 3 and
+ * normalise the whole tree on load; a structural deviation that crashes that
+ * pass — e.g. a `null` where an `AnnotationPage` belongs — makes the manifest
+ * fail to load even though it parses as JSON and is manifest-shaped. Running
+ * the same `upgrade()` then `normalize()` here reproduces that load: a throw
+ * from either step means no viewer would render it. `upgrade()` is
+ * version-agnostic (a no-op for documents already in v3), so this single path
+ * covers both v2 (`sc:Manifest`) and v3 documents.
+ */
+function loadsInViewer(body: unknown): boolean {
+  try {
+    normalize(upgrade(body));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/iiif-validator/test/fixtures/cosmetic-deviations-manifest.json
+++ b/packages/iiif-validator/test/fixtures/cosmetic-deviations-manifest.json
@@ -1,0 +1,36 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://example.org/manifest.json",
+  "type": "Manifest",
+  "label": { "en": ["Manifest with cosmetic spec deviations"] },
+  "items": [
+    {
+      "id": "https://example.org/canvas/1",
+      "type": "Canvas",
+      "height": 50,
+      "width": 50,
+      "items": [
+        {
+          "id": "https://example.org/canvas/1/page",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://example.org/canvas/1/annotation",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://example.org/canvas/1",
+              "body": {
+                "id": "https://example.org/image/1.jpg",
+                "type": "Image",
+                "format": "image/jpg",
+                "height": 50,
+                "width": 50
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "rights": "https://creativecommons.org/licenses/zero/1.0/"
+}

--- a/packages/iiif-validator/test/fixtures/null-annotation-manifest.json
+++ b/packages/iiif-validator/test/fixtures/null-annotation-manifest.json
@@ -1,0 +1,76 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://archief.literatuurmuseum.nl/iiif/presentation/3.0/46764587/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "nl": ["Presentatie van 46764587"],
+    "en": ["Presentation of 46764587"]
+  },
+  "items": [
+    {
+      "id": "https://archief.literatuurmuseum.nl/iiif/presentation/13297860/canvas",
+      "type": "Canvas",
+      "height": 50,
+      "width": 50,
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://archief.literatuurmuseum.nl/iiif/presentation/13297860/canvas/annotation",
+          "items": [
+            {
+              "id": "https://archief.literatuurmuseum.nl/iiif/presentation/13297860/canvas/annotation/image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://archief.literatuurmuseum.nl/iiif/presentation/13297860/canvas",
+              "body": {
+                "id": "https://archief.literatuurmuseum.nl/iiif/image/3.0/ic:13297860/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpg",
+                "service": [
+                  {
+                    "id": "https://archief.literatuurmuseum.nl/iiif/image/3.0/ic:13297860",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ],
+                "height": 50,
+                "width": 50
+              }
+            }
+          ]
+        }
+      ],
+      "annotations": [null]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https://archief.literatuurmuseum.nl/iiif/image/3.0/ic:13297860/full/150,/0/default.png",
+      "type": "Image"
+    }
+  ],
+  "summary": {
+    "none": ["J 00XXX Jonker, Ingrid 1933-1968"]
+  },
+  "provider": [
+    {
+      "id": "https://archief.literatuurmuseum.nl",
+      "type": "Agent",
+      "homepage": [
+        {
+          "id": "https://archief.literatuurmuseum.nl",
+          "type": "Text",
+          "format": "text/html"
+        }
+      ]
+    }
+  ],
+  "homepage": [
+    {
+      "id": "https://hdl.handle.net/21.12129/46764587",
+      "type": "Text",
+      "format": "text/html"
+    }
+  ],
+  "rights": "https://creativecommons.org/licenses/zero/1.0/"
+}

--- a/packages/iiif-validator/test/fixtures/v2-null-canvas-manifest.json
+++ b/packages/iiif-validator/test/fixtures/v2-null-canvas-manifest.json
@@ -1,0 +1,37 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://example.org/manifest.json",
+  "@type": "sc:Manifest",
+  "label": "Presentation 2 manifest with a null canvas",
+  "sequences": [
+    {
+      "@id": "https://example.org/sequence/1",
+      "@type": "sc:Sequence",
+      "canvases": [
+        {
+          "@id": "https://example.org/canvas/1",
+          "@type": "sc:Canvas",
+          "label": "p1",
+          "height": 100,
+          "width": 100,
+          "images": [
+            {
+              "@id": "https://example.org/annotation/1",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://example.org/canvas/1",
+              "resource": {
+                "@id": "https://example.org/image/1.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 100,
+                "width": 100
+              }
+            }
+          ]
+        },
+        null
+      ]
+    }
+  ]
+}

--- a/packages/iiif-validator/test/validateManifest.test.ts
+++ b/packages/iiif-validator/test/validateManifest.test.ts
@@ -1,5 +1,14 @@
 import { validateManifest } from '../src/index.js';
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Read a JSON fixture from `test/fixtures` as a raw string.
+ */
+function fixture(name: string): string {
+  return readFileSync(join(import.meta.dirname, 'fixtures', name), 'utf8');
+}
 
 /**
  * Build a fake `fetch` that always resolves with the given body and status.
@@ -96,6 +105,76 @@ describe('validateManifest', () => {
     await validateManifest(URL, { fetch });
 
     expect(sentAccept).toBe('*/*');
+  });
+
+  it('accepts a manifest with a full Canvas / AnnotationPage / painting-annotation tree', async () => {
+    const fetch = fetchReturning(
+      JSON.stringify({
+        '@context': 'http://iiif.io/api/presentation/3/context.json',
+        id: URL,
+        type: 'Manifest',
+        items: [
+          {
+            id: 'https://example.org/canvas/1',
+            type: 'Canvas',
+            height: 100,
+            width: 100,
+            items: [
+              {
+                id: 'https://example.org/page/1',
+                type: 'AnnotationPage',
+                items: [
+                  {
+                    id: 'https://example.org/anno/1',
+                    type: 'Annotation',
+                    motivation: 'painting',
+                    target: 'https://example.org/canvas/1',
+                    body: {
+                      id: 'https://example.org/img.jpg',
+                      type: 'Image',
+                      format: 'image/jpeg',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const verdict = await validateManifest(URL, { fetch });
+
+    expect(verdict).toEqual({ valid: true, reason: 'valid-manifest' });
+  });
+
+  it('reports does-not-load for a manifest-shaped document that fails to normalise (annotations: [null])', async () => {
+    const fetch = fetchReturning(fixture('null-annotation-manifest.json'));
+
+    const verdict = await validateManifest(URL, { fetch });
+
+    expect(verdict).toEqual({ valid: false, reason: 'does-not-load' });
+  });
+
+  it('keeps a manifest with cosmetic-only deviations valid (image/jpg, non-canonical rights URI)', async () => {
+    // Deviations that real viewers tolerate must not flip the verdict: there is
+    // no warning tier, so anything that still normalises stays valid.
+    const fetch = fetchReturning(fixture('cosmetic-deviations-manifest.json'));
+
+    const verdict = await validateManifest(URL, { fetch });
+
+    expect(verdict).toEqual({ valid: true, reason: 'valid-manifest' });
+  });
+
+  it('reports does-not-load for a v2 sc:Manifest that fails the upgrade-to-v3 load path (null canvas)', async () => {
+    // v2 documents are upgraded to v3 before normalising, mirroring how Vault
+    // loads them; a null canvas crashes that upgrade, so the manifest does not
+    // load in a real viewer.
+    const fetch = fetchReturning(fixture('v2-null-canvas-manifest.json'));
+
+    const verdict = await validateManifest(URL, { fetch });
+
+    expect(verdict).toEqual({ valid: false, reason: 'does-not-load' });
   });
 
   it('reports http-error for a non-2xx response', async () => {

--- a/packages/iiif-validator/vite.config.ts
+++ b/packages/iiif-validator/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 97.43,
+          lines: 97.77,
           functions: 100,
-          branches: 89.47,
-          statements: 95.45,
+          branches: 90,
+          statements: 96,
         },
       },
     },


### PR DESCRIPTION
## Summary

Tightens `@lde/iiif-validator` so that a “valid” manifest means **“loads in a real IIIF viewer”**, not merely “parses as JSON and looks like a manifest”.

The previous structural check (`isPresentationManifest`) accepted a document when it was HTTP 2xx, parsed as JSON, referenced an IIIF Presentation `@context`, and carried a manifest `type`. That is too permissive: a manifest can pass all four checks yet fail to load in every viewer built on the `@iiif/parser` / Vault stack (Mirador 4, Clover, Theseus), because those viewers eagerly upgrade and normalise the whole manifest tree on load.

Real-world example: the Literature Museum’s manifests declare `"annotations": [null]` on each Canvas – a `null` where an `AnnotationPage` belongs. The old validator reported them `valid: true`, but `@iiif/parser`’s `normalize()` throws (`Cannot read properties of null (reading 'items')`), so they render in no Vault-based viewer.

## Change

- After the structural check passes, reproduce the viewer load path with `@iiif/parser` (`normalize(upgrade(body))`). If it throws, the verdict is the new `does-not-load` reason.
- A single pipeline covers **both v2 and v3**: `upgrade()` is a no-op for v3 documents and is what catches v2 faults, since `presentation-2` exposes no `normalize()`. This mirrors how Vault actually loads manifests (detect version → upgrade to v3 → normalise).
- Two tiers only – valid or invalid. Cosmetic deviations that still load (a non-canonical `rights` URI, `image/jpg` instead of `image/jpeg`) stay valid; there is no warning tier.
- Add `@iiif/parser` as a dependency.
- Document the viewer-load gate in the README and add the missing `binary-content` reason the docs had drifted on.

## Tests

- Literature Museum `annotations: [null]` fixture → `valid: false`, `does-not-load`.
- Full Canvas / AnnotationPage / painting-annotation tree → `valid: true`.
- Cosmetic-deviation fixture (`image/jpg`, CC0 `rights` URI) → `valid: true`.
- v2 `sc:Manifest` with a null canvas (caught during `upgrade()`) → `valid: false`, `does-not-load`.

## Downstream

No consumer changes required: the Dataset Knowledge Graph and Dataset Register consume the `valid` boolean. After release, bump `@lde/iiif-validator` in the Dataset Knowledge Graph to flip datasets whose sampled manifests don’t load from a green IIIF “Yes” to failed.

Fix #444
