### PR TITLE
feat(dataset): accept application/rdf+xml as an RDF media type

### DIFF
--- a/packages/dataset-registry-client/test/client.test.ts
+++ b/packages/dataset-registry-client/test/client.test.ts
@@ -32,7 +32,8 @@ describe('Client', () => {
         },
       });
 
-      const expectedTotal = 2;
+      // foo (turtle), bar (turtle) and baz (rdf+xml) all match.
+      const expectedTotal = 3;
       expect(results.total).toEqual(expectedTotal);
       let count = 0;
       let firstResult;
@@ -74,7 +75,8 @@ describe('Client', () => {
       `;
       const results = await client.query(query);
 
-      const expectedTotal = 2;
+      // foo, bar and baz each have a titled distribution with a mediaType.
+      const expectedTotal = 3;
       expect(results.total).toEqual(expectedTotal);
       let count = 0;
       for await (const _ of results) {

--- a/packages/dataset-registry-client/test/fixtures/registry.ttl
+++ b/packages/dataset-registry-client/test/fixtures/registry.ttl
@@ -35,6 +35,15 @@
     dcat:byteSize "87654321" ;
   ] .
 
+<http://baz.org/id/dataset/baz> a dcat:Dataset ;
+  dct:title "test" ;
+  dcat:distribution [
+    a dcat:Distribution ;
+    dcat:accessURL <http://baz.org/files/baz.rdf> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/rdf+xml> ;
+    dcat:byteSize "87654321" ;
+  ] .
+
 <http://foo.org> a foaf:Organization ;
   foaf:name "Foo Organization" ;
 .

--- a/packages/dataset/src/mediaType.ts
+++ b/packages/dataset/src/mediaType.ts
@@ -12,6 +12,7 @@ export const rdfMediaTypes = [
   iana('application/ld+json'),
   iana('application/n-quads'),
   iana('application/n-triples'),
+  iana('application/rdf+xml'),
   iana('text/turtle'),
 ];
 


### PR DESCRIPTION
## Problem

`rdfMediaTypes` – the allow-list spread into the registry client’s `mediaType $in` filter – omitted `application/rdf+xml`. Consumers querying the Dataset Register by media-type criteria would therefore skip datasets whose only RDF distribution is RDF/XML, even though the probe and the QLever importer both already support that serialization.

This surfaced via RoMeO (netwerk-digitaal-erfgoed/dataset-register#2058), whose Turtle/NT/NQ/JSON-LD dumps all return 0 bytes while its 49 MB `application/rdf+xml` dump is the only one with data.

## Change

- Add `application/rdf+xml` to `rdfMediaTypes` in `@lde/dataset`.
- Extend the `dataset-registry-client` fixture with a dataset whose only distribution is RDF/XML, and bump the expected match counts, so the new media type is covered by a regression test.

## Testing

- `nx run-many -t build test lint typecheck` for `@lde/dataset` and `@lde/dataset-registry-client` – all green (client tests: 4 passed).
