### PR TITLE
fix(pipeline): prefer most recent of register and HTTP dates for dump change detection

### DIFF
--- a/packages/pipeline/src/distribution/importResolver.ts
+++ b/packages/pipeline/src/distribution/importResolver.ts
@@ -80,17 +80,23 @@ export class ImportResolver implements DistributionResolver {
       .getDownloadDistributions()
       .filter((d) => d.accessUrl && successfulUrls.has(d.accessUrl.toString()));
 
-    // Propagate Last-Modified from probe to candidate so the downloader can
-    // skip redundant downloads (and preserve the QLever index cache).
+    // Establish a trustworthy change signal for the downloader so it can skip
+    // redundant downloads (and preserve the QLever index cache). For a data
+    // dump the authoritative date is the most recent of the register’s declared
+    // `dct:modified` and the artifact’s real HTTP `Last-Modified`: a stale
+    // register date must never mask a newer upload (openarchieven publishes
+    // dumps with a months-old `dct:modified`, see #436). Taking the maximum errs
+    // toward reprocessing rather than serving stale output.
     for (const candidate of candidates) {
-      if (candidate.lastModified) continue;
       const probeResult = probeResults.find(
         (r) => r.url === candidate.accessUrl.toString(),
       );
       if (
         probeResult &&
         !(probeResult instanceof NetworkError) &&
-        probeResult.lastModified
+        probeResult.lastModified &&
+        (candidate.lastModified === undefined ||
+          probeResult.lastModified > candidate.lastModified)
       ) {
         candidate.lastModified = probeResult.lastModified;
       }

--- a/packages/pipeline/test/distribution/importResolver.test.ts
+++ b/packages/pipeline/test/distribution/importResolver.test.ts
@@ -423,8 +423,9 @@ describe('ImportResolver', () => {
       ]);
     });
 
-    it('does not overwrite Last-Modified already set on the distribution', async () => {
-      const existingLastModified = new Date('2026-01-01T00:00:00Z');
+    it('prefers a newer probe Last-Modified over a stale register date', async () => {
+      const staleRegisterDate = new Date('2026-01-01T00:00:00Z');
+      const realHttpLastModified = new Date('2026-02-15T10:00:00Z');
       const dataset = new Dataset({
         iri: new URL('http://example.org/dataset'),
         distributions: [
@@ -433,7 +434,7 @@ describe('ImportResolver', () => {
               new URL('http://example.org/data.nt'),
               'application/n-triples',
             );
-            distribution.lastModified = existingLastModified;
+            distribution.lastModified = staleRegisterDate;
             return distribution;
           })(),
         ],
@@ -445,7 +446,7 @@ describe('ImportResolver', () => {
           headers: {
             'Content-Length': '1000',
             'Content-Type': 'application/n-triples',
-            'Last-Modified': new Date('2026-02-15T10:00:00Z').toUTCString(),
+            'Last-Modified': realHttpLastModified.toUTCString(),
           },
         }),
         0,
@@ -472,8 +473,60 @@ describe('ImportResolver', () => {
       await resolver.resolve(dataset);
 
       expect(dataset.distributions[0].lastModified).toEqual(
-        existingLastModified,
+        realHttpLastModified,
       );
+    });
+
+    it('keeps a newer register date over an older probe Last-Modified', async () => {
+      const newerRegisterDate = new Date('2026-03-01T00:00:00Z');
+      const olderHttpLastModified = new Date('2026-02-15T10:00:00Z');
+      const dataset = new Dataset({
+        iri: new URL('http://example.org/dataset'),
+        distributions: [
+          (() => {
+            const distribution = new Distribution(
+              new URL('http://example.org/data.nt'),
+              'application/n-triples',
+            );
+            distribution.lastModified = newerRegisterDate;
+            return distribution;
+          })(),
+        ],
+      });
+      const probeResult = new DataDumpProbeResult(
+        'http://example.org/data.nt',
+        new Response('', {
+          status: 200,
+          headers: {
+            'Content-Length': '1000',
+            'Content-Type': 'application/n-triples',
+            'Last-Modified': olderHttpLastModified.toUTCString(),
+          },
+        }),
+        0,
+      );
+      const inner = makeInnerResolver(
+        new NoDistributionAvailable(dataset, 'No endpoint', [probeResult]),
+      );
+
+      const mockImporter = {
+        import: vi
+          .fn()
+          .mockResolvedValue(
+            new ImportSuccessful(
+              Distribution.sparql(new URL('http://localhost:7878/sparql')),
+              'test-graph',
+            ),
+          ),
+      };
+
+      const resolver = new ImportResolver(inner, {
+        importer: mockImporter,
+        server: makeServer(),
+      });
+      await resolver.resolve(dataset);
+
+      expect(dataset.distributions[0].lastModified).toEqual(newerRegisterDate);
     });
 
     it('preserves subjectFilter from imported distribution', async () => {

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 94.44,
-          lines: 93.78,
+          lines: 93.77,
           branches: 88.99,
-          statements: 93.32,
+          statements: 93.3,
         },
       },
     },


### PR DESCRIPTION
## Problem

Change detection that trusts a dataset description’s `dct:modified` is unreliable: the published date can be badly stale relative to the actual distribution. Across all 83 openarchieven `.nt.gz` dumps, the register-exposed `dct:modified` is `2024-01-17`, while the dumps’ real HTTP `Last-Modified` is `2025-09-13` – roughly 20 months stale.

`ImportResolver` previously only fell back to the probe’s HTTP `Last-Modified` when the register date was absent (`if (candidate.lastModified) continue;`). So a stale register date won, and `LastModifiedDownloader` would judge the local file up to date and skip the re-download – serving stale output.

## Change

For data-dump candidates, `ImportResolver` now sets the change signal to the **most recent** of the register’s `dct:modified` and the artifact’s real HTTP `Last-Modified`:

- A stale register date can no longer mask a newer upload – the max picks the real `2025-09-13` date, so the downloader re-fetches.
- A newer register date is still preserved (the probe date never downgrades it).
- This errs toward reprocessing rather than serving stale output. A spuriously future register date therefore causes harmless permanent reprocessing (wasteful but never stale).

SPARQL endpoints are unaffected: only data-dump candidates (`getDownloadDistributions()`) pass through this path, so endpoints keep relying on their declared date.

ETag-based detection (the issue’s preferred primary signal for same-day re-uploads) is intentionally out of scope here – it needs probe ETag capture plus sidecar persistence in the downloader, tracked as companion work to #308.

## Verification

- Unit tests pin both directions of the max (stale register yields to newer HTTP date; newer register is kept over an older HTTP date), alongside the existing register-absent propagation test.
- Verified end-to-end against the live artifact `oa-export.s3.nl-ams.scw.cloud/nt/frl.nt.gz`: the real probe captures HTTP `Last-Modified 2025-09-13`, and the max selects it over the `2024-01-17` register date.

The coverage threshold nudge (`lines`/`statements`) reflects the one-line denominator shift from the refactor; `autoUpdate` only ratchets thresholds up.

Fix #436
