### PR TITLE
feat(pipeline): add FileWriter graphIri option and atomic writes

### DIFF
--- a/packages/pipeline/src/writer/fileWriter.ts
+++ b/packages/pipeline/src/writer/fileWriter.ts
@@ -1,10 +1,10 @@
 import { Dataset } from '@lde/dataset';
 import type { Quad } from '@rdfjs/types';
 import { createWriteStream, type WriteStream } from 'node:fs';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, rename, rm } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import filenamifyUrl from 'filenamify-url';
-import { Writer as N3Writer } from 'n3';
+import { DataFactory, Writer as N3Writer } from 'n3';
 import { Writer } from './writer.js';
 
 export interface FileWriterOptions {
@@ -27,6 +27,16 @@ export interface FileWriterOptions {
    * Only used when format is 'turtle'.
    */
   prefixes?: Record<string, string>;
+  /**
+   * Derive the named-graph IRI each quad is written into. Only meaningful for
+   * format `'n-quads'`; ignored for `'turtle'` and `'n-triples'`, which have no
+   * graph slot. When set, every quad is re-emitted with this graph term,
+   * regardless of the quad's own graph — mirroring
+   * {@link SparqlUpdateWriter}'s `graphIri`, so the same callback produces the
+   * same named-graph structure whether you write to a SPARQL store or to files.
+   * Defaults to undefined (quads written as-is, i.e. the default graph).
+   */
+  graphIri?: (dataset: Dataset) => URL;
 }
 
 /**
@@ -49,9 +59,10 @@ export class FileWriter implements Writer {
   readonly format: 'turtle' | 'n-triples' | 'n-quads';
   private readonly replacementCharacter: string;
   private readonly prefixes?: Record<string, string>;
+  private readonly graphIri?: (dataset: Dataset) => URL;
   private readonly activeWriters = new Map<
     string,
-    { n3Writer: N3Writer; stream: WriteStream }
+    { n3Writer: N3Writer; stream: WriteStream; tempPath: string }
   >();
 
   constructor(options: FileWriterOptions) {
@@ -59,6 +70,7 @@ export class FileWriter implements Writer {
     this.format = options.format ?? 'n-triples';
     this.replacementCharacter = options.replacementCharacter ?? '-';
     this.prefixes = options.prefixes;
+    this.graphIri = options.graphIri;
   }
 
   async write(dataset: Dataset, quads: AsyncIterable<Quad>): Promise<void> {
@@ -69,9 +81,28 @@ export class FileWriter implements Writer {
 
     const { n3Writer } = await this.getOrCreateWriter(dataset);
 
-    n3Writer.addQuad(first.value);
+    // Re-emit each quad into the configured named graph (n-quads only). The
+    // pipeline's quads carry no graph context, so the graph is supplied here
+    // exactly as SparqlUpdateWriter supplies it via INSERT DATA { GRAPH … }.
+    const graphNode =
+      this.format === 'n-quads' && this.graphIri
+        ? DataFactory.namedNode(this.graphIri(dataset).toString())
+        : undefined;
+    const addQuad = (quad: Quad) =>
+      n3Writer.addQuad(
+        graphNode
+          ? DataFactory.quad(
+              quad.subject,
+              quad.predicate,
+              quad.object,
+              graphNode,
+            )
+          : quad,
+      );
+
+    addQuad(first.value);
     for await (const quad of { [Symbol.asyncIterator]: () => iterator }) {
-      n3Writer.addQuad(quad);
+      addQuad(quad);
     }
   }
 
@@ -81,16 +112,28 @@ export class FileWriter implements Writer {
     if (!entry) return;
 
     this.activeWriters.delete(key);
-    await new Promise<void>((resolve, reject) => {
-      if (entry.stream.errored) {
-        reject(entry.stream.errored);
-        return;
-      }
-      entry.n3Writer.end((error) => {
-        if (error) reject(error);
-        else resolve();
+
+    // Quads are streamed to a sibling temp file; only on a clean flush is it
+    // atomically renamed onto the final path. A crash therefore leaves at most
+    // a stale `*.tmp` — never a truncated final file — so a downstream index
+    // rebuild that globs the final extension never reads a half-written file.
+    try {
+      await new Promise<void>((resolve, reject) => {
+        if (entry.stream.errored) {
+          reject(entry.stream.errored);
+          return;
+        }
+        entry.n3Writer.end((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
       });
-    });
+    } catch (error) {
+      await rm(entry.tempPath, { force: true, recursive: true });
+      throw error;
+    }
+
+    await rename(entry.tempPath, key);
   }
 
   getOutputPath(dataset: Dataset): string {
@@ -111,14 +154,18 @@ export class FileWriter implements Writer {
 
   private async getOrCreateWriter(
     dataset: Dataset,
-  ): Promise<{ n3Writer: N3Writer; stream: WriteStream }> {
+  ): Promise<{ n3Writer: N3Writer; stream: WriteStream; tempPath: string }> {
     const key = this.getFilePath(dataset);
     const existing = this.activeWriters.get(key);
     if (existing) return existing;
 
     await mkdir(dirname(key), { recursive: true });
 
-    const stream = createWriteStream(key, { flags: 'w' });
+    // Write to a sibling temp file (same directory, so the flush rename stays on
+    // one filesystem and is atomic). The `.tmp` suffix keeps it out of any glob
+    // on the final extension.
+    const tempPath = `${key}.tmp`;
+    const stream = createWriteStream(tempPath, { flags: 'w' });
     stream.on('error', (error) => {
       // Surface stream errors when flushing; prevents 'unhandled error' crashes.
       stream.destroy(error);
@@ -128,7 +175,7 @@ export class FileWriter implements Writer {
       prefixes: this.prefixes,
     });
 
-    const entry = { n3Writer, stream };
+    const entry = { n3Writer, stream, tempPath };
     this.activeWriters.set(key, entry);
     return entry;
   }

--- a/packages/pipeline/test/writer/fileWriter.test.ts
+++ b/packages/pipeline/test/writer/fileWriter.test.ts
@@ -3,9 +3,18 @@ import { Dataset, Distribution } from '@lde/dataset';
 import { DataFactory } from 'n3';
 import type { Quad } from '@rdfjs/types';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, readFile, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 const { namedNode, literal, quad } = DataFactory;
 
@@ -192,6 +201,189 @@ describe('FileWriter', () => {
         'utf-8',
       );
       expect(content).toBeTruthy();
+    });
+  });
+
+  describe('named graphs (n-quads)', () => {
+    it('writes each quad into the graph derived from graphIri', async () => {
+      const writer = new FileWriter({
+        outputDir: tempDir,
+        format: 'n-quads',
+        graphIri: (dataset) => dataset.iri,
+      });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/subject'),
+            namedNode('http://example.com/predicate'),
+            literal('object'),
+          ),
+        ),
+      );
+      await writer.flush(dataset);
+
+      const content = await readFile(
+        join(tempDir, 'example.com-dataset-1.nq'),
+        'utf-8',
+      );
+      // The graph is the 4th term on the line.
+      expect(content.trim()).toBe(
+        '<http://example.com/subject> <http://example.com/predicate> "object" <http://example.com/dataset/1> .',
+      );
+    });
+
+    it('supports a graphIri unrelated to the dataset IRI (e.g. validation report)', async () => {
+      const writer = new FileWriter({
+        outputDir: tempDir,
+        format: 'n-quads',
+        graphIri: (dataset) =>
+          new URL(
+            `https://reports.example/${encodeURIComponent(dataset.iri.toString())}`,
+          ),
+      });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/s'),
+            namedNode('http://example.com/p'),
+            literal('o'),
+          ),
+        ),
+      );
+      await writer.flush(dataset);
+
+      const content = await readFile(
+        join(tempDir, 'example.com-dataset-1.nq'),
+        'utf-8',
+      );
+      expect(content).toContain(
+        '<https://reports.example/http%3A%2F%2Fexample.com%2Fdataset%2F1>',
+      );
+    });
+
+    it('writes the default graph when graphIri is omitted', async () => {
+      const writer = new FileWriter({ outputDir: tempDir, format: 'n-quads' });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/subject'),
+            namedNode('http://example.com/predicate'),
+            literal('object'),
+          ),
+        ),
+      );
+      await writer.flush(dataset);
+
+      const content = await readFile(
+        join(tempDir, 'example.com-dataset-1.nq'),
+        'utf-8',
+      );
+      // No 4th term: the triple sits in the default graph.
+      expect(content.trim()).toBe(
+        '<http://example.com/subject> <http://example.com/predicate> "object" .',
+      );
+    });
+
+    it('ignores graphIri for turtle output', async () => {
+      const writer = new FileWriter({
+        outputDir: tempDir,
+        format: 'turtle',
+        graphIri: (dataset) => dataset.iri,
+      });
+
+      const dataset = createDataset('http://example.com/dataset/1');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/subject'),
+            namedNode('http://example.com/predicate'),
+            literal('object'),
+          ),
+        ),
+      );
+      await writer.flush(dataset);
+
+      const content = await readFile(
+        join(tempDir, 'example.com-dataset-1.ttl'),
+        'utf-8',
+      );
+      expect(content).not.toContain('http://example.com/dataset/1');
+    });
+  });
+
+  describe('atomic flush', () => {
+    it('only materializes the final file on flush, never a truncated one', async () => {
+      const writer = new FileWriter({ outputDir: tempDir, format: 'n-quads' });
+      const dataset = createDataset('http://example.com/dataset/1');
+      const finalPath = join(tempDir, 'example.com-dataset-1.nq');
+
+      await writer.write(
+        dataset,
+        quadsOf(
+          quad(
+            namedNode('http://example.com/s'),
+            namedNode('http://example.com/p'),
+            literal('o'),
+          ),
+        ),
+      );
+
+      // Before flush: the final file does not exist yet — a crash here leaves
+      // only a `.tmp`, never a half-written final file.
+      expect(await exists(finalPath)).toBe(false);
+
+      await writer.flush(dataset);
+
+      // After flush: the final file exists and the temp is gone.
+      expect(await exists(finalPath)).toBe(true);
+      expect(await exists(`${finalPath}.tmp`)).toBe(false);
+    });
+
+    it('cleans up the temp file and rejects when the stream fails', async () => {
+      const writer = new FileWriter({ outputDir: tempDir, format: 'n-quads' });
+      const dataset = createDataset('http://example.com/dataset/1');
+      const finalPath = join(tempDir, 'example.com-dataset-1.nq');
+      const tempPath = `${finalPath}.tmp`;
+
+      // Pre-create a directory exactly where the temp file would be opened, so
+      // the write stream fails to open (EISDIR) — a deterministic stand-in for
+      // a mid-flush I/O failure.
+      await mkdir(tempPath, { recursive: true });
+
+      await writer
+        .write(
+          dataset,
+          quadsOf(
+            quad(
+              namedNode('http://example.com/s'),
+              namedNode('http://example.com/p'),
+              literal('o'),
+            ),
+          ),
+        )
+        .catch(() => undefined);
+      // Let the asynchronous open error settle.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      await expect(writer.flush(dataset)).rejects.toThrow();
+
+      // No final file was produced, and the temp path was cleaned up.
+      expect(await exists(finalPath)).toBe(false);
+      expect(await exists(tempPath)).toBe(false);
     });
   });
 

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 94.44,
-          lines: 93.77,
-          branches: 88.99,
-          statements: 93.3,
+          functions: 95.09,
+          lines: 94.35,
+          branches: 89.62,
+          statements: 93.87,
         },
       },
     },


### PR DESCRIPTION
## What

Two backward-compatible additions to `FileWriter` in `@lde/pipeline`:

1. **`graphIri?: (dataset) => URL`** — n-quads only. Re-emits each quad into the
   named graph the callback returns (mirrors `SparqlUpdateWriter.graphIri`). The
   pipeline’s quads carry no graph context, so without this n-quads output lands
   in the default graph. Omitting the option preserves current behaviour;
   ignored for `turtle`/`n-triples`.
2. **Atomic flush** — each dataset is streamed to a sibling `*.tmp` and `rename`d
   onto the final path on a clean flush; a stream error deletes the temp and
   rethrows. A crash therefore leaves at most a stale `*.tmp`, never a truncated
   final file.

## Why

Enables the “write per-dataset n-quads, rebuild a read-only index” pattern — the
new output store for the Dataset Knowledge Graph
(netwerk-digitaal-erfgoed/dataset-knowledge-graph#298), which needs one named
graph per analysed dataset and files that are safe to index even if a run is
interrupted.

## Tests

Added FileWriter tests for graphIri (n-quads with/without, ignored for turtle)
and atomicity (no final file before flush, complete after, cleaned up on error).
Full `@lde/pipeline` suite green; coverage thresholds updated upward.
