### PR TITLE
feat(pipeline-shacl-sampler): add excludeResources hook to subtract resources from samples

### DIFF
--- a/packages/pipeline-shacl-sampler/README.md
+++ b/packages/pipeline-shacl-sampler/README.md
@@ -50,6 +50,7 @@ await new Pipeline({ /* … */, stages }).run();
 | `validator`        | —                 | Optional [`Validator`](../pipeline/src/validator.ts) attached to every generated stage (typically a `ShaclValidator`).                                 |
 | `onInvalid`        | `'write'`         | Behaviour when a sampled batch fails validation: `'write'` \| `'skip'` \| `'halt'`. Only used when `validator` is set.                                 |
 | `namespaceAliases` | `[]`              | Namespaces to treat as equivalent when matching `sh:targetClass` and when handing quads to the validator. See [Namespace aliases](#namespace-aliases). |
+| `excludeResources` | —                 | Hook returning a SPARQL fragment that subtracts resources from a target class’s sample. See [Excluding resources](#excluding-resources).               |
 
 ## Namespace aliases
 
@@ -82,6 +83,45 @@ const stages = await shaclSampleStages({
   ],
 });
 ```
+
+## Excluding resources
+
+A profile may target a class that also describes a dataset’s own
+administrative metadata rather than its collection content. For example,
+SCHEMA-AP-NDE targets `schema:Organization`, so a dump containing nothing
+but a `schema:Dataset` and the publisher `Organization` that supports it
+would get that publisher sampled, found trivially conformant (only `name`
+is required), and reported as “tested and passed” — even though the
+dataset holds no real content.
+
+`excludeResources` lets the caller subtract such resources from a target
+class’s sample **without weakening the SHACL shapes**. It is a hook called
+once per `sh:targetClass`; the SPARQL fragment it returns is inlined
+verbatim into the subject-selector `WHERE` clause **after** the type
+pattern, so it can reference the bound `?s` (e.g. a `MINUS { … }` clause
+that removes `?s` when it is the dataset’s publisher). Return `''` to
+sample that class unchanged; omitting the option entirely leaves every
+generated query byte-for-byte the same.
+
+The fragment is interpolated verbatim and therefore caller-trusted — the
+same trust model as a distribution’s `subjectFilter`.
+
+```ts
+const SCHEMA = 'https://schema.org/';
+const stages = await shaclSampleStages({
+  shapesFile,
+  validator,
+  excludeResources: (targetClass) =>
+    targetClass.value === `${SCHEMA}Organization`
+      ? `MINUS { ?dataset a <${SCHEMA}Dataset> ; <${SCHEMA}publisher> ?s . }`
+      : '',
+});
+```
+
+Anchoring the exclusion to the dataset node (rather than to the predicate
+alone) keeps genuine content resources in the sample: an `Organization`
+reached as the `creator` of a `CreativeWork`, say, is never the dataset’s
+publisher, so it is still sampled and validated.
 
 ## Limitations
 

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -85,6 +85,21 @@ export interface ShaclSampleStagesOptions {
    * `[{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }]`.
    */
   namespaceAliases?: NamespaceAlias[];
+  /**
+   * Optional hook returning a SPARQL graph-pattern fragment that subtracts
+   * resources from the per-target-class sample. Called once per
+   * `sh:targetClass`; the returned fragment is inlined verbatim into the
+   * subject-selector `WHERE` clause after the type pattern (so it can
+   * reference the bound `?s`), alongside the per-distribution
+   * {@link SubjectSelectorQueryOptions.subjectFilter}. Return `''` (the
+   * default behaviour when the option is omitted) to sample that class
+   * unchanged.
+   *
+   * Typical use: a caller that knows some resources are administrative
+   * metadata rather than collection content (e.g. a dataset’s own publisher)
+   * returns a `MINUS { … }` fragment to keep them out of validation.
+   */
+  excludeResources?: (targetClass: NamedNode) => string;
 }
 
 /**
@@ -128,6 +143,7 @@ export async function shaclSampleStages(
           shape.targetClass,
           samplesPerClass,
           namespaceAliases,
+          options.excludeResources?.(shape.targetClass),
         ),
         executors: new SparqlConstructExecutor({
           query: buildSampleQuery(shape),
@@ -143,6 +159,7 @@ function subjectSelector(
   targetClass: NamedNode,
   limit: number,
   namespaceAliases: NamespaceAlias[],
+  excludeFilter?: string,
 ): ItemSelector {
   assertSafeIri(targetClass.value);
   return {
@@ -155,6 +172,7 @@ function subjectSelector(
         subjectFilter: distribution.subjectFilter,
         namedGraph: distribution.namedGraph,
         namespaceAliases,
+        excludeFilter,
       });
       return new SparqlItemSelector({
         query,
@@ -174,6 +192,12 @@ export interface SubjectSelectorQueryOptions {
   namedGraph?: string;
   /** Equivalent namespaces to broaden the type match across. @default [] */
   namespaceAliases?: NamespaceAlias[];
+  /**
+   * Optional fragment subtracting resources from the sample, inlined verbatim
+   * after the type pattern so it can reference the bound `?s` (e.g. a
+   * `MINUS { … }` clause). @default ''
+   */
+  excludeFilter?: string;
 }
 
 export function buildSubjectSelectorQuery({
@@ -181,6 +205,7 @@ export function buildSubjectSelectorQuery({
   subjectFilter,
   namedGraph,
   namespaceAliases = [],
+  excludeFilter,
 }: SubjectSelectorQueryOptions): string {
   let fromClause = '';
   if (namedGraph) {
@@ -191,7 +216,7 @@ export function buildSubjectSelectorQuery({
   return [
     'SELECT DISTINCT ?s',
     fromClause,
-    `WHERE { ${subjectFilter ?? ''} ${typePattern} }`,
+    `WHERE { ${subjectFilter ?? ''} ${typePattern} ${excludeFilter ?? ''} }`,
   ].join('\n');
 }
 

--- a/packages/pipeline-shacl-sampler/test/sampleStages.test.ts
+++ b/packages/pipeline-shacl-sampler/test/sampleStages.test.ts
@@ -112,6 +112,22 @@ describe('buildSubjectSelectorQuery', () => {
     });
     expect(query).toContain('FROM <https://example.org/graph>');
   });
+
+  it('inlines an excludeFilter after the type pattern so it can reference ?s', () => {
+    const query = buildSubjectSelectorQuery({
+      targetClass,
+      excludeFilter: 'MINUS { ?d <https://schema.org/publisher> ?s . }',
+    });
+    const typeIndex = query.indexOf('?s a <https://schema.org/CreativeWork> .');
+    const minusIndex = query.indexOf('MINUS {');
+    expect(typeIndex).toBeGreaterThanOrEqual(0);
+    expect(minusIndex).toBeGreaterThan(typeIndex);
+  });
+
+  it('leaves the WHERE clause free of MINUS when no excludeFilter is given', () => {
+    const query = buildSubjectSelectorQuery({ targetClass });
+    expect(query).not.toMatch(/\bMINUS\b/);
+  });
 });
 
 describe('wrapValidatorWithAliasNormalization', () => {
@@ -255,6 +271,23 @@ describe('shaclSampleStages', () => {
       {} as Dataset,
     );
     expect(seen[0]?.[0]?.predicate.value).toBe('https://schema.org/creator');
+  });
+
+  it('invokes excludeResources once per sh:targetClass when provided', async () => {
+    const seenTargetClasses: string[] = [];
+    await shaclSampleStages({
+      shapesFile,
+      excludeResources: (targetClass) => {
+        seenTargetClasses.push(targetClass.value);
+        return '';
+      },
+    });
+    expect(seenTargetClasses.sort()).toEqual([
+      'https://schema.org/CreativeWork',
+      'https://schema.org/Organization',
+      'https://schema.org/Person',
+      'https://schema.org/Place',
+    ]);
   });
 
   it('passes the validator through unchanged when no namespaceAliases are configured (the default)', async () => {

--- a/packages/pipeline-shacl-sampler/vite.config.ts
+++ b/packages/pipeline-shacl-sampler/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
           autoUpdate: true,
           functions: 96.77,
           lines: 97.36,
-          branches: 89.61,
+          branches: 89.87,
           statements: 95.15,
         },
       },


### PR DESCRIPTION
## What

Adds an optional `excludeResources(targetClass)` hook to `shaclSampleStages`. The string it returns is inlined verbatim into the per-target-class subject-selector `WHERE` clause, right after the type pattern, alongside the existing per-distribution `subjectFilter`. Returning `''` (the default when the option is omitted) leaves generated queries byte-for-byte unchanged.

## Why

A SHACL profile may target a class that also describes a dataset’s *own administrative metadata* rather than its collection content. The motivating case (NDE’s SCHEMA-AP-NDE in the dataset-knowledge-graph pipeline): the profile targets `schema:Organization`, so a dump containing nothing but a `schema:Dataset` and the publisher `Organization` that supports it gets that publisher sampled, found trivially conformant (only `name` is required), and reported as “tested and passed”.

This hook lets the caller subtract such resources from the sample without weakening the SHACL shapes (Organizations are intentionally optional there). The exclusion is a caller-supplied SPARQL fragment, so the policy of *what* counts as non-content metadata stays in the consumer, not in this generic package.

## Notes

- Mirrors the existing `subjectFilter` inlining; the fragment is interpolated verbatim (caller-trusted), same trust model as `subjectFilter`.
- The fragment is appended after the type pattern so it can reference the bound `?s` (e.g. a `MINUS { … }` clause).

## Tests

- `buildSubjectSelectorQuery` inlines the `excludeFilter` after the type pattern, and omits any `MINUS` when no filter is given.
- `shaclSampleStages` invokes `excludeResources` once per `sh:targetClass`.
- Full suite green (28 tests), lint clean.

## Downstream

Consumed by a follow-up in `dataset-knowledge-graph` that excludes a dataset’s own publisher from SCHEMA-AP-NDE sampling. Needs a release of this package before that bump can land.
