### PR TITLE
feat(pipeline): skip unchanged datasets — provenance store, two-phase resolver, gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Each package uses conditional exports with a `development` condition for local d
 - Test files use `.test.ts` suffix in `test/` directory
 - Fixtures in `test/fixtures/`
 - HTTP mocking with Nock
-- Tests that start a local SPARQL endpoint (`@lde/local-sparql-endpoint`) must use unique ports across packages to avoid conflicts when Nx runs tests in parallel. Current port allocations: `dataset-registry-client` (3002), `pipeline` sparqlQuery (3001), `pipeline` executor (3003)
+- Tests that start a local SPARQL endpoint (`@lde/local-sparql-endpoint`) must use unique ports across packages to avoid conflicts when Nx runs tests in parallel. Current port allocations: `dataset-registry-client` (3002), `pipeline` sparqlQuery (3001), `pipeline` executor (3003), `pipeline` provenance store (3004)
 
 ### Key Dependencies
 

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -276,6 +276,42 @@ Writes generated quads to a destination:
 - `SparqlUpdateWriter` — writes to a SPARQL endpoint via UPDATE queries
 - `FileWriter` — writes to local files
 
+### Provenance store
+
+A `ProvenanceStore` gives the pipeline a small per-dataset memory, so a future run can skip datasets that are genuinely unchanged. It is purely a storage seam: the framework owns the skip decision (see [`sourceFingerprint`](#source-change-fingerprint) and `shouldReprocess`), the store owns only how each record is persisted.
+
+```typescript
+interface ProvenanceStore {
+  get(datasetUri: URL): Promise<ProcessingRecord | null>;
+  set(datasetUri: URL, record: ProcessingRecord): Promise<void>;
+}
+```
+
+A `ProcessingRecord` holds the two opaque change fields — `sourceFingerprint` (derived automatically from source metadata) and `pipelineVersion` (consumer-declared) — plus `generatedAt` and a `status` of `'success'` or `'failed'`. The two change fields are compared only for equality, never parsed or ordered.
+
+#### `FileLoadedSparqlProvenanceStore`
+
+The reference implementation targets a triplestore that is served read-only and rebuilt by bulk-loading files (e.g. [QLever](https://github.com/ad-freiburg/qlever)). It reads through SPARQL queries against the live endpoint, and writes records as files for the next bulk-load — because the endpoint accepts no SPARQL UPDATE.
+
+```typescript
+import { FileLoadedSparqlProvenanceStore } from '@lde/pipeline';
+
+const store = new FileLoadedSparqlProvenanceStore({
+  queryEndpoint: new URL('http://localhost:7001/sparql'),
+  pipelineIri: new URL('https://example.org/pipelines/dkg'),
+  outputDir: './provenance',
+});
+```
+
+- `get` runs a named-graph-scoped SPARQL `SELECT` against `queryEndpoint`, reading the records a previous run loaded.
+- `set` writes one flat [PROV-O](https://www.w3.org/TR/prov-o/) N-Quads file per dataset into `outputDir`, in the pipeline-scoped named graph, to be bulk-loaded after the run.
+
+Each record is stored as flat PROV-O on the dataset entity — `prov:generatedAtTime` plus `sourceFingerprint`, `pipelineVersion` and `status` under the `https://w3id.org/lde/provenance#` namespace. Scoping every record by `pipelineIri` (used as the named graph) lets multiple pipelines share one triplestore without colliding.
+
+### Source-change fingerprint
+
+`sourceFingerprint(distribution, probeResult)` derives a cheap, opaque change signal for a distribution from metadata the probe already collected — no body download. For a data dump it combines the most recent of the register’s `dct:modified` and the artifact’s HTTP `Last-Modified` with the byte size (the probe’s `Content-Length`, falling back to the declared `dcat:byteSize`). It returns `null` for a live SPARQL endpoint, or when no date and no size can be established — a `null` fingerprint never compares equal, so such a distribution is always reprocessed.
+
 ### Plugins
 
 Plugins hook into the pipeline lifecycle via the `PipelinePlugin` interface. Register them in the `plugins` array when constructing a `Pipeline`.

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -308,6 +308,27 @@ const store = new FileLoadedSparqlProvenanceStore({
 
 Each record is stored as flat PROV-O on the dataset entity — `prov:generatedAtTime` plus `sourceFingerprint`, `pipelineVersion` and `status` under the `https://w3id.org/lde/provenance#` namespace. Scoping every record by `pipelineIri` (used as the named graph) lets multiple pipelines share one triplestore without colliding.
 
+#### Enabling skipping
+
+Skipping is opt-in. Pass a `provenanceStore` and a `pipelineVersion` to the `Pipeline`:
+
+```typescript
+new Pipeline({
+  // …
+  provenanceStore: store,
+  pipelineVersion: 'v3', // rotate only on releases that change output
+});
+```
+
+For each dataset the pipeline probes its distributions, derives the source-change fingerprint, reads the stored record, and **skips before importing** when both change fields match:
+
+```
+skip iff  recorded.sourceFingerprint === current.sourceFingerprint
+     AND  recorded.pipelineVersion   === current.pipelineVersion
+```
+
+Otherwise it imports (if needed), runs the stages, and writes an updated record. `pipelineVersion` is consumer-owned and opaque: rotate it only on releases that change output, and every dataset reprocesses on the next run. It is **required** when a `provenanceStore` is configured (a skip-enabled pipeline with no version would silently freeze); when no store is configured, every dataset is reprocessed — today’s behaviour. A dataset that failed but whose source is unchanged is recorded as `'failed'` and skipped on later runs until its source changes or the version rotates, so a deterministically failing import is not retried every run.
+
 ### Source-change fingerprint
 
 `sourceFingerprint(distribution, probeResult)` derives a cheap, opaque change signal for a distribution from metadata the probe already collected — no body download. For a data dump it combines the most recent of the register’s `dct:modified` and the artifact’s HTTP `Last-Modified` with the byte size (the probe’s `Content-Length`, falling back to the declared `dcat:byteSize`). It returns `null` for a live SPARQL endpoint, or when no date and no size can be established — a `null` fingerprint never compares equal, so such a distribution is always reprocessed.

--- a/packages/pipeline/src/distribution/importResolver.ts
+++ b/packages/pipeline/src/distribution/importResolver.ts
@@ -8,11 +8,13 @@ import {
 import type { SparqlServer } from '@lde/sparql-server';
 import {
   type DistributionResolver,
+  type ProbedSource,
   type ResolveCallbacks,
   NoDistributionAvailable,
+  ProbedDistributions,
   ResolvedDistribution,
 } from './resolver.js';
-import { NetworkError } from '@lde/distribution-probe';
+import { NetworkError, type ProbeResultType } from '@lde/distribution-probe';
 
 export interface ImportResolverOptions {
   importer: Importer;
@@ -40,6 +42,11 @@ export interface ImportResolverOptions {
  * adds the ability to import a data dump into a local SPARQL server. The
  * {@link ImportResolverOptions.strategy | strategy} option controls whether the
  * inner resolver's SPARQL endpoint is preferred or bypassed.
+ *
+ * The split is preserved across both phases: {@link probe} chooses the
+ * {@link ProbedSource} (the inner SPARQL endpoint, or the preferred importable
+ * data dump) without importing; {@link resolve} performs the import only when
+ * that source is a data dump.
  */
 export class ImportResolver implements DistributionResolver {
   constructor(
@@ -47,38 +54,89 @@ export class ImportResolver implements DistributionResolver {
     private readonly options: ImportResolverOptions,
   ) {}
 
-  async resolve(
-    ...args: Parameters<DistributionResolver['resolve']>
-  ): Promise<ResolvedDistribution | NoDistributionAvailable> {
-    const [dataset, callbacks] = args;
-    const result = await this.inner.resolve(...args);
+  async probe(
+    dataset: Dataset,
+    callbacks?: ResolveCallbacks,
+  ): Promise<ProbedDistributions> {
+    const probed = await this.inner.probe(dataset, callbacks);
 
-    // 'sparql' strategy (default): use SPARQL endpoint if inner found one.
-    if (
-      this.options.strategy !== 'import' &&
-      result instanceof ResolvedDistribution
-    ) {
-      return result;
+    // 'sparql' strategy (default): keep the inner SPARQL endpoint if found.
+    if (this.options.strategy !== 'import' && probed.source) {
+      return probed;
     }
 
-    // Either 'import' strategy or inner found nothing: import a data dump.
-    return this.importDataset(dataset, result.probeResults, callbacks);
+    // Either 'import' strategy or no SPARQL endpoint: select a data dump to
+    // import. Choosing the candidate here (not in resolve) keeps the import
+    // cost out of the probe phase while still letting the pipeline fingerprint
+    // the dump it would import.
+    const source = this.selectImportCandidate(dataset, probed.probeResults);
+    return new ProbedDistributions(dataset, probed.probeResults, source);
   }
 
-  private async importDataset(
-    dataset: Dataset,
-    probeResults: NoDistributionAvailable['probeResults'],
+  async resolve(
+    probed: ProbedDistributions,
     callbacks?: ResolveCallbacks,
   ): Promise<ResolvedDistribution | NoDistributionAvailable> {
+    if (!probed.source) {
+      return new NoDistributionAvailable(
+        probed.dataset,
+        'No importable distributions passed probing',
+        probed.probeResults,
+      );
+    }
+
+    // A SPARQL endpoint source needs no import.
+    if (probed.source.distribution.isSparql()) {
+      return new ResolvedDistribution(
+        probed.source.distribution,
+        probed.probeResults,
+      );
+    }
+
+    return this.importDataset(probed.dataset, probed.probeResults, callbacks);
+  }
+
+  /**
+   * The preferred importable data dump and its probe result, or `null` if no
+   * downloadable distribution passed probing.
+   */
+  private selectImportCandidate(
+    dataset: Dataset,
+    probeResults: ProbeResultType[],
+  ): ProbedSource | null {
+    const candidate = this.importCandidates(dataset, probeResults)[0];
+    if (!candidate) return null;
+    const probeResult = probeResults.find(
+      (result) => result.url === candidate.accessUrl.toString(),
+    );
+    return probeResult ? { distribution: candidate, probeResult } : null;
+  }
+
+  /**
+   * Downloadable distributions whose access URL passed probing, in preference
+   * order (compressed first, see {@link Dataset.getDownloadDistributions}).
+   */
+  private importCandidates(
+    dataset: Dataset,
+    probeResults: ProbeResultType[],
+  ): Distribution[] {
     const successfulUrls = new Set(
       probeResults
         .filter((r) => !(r instanceof NetworkError) && r.isSuccess())
         .map((r) => r.url),
     );
 
-    const candidates = dataset
+    return dataset
       .getDownloadDistributions()
       .filter((d) => d.accessUrl && successfulUrls.has(d.accessUrl.toString()));
+  }
+
+  private async importDataset(
+    dataset: Dataset,
+    probeResults: ProbeResultType[],
+    callbacks?: ResolveCallbacks,
+  ): Promise<ResolvedDistribution | NoDistributionAvailable> {
+    const candidates = this.importCandidates(dataset, probeResults);
 
     // Establish a trustworthy change signal for the downloader so it can skip
     // redundant downloads (and preserve the QLever index cache). For a data

--- a/packages/pipeline/src/distribution/index.ts
+++ b/packages/pipeline/src/distribution/index.ts
@@ -16,8 +16,10 @@ export {
 export {
   ResolvedDistribution,
   NoDistributionAvailable,
+  ProbedDistributions,
   SparqlDistributionResolver,
   type DistributionResolver,
+  type ProbedSource,
   type ResolveCallbacks,
   type SparqlDistributionResolverOptions,
 } from './resolver.js';

--- a/packages/pipeline/src/distribution/resolveDistributions.ts
+++ b/packages/pipeline/src/distribution/resolveDistributions.ts
@@ -17,7 +17,8 @@ export async function resolveDistributions(
   dataset: Dataset,
   resolver: DistributionResolver,
 ): Promise<DistributionStageResult> {
-  const result = await resolver.resolve(dataset);
+  const probed = await resolver.probe(dataset);
+  const result = await resolver.resolve(probed);
 
   if (result instanceof NoDistributionAvailable) {
     return {

--- a/packages/pipeline/src/distribution/resolver.ts
+++ b/packages/pipeline/src/distribution/resolver.ts
@@ -25,19 +25,56 @@ export class NoDistributionAvailable {
   ) {}
 }
 
-/** Callbacks fired during distribution resolution. */
+/**
+ * The distribution a dataset will be processed from, paired with its probe
+ * result. Drives the source-change fingerprint: a live SPARQL endpoint yields
+ * `null` (always reprocess), a data dump yields its change fingerprint.
+ */
+export interface ProbedSource {
+  distribution: Distribution;
+  probeResult: ProbeResultType;
+}
+
+/**
+ * The outcome of the probe phase: every distribution’s probe result, plus the
+ * {@link ProbedSource} that will be used to process the dataset (or `null` if
+ * none is available). Determined without importing, so the pipeline can decide
+ * to skip a dataset before paying the import cost.
+ */
+export class ProbedDistributions {
+  constructor(
+    readonly dataset: Dataset,
+    readonly probeResults: ProbeResultType[],
+    readonly source: ProbedSource | null,
+  ) {}
+}
+
+/** Callbacks fired during distribution probing and resolution. */
 export interface ResolveCallbacks {
-  /** Called each time a single distribution probe completes. */
+  /** Called each time a single distribution probe completes (probe phase). */
   onProbe?: (distribution: Distribution, result: ProbeResultType) => void;
-  /** Called when a data-dump import begins. */
+  /** Called when a data-dump import begins (resolve phase). */
   onImportStart?: () => void;
-  /** Called when importing a distribution fails. */
+  /** Called when importing a distribution fails (resolve phase). */
   onImportFailed?: (distribution: Distribution, error: string) => void;
 }
 
+/**
+ * Resolves a dataset to a usable distribution in two phases so the pipeline can
+ * gate on a dataset’s source-change fingerprint before paying any import cost:
+ *
+ * 1. {@link probe} probes every distribution and selects the source-to-be,
+ *    without importing.
+ * 2. {@link resolve} turns that probed source into a usable SPARQL endpoint,
+ *    importing a data dump only when the source is one.
+ */
 export interface DistributionResolver {
-  resolve(
+  probe(
     dataset: Dataset,
+    callbacks?: ResolveCallbacks,
+  ): Promise<ProbedDistributions>;
+  resolve(
+    probed: ProbedDistributions,
     callbacks?: ResolveCallbacks,
   ): Promise<ResolvedDistribution | NoDistributionAvailable>;
   cleanup?(): Promise<void>;
@@ -48,11 +85,13 @@ export interface SparqlDistributionResolverOptions {
 }
 
 /**
- * Resolves a dataset to a usable SPARQL distribution by probing its distributions.
+ * Resolves a dataset to its own SPARQL endpoint by probing its distributions.
  *
- * 1. Probes all distributions in parallel.
- * 2. Returns the first valid SPARQL endpoint as a `ResolvedDistribution`.
- * 3. If none: returns `NoDistributionAvailable`.
+ * {@link probe} returns the first valid SPARQL endpoint as the
+ * {@link ProbedSource}; {@link resolve} returns it as a
+ * {@link ResolvedDistribution}, or {@link NoDistributionAvailable} when none
+ * responded. Never imports a data dump – wrap with {@link ImportResolver} for
+ * that.
  *
  * Does not mutate `dataset.distributions`.
  */
@@ -63,10 +102,10 @@ export class SparqlDistributionResolver implements DistributionResolver {
     this.timeout = options?.timeout ?? 5000;
   }
 
-  async resolve(
+  async probe(
     dataset: Dataset,
     callbacks?: ResolveCallbacks,
-  ): Promise<ResolvedDistribution | NoDistributionAvailable> {
+  ): Promise<ProbedDistributions> {
     const results = await Promise.all(
       dataset.distributions.map(async (distribution) => {
         const result = await probe(distribution, { timeoutMs: this.timeout });
@@ -76,6 +115,7 @@ export class SparqlDistributionResolver implements DistributionResolver {
     );
 
     // Find first valid SPARQL endpoint.
+    let source: ProbedSource | null = null;
     for (let i = 0; i < dataset.distributions.length; i++) {
       const distribution = dataset.distributions[i];
       const result = results[i];
@@ -85,14 +125,28 @@ export class SparqlDistributionResolver implements DistributionResolver {
         result instanceof SparqlProbeResult &&
         result.isSuccess()
       ) {
-        return new ResolvedDistribution(distribution, results);
+        source = { distribution, probeResult: result };
+        break;
       }
     }
 
+    return new ProbedDistributions(dataset, results, source);
+  }
+
+  async resolve(
+    probed: ProbedDistributions,
+  ): Promise<ResolvedDistribution | NoDistributionAvailable> {
+    if (probed.source && probed.source.distribution.isSparql()) {
+      return new ResolvedDistribution(
+        probed.source.distribution,
+        probed.probeResults,
+      );
+    }
+
     return new NoDistributionAvailable(
-      dataset,
+      probed.dataset,
       'No SPARQL endpoint available',
-      results,
+      probed.probeResults,
     );
   }
 }

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -268,7 +268,15 @@ export class Pipeline {
 
     // Gate: skip an unchanged dataset before paying any import cost.
     if (this.provenanceStore) {
-      const stored = await this.provenanceStore.get(dataset.iri);
+      let stored: ProcessingRecord | null = null;
+      try {
+        stored = await this.provenanceStore.get(dataset.iri);
+      } catch {
+        // An unreadable record must not abort the whole run, nor wrongly skip:
+        // treat it as ‘never processed’ so this dataset reprocesses. The
+        // periodic full reprocess is the backstop.
+        stored = null;
+      }
       if (
         !shouldReprocess(
           {
@@ -325,6 +333,7 @@ export class Pipeline {
       onRelax: (event) => this.reporter?.timeoutRelaxed?.(event),
     });
 
+    let stageFailed = false;
     try {
       for (const stage of this.stages) {
         try {
@@ -340,6 +349,7 @@ export class Pipeline {
             );
           }
         } catch (error) {
+          stageFailed = true;
           this.reporter?.stageFailed?.(
             stage.name,
             error instanceof Error ? error : new Error(String(error)),
@@ -353,7 +363,13 @@ export class Pipeline {
 
     await this.writer.flush?.(dataset);
     await this.reportValidators(dataset);
-    await this.recordOutcome(dataset, fingerprint, 'success');
+    // A dataset whose stages threw produced incomplete output; record it as
+    // ‘failed’ rather than freezing a broken result under a ‘success’ record.
+    await this.recordOutcome(
+      dataset,
+      fingerprint,
+      stageFailed ? 'failed' : 'success',
+    );
     const datasetMemory = process.memoryUsage();
     this.reporter?.datasetComplete?.(dataset, {
       memoryUsageBytes: datasetMemory.rss,
@@ -368,12 +384,17 @@ export class Pipeline {
     status: ProcessingRecord['status'],
   ): Promise<void> {
     if (!this.provenanceStore) return;
-    await this.provenanceStore.set(dataset.iri, {
-      sourceFingerprint: fingerprint,
-      pipelineVersion: this.pipelineVersion!,
-      generatedAt: new Date().toISOString(),
-      status,
-    });
+    try {
+      await this.provenanceStore.set(dataset.iri, {
+        sourceFingerprint: fingerprint,
+        pipelineVersion: this.pipelineVersion!,
+        generatedAt: new Date().toISOString(),
+        status,
+      });
+    } catch {
+      // A failed write must not abort the run; the dataset simply reprocesses
+      // next run, its record not yet updated.
+    }
   }
 
   private async reportValidators(dataset: Dataset): Promise<void> {

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -9,9 +9,14 @@ import type { Writer } from './writer/writer.js';
 import { FileWriter } from './writer/fileWriter.js';
 import {
   type DistributionResolver,
+  type ProbedDistributions,
   NoDistributionAvailable,
 } from './distribution/resolver.js';
 import { SparqlDistributionResolver } from './distribution/index.js';
+import { sourceFingerprint } from './provenance/sourceFingerprint.js';
+import { shouldReprocess } from './provenance/reprocessDecision.js';
+import type { ProcessingRecord } from './provenance/record.js';
+import type { ProvenanceStore } from './provenance/store.js';
 import {
   NetworkError,
   SparqlProbeResult,
@@ -53,6 +58,22 @@ export interface PipelineOptions {
     outputDir: string;
   };
   reporter?: ProgressReporter;
+  /**
+   * Optional per-dataset processing memory. When set, the pipeline skips a
+   * dataset whose source-change fingerprint and {@link pipelineVersion} both
+   * match the stored record – before paying the import cost – and writes an
+   * updated record after processing. When omitted, every dataset is
+   * reprocessed (today’s behaviour).
+   */
+  provenanceStore?: ProvenanceStore;
+  /**
+   * Opaque, consumer-declared version of the pipeline’s output-affecting
+   * logic, rotated only on releases that change output. Compared for equality,
+   * never parsed or ordered. Required when {@link provenanceStore} is set (a
+   * skip-enabled pipeline with no version would silently freeze); ignored
+   * otherwise.
+   */
+  pipelineVersion?: string;
   /**
    * Factory producing a fresh {@link TimeoutPolicy} per dataset. Defaults
    * to {@link constantTimeoutPolicy}`(300_000)` so existing call sites
@@ -153,6 +174,8 @@ export class Pipeline {
   private readonly chaining?: PipelineOptions['chaining'];
   private readonly reporter?: ProgressReporter;
   private readonly timeoutFactory: () => TimeoutPolicy;
+  private readonly provenanceStore?: ProvenanceStore;
+  private readonly pipelineVersion?: string;
 
   constructor(options: PipelineOptions) {
     const hasSubStages = options.stages.some(
@@ -160,6 +183,12 @@ export class Pipeline {
     );
     if (hasSubStages && !options.chaining) {
       throw new Error('chaining is required when any stage has sub-stages');
+    }
+
+    if (options.provenanceStore && options.pipelineVersion === undefined) {
+      throw new Error(
+        'pipelineVersion is required when a provenanceStore is configured',
+      );
     }
 
     this.name = options.name ?? '';
@@ -186,6 +215,8 @@ export class Pipeline {
     this.reporter = options.reporter;
     this.timeoutFactory =
       options.timeout ?? (() => new ConstantTimeoutPolicy(300_000));
+    this.provenanceStore = options.provenanceStore;
+    this.pipelineVersion = options.pipelineVersion;
   }
 
   async run(): Promise<void> {
@@ -211,20 +242,51 @@ export class Pipeline {
   private async processDataset(dataset: Dataset): Promise<void> {
     this.reporter?.datasetStart?.(dataset);
 
-    const timeout: TimeoutPolicy = this.timeoutFactory();
-    const unsubscribe = timeout.subscribe?.({
-      onTighten: (event) => this.reporter?.timeoutTightened?.(event),
-      onRelax: (event) => this.reporter?.timeoutRelaxed?.(event),
-    });
-
-    let resolved;
+    // Probe phase: gather probe results and the source-to-be, without importing.
+    let probed: ProbedDistributions;
     try {
-      resolved = await this.distributionResolver.resolve(dataset, {
+      probed = await this.distributionResolver.probe(dataset, {
         onProbe: (distribution, result) => {
           this.reporter?.distributionProbed?.(
             mapProbeResult(distribution, result),
           );
         },
+      });
+    } catch (error) {
+      this.reporter?.datasetSkipped?.(
+        dataset,
+        `Distribution probing failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return;
+    }
+
+    // Derive the source-change fingerprint from the probed source: null for a
+    // live SPARQL endpoint (always reprocess) or when no source is available.
+    const fingerprint = probed.source
+      ? sourceFingerprint(probed.source.distribution, probed.source.probeResult)
+      : null;
+
+    // Gate: skip an unchanged dataset before paying any import cost.
+    if (this.provenanceStore) {
+      const stored = await this.provenanceStore.get(dataset.iri);
+      if (
+        !shouldReprocess(
+          {
+            sourceFingerprint: fingerprint,
+            pipelineVersion: this.pipelineVersion!,
+          },
+          stored,
+        )
+      ) {
+        this.reporter?.datasetSkipped?.(dataset, 'Unchanged since last run');
+        return;
+      }
+    }
+
+    // Resolve phase: import a data dump only when the source is one.
+    let resolved;
+    try {
+      resolved = await this.distributionResolver.resolve(probed, {
         onImportStart: () => {
           this.reporter?.importStarted?.();
         },
@@ -241,6 +303,10 @@ export class Pipeline {
     }
 
     if (resolved instanceof NoDistributionAvailable) {
+      // Record the failure so a dataset whose source is unchanged is not
+      // re-imported every run; it is retried at the next fingerprint change or
+      // version rotation.
+      await this.recordOutcome(dataset, fingerprint, 'failed');
       this.reporter?.datasetSkipped?.(dataset, resolved.message);
       return;
     }
@@ -252,6 +318,12 @@ export class Pipeline {
       resolved.importDuration,
       resolved.tripleCount,
     );
+
+    const timeout: TimeoutPolicy = this.timeoutFactory();
+    const unsubscribe = timeout.subscribe?.({
+      onTighten: (event) => this.reporter?.timeoutTightened?.(event),
+      onRelax: (event) => this.reporter?.timeoutRelaxed?.(event),
+    });
 
     try {
       for (const stage of this.stages) {
@@ -281,10 +353,26 @@ export class Pipeline {
 
     await this.writer.flush?.(dataset);
     await this.reportValidators(dataset);
+    await this.recordOutcome(dataset, fingerprint, 'success');
     const datasetMemory = process.memoryUsage();
     this.reporter?.datasetComplete?.(dataset, {
       memoryUsageBytes: datasetMemory.rss,
       heapUsedBytes: datasetMemory.heapUsed,
+    });
+  }
+
+  /** Persist the processing record for a dataset, when a store is configured. */
+  private async recordOutcome(
+    dataset: Dataset,
+    fingerprint: string | null,
+    status: ProcessingRecord['status'],
+  ): Promise<void> {
+    if (!this.provenanceStore) return;
+    await this.provenanceStore.set(dataset.iri, {
+      sourceFingerprint: fingerprint,
+      pipelineVersion: this.pipelineVersion!,
+      generatedAt: new Date().toISOString(),
+      status,
     });
   }
 

--- a/packages/pipeline/src/provenance/fileLoadedSparqlProvenanceStore.ts
+++ b/packages/pipeline/src/provenance/fileLoadedSparqlProvenanceStore.ts
@@ -1,0 +1,127 @@
+import { Dataset } from '@lde/dataset';
+import type { Quad, Term } from '@rdfjs/types';
+import { DataFactory } from 'n3';
+import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
+import { FileWriter } from '../writer/fileWriter.js';
+import type { ProcessingRecord } from './record.js';
+import type { ProvenanceStore } from './store.js';
+
+const { namedNode, literal, quad } = DataFactory;
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const PROV = 'http://www.w3.org/ns/prov#';
+const LDE = 'https://w3id.org/lde/provenance#';
+const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
+
+export interface FileLoadedSparqlProvenanceStoreOptions {
+  /** Read-only SPARQL endpoint to query for previously-loaded records. */
+  queryEndpoint: URL;
+  /**
+   * The pipeline’s IRI, used as the named graph that scopes this pipeline’s
+   * records so multiple pipelines sharing one triplestore do not collide.
+   */
+  pipelineIri: URL;
+  /**
+   * Directory the records are written to as files, to be bulk-loaded into the
+   * read-only triplestore after the run. Kept separate from the data output
+   * directory so filenames (keyed by dataset URI) never collide.
+   */
+  outputDir: string;
+  /**
+   * Optional {@link SparqlEndpointFetcher} for the query side, intended for
+   * tests. Defaults to a fresh instance.
+   */
+  fetcher?: SparqlEndpointFetcher;
+}
+
+/**
+ * A {@link ProvenanceStore} for a triplestore that is served read-only and
+ * rebuilt by bulk-loading files (e.g. QLever).
+ *
+ * Reads through SPARQL queries against the live endpoint (records loaded from
+ * a previous run); writes the records as files for the next bulk-load, since
+ * the endpoint accepts no SPARQL UPDATE. Records are flat PROV-O keyed by the
+ * dataset URI, written into the pipeline-scoped provenance named graph.
+ */
+export class FileLoadedSparqlProvenanceStore implements ProvenanceStore {
+  private readonly queryEndpoint: URL;
+  private readonly pipelineIri: URL;
+  private readonly writer: FileWriter;
+  private readonly fetcher: SparqlEndpointFetcher;
+
+  constructor(options: FileLoadedSparqlProvenanceStoreOptions) {
+    this.queryEndpoint = options.queryEndpoint;
+    this.pipelineIri = options.pipelineIri;
+    this.writer = new FileWriter({
+      outputDir: options.outputDir,
+      format: 'n-quads',
+      graphIri: () => this.pipelineIri,
+    });
+    this.fetcher = options.fetcher ?? new SparqlEndpointFetcher();
+  }
+
+  async get(datasetUri: URL): Promise<ProcessingRecord | null> {
+    const stream = (await this.fetcher.fetchBindings(
+      this.queryEndpoint.toString(),
+      this.selectQuery(datasetUri),
+    )) as AsyncIterable<Record<string, Term>>;
+
+    for await (const binding of stream) {
+      // A record exists iff the mandatory fields bound; the fingerprint is
+      // optional and absent for a run with no establishable signal.
+      return {
+        sourceFingerprint: binding.fingerprint?.value ?? null,
+        pipelineVersion: binding.version.value,
+        generatedAt: binding.generatedAt.value,
+        status: binding.status.value as ProcessingRecord['status'],
+      };
+    }
+
+    return null;
+  }
+
+  private selectQuery(datasetUri: URL): string {
+    const dataset = `<${datasetUri.toString()}>`;
+    return `SELECT ?fingerprint ?version ?status ?generatedAt WHERE {
+      GRAPH <${this.pipelineIri.toString()}> {
+        ${dataset} <${LDE}pipelineVersion> ?version ;
+                   <${LDE}status> ?status ;
+                   <${PROV}generatedAtTime> ?generatedAt .
+        OPTIONAL { ${dataset} <${LDE}sourceFingerprint> ?fingerprint }
+      }
+    } LIMIT 1`;
+  }
+
+  async set(datasetUri: URL, record: ProcessingRecord): Promise<void> {
+    const dataset = new Dataset({ iri: datasetUri, distributions: [] });
+    await this.writer.write(dataset, this.toQuads(datasetUri, record));
+    await this.writer.flush(dataset);
+  }
+
+  private async *toQuads(
+    datasetUri: URL,
+    record: ProcessingRecord,
+  ): AsyncIterable<Quad> {
+    const subject = namedNode(datasetUri.toString());
+
+    yield quad(subject, namedNode(RDF_TYPE), namedNode(`${PROV}Entity`));
+    yield quad(
+      subject,
+      namedNode(`${PROV}generatedAtTime`),
+      literal(record.generatedAt, namedNode(XSD_DATE_TIME)),
+    );
+    if (record.sourceFingerprint !== null) {
+      yield quad(
+        subject,
+        namedNode(`${LDE}sourceFingerprint`),
+        literal(record.sourceFingerprint),
+      );
+    }
+    yield quad(
+      subject,
+      namedNode(`${LDE}pipelineVersion`),
+      literal(record.pipelineVersion),
+    );
+    yield quad(subject, namedNode(`${LDE}status`), literal(record.status));
+  }
+}

--- a/packages/pipeline/src/provenance/fileLoadedSparqlProvenanceStore.ts
+++ b/packages/pipeline/src/provenance/fileLoadedSparqlProvenanceStore.ts
@@ -1,4 +1,4 @@
-import { Dataset } from '@lde/dataset';
+import { Dataset, assertSafeIri } from '@lde/dataset';
 import type { Quad, Term } from '@rdfjs/types';
 import { DataFactory } from 'n3';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
@@ -81,9 +81,16 @@ export class FileLoadedSparqlProvenanceStore implements ProvenanceStore {
   }
 
   private selectQuery(datasetUri: URL): string {
-    const dataset = `<${datasetUri.toString()}>`;
+    // Guard before interpolating into a SPARQL `<…>` reference, mirroring
+    // SparqlUpdateWriter. URL normalisation already encodes unsafe characters,
+    // so this is defence-in-depth against a non-normalised IRI reaching here.
+    const datasetIri = datasetUri.toString();
+    const pipelineIri = this.pipelineIri.toString();
+    assertSafeIri(datasetIri);
+    assertSafeIri(pipelineIri);
+    const dataset = `<${datasetIri}>`;
     return `SELECT ?fingerprint ?version ?status ?generatedAt WHERE {
-      GRAPH <${this.pipelineIri.toString()}> {
+      GRAPH <${pipelineIri}> {
         ${dataset} <${LDE}pipelineVersion> ?version ;
                    <${LDE}status> ?status ;
                    <${PROV}generatedAtTime> ?generatedAt .

--- a/packages/pipeline/src/provenance/index.ts
+++ b/packages/pipeline/src/provenance/index.ts
@@ -1,3 +1,8 @@
 export { sourceFingerprint } from './sourceFingerprint.js';
 export { shouldReprocess } from './reprocessDecision.js';
 export type { ProcessingRecord, ChangeKey } from './record.js';
+export type { ProvenanceStore } from './store.js';
+export {
+  FileLoadedSparqlProvenanceStore,
+  type FileLoadedSparqlProvenanceStoreOptions,
+} from './fileLoadedSparqlProvenanceStore.js';

--- a/packages/pipeline/src/provenance/store.ts
+++ b/packages/pipeline/src/provenance/store.ts
@@ -1,0 +1,20 @@
+import type { ProcessingRecord } from './record.js';
+
+/**
+ * The pipeline’s per-dataset processing memory.
+ *
+ * The framework owns the skip semantics (see `shouldReprocess`); a
+ * `ProvenanceStore` owns only the physical storage of {@link ProcessingRecord}s,
+ * keyed by dataset URI. Implementations are free to back this with a
+ * triplestore, files, or anything else.
+ */
+export interface ProvenanceStore {
+  /**
+   * The record from the dataset’s last processing, or `null` if it has never
+   * been processed (or the store was wiped). A `null` result drives a
+   * reprocess.
+   */
+  get(datasetUri: URL): Promise<ProcessingRecord | null>;
+  /** Persist the record for a dataset, replacing any previous one. */
+  set(datasetUri: URL, record: ProcessingRecord): Promise<void>;
+}

--- a/packages/pipeline/test/distribution/importResolver.test.ts
+++ b/packages/pipeline/test/distribution/importResolver.test.ts
@@ -2,8 +2,12 @@ import {
   ImportResolver,
   ResolvedDistribution,
   NoDistributionAvailable,
+  ProbedDistributions,
   DataDumpProbeResult,
+  SparqlProbeResult,
   type DistributionResolver,
+  type ProbeResultType,
+  type ResolveCallbacks,
 } from '../../src/distribution/index.js';
 import { Dataset, Distribution } from '@lde/dataset';
 import {
@@ -13,6 +17,8 @@ import {
 } from '@lde/sparql-importer';
 import type { SparqlServer } from '@lde/sparql-server';
 import { describe, it, expect, vi } from 'vitest';
+
+const SPARQL_URL = 'http://example.org/sparql';
 
 const dataDumpProbeResult = new DataDumpProbeResult(
   'http://example.org/data.nt',
@@ -26,6 +32,18 @@ const dataDumpProbeResult = new DataDumpProbeResult(
   0,
 );
 
+function sparqlProbeResult(): SparqlProbeResult {
+  return new SparqlProbeResult(
+    SPARQL_URL,
+    new Response('{"results":{"bindings":[]}}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/sparql-results+json' },
+    }),
+    0,
+    'application/sparql-results+json',
+  );
+}
+
 function makeDataset(): Dataset {
   return new Dataset({
     iri: new URL('http://example.org/dataset'),
@@ -38,10 +56,34 @@ function makeDataset(): Dataset {
   });
 }
 
-function makeInnerResolver(
-  result: ResolvedDistribution | NoDistributionAvailable,
+/** An inner resolver whose probe found a working SPARQL endpoint. */
+function innerWithSparqlEndpoint(
+  dataset: Dataset,
+  sparqlDistribution: Distribution,
+  probeResults: ProbeResultType[],
 ): DistributionResolver {
-  return { resolve: vi.fn().mockResolvedValue(result) };
+  return {
+    probe: vi.fn().mockResolvedValue(
+      new ProbedDistributions(dataset, probeResults, {
+        distribution: sparqlDistribution,
+        probeResult: probeResults[0],
+      }),
+    ),
+    resolve: vi.fn(),
+  };
+}
+
+/** An inner resolver whose probe found no SPARQL endpoint. */
+function innerNoSparqlEndpoint(
+  dataset: Dataset,
+  probeResults: ProbeResultType[],
+): DistributionResolver {
+  return {
+    probe: vi
+      .fn()
+      .mockResolvedValue(new ProbedDistributions(dataset, probeResults, null)),
+    resolve: vi.fn(),
+  };
 }
 
 function makeServer(): SparqlServer & {
@@ -55,32 +97,38 @@ function makeServer(): SparqlServer & {
   };
 }
 
+/** Run both phases, threading callbacks to each, as the pipeline does. */
+async function resolve(
+  resolver: ImportResolver,
+  dataset: Dataset,
+  callbacks?: ResolveCallbacks,
+) {
+  return resolver.resolve(await resolver.probe(dataset, callbacks), callbacks);
+}
+
 describe('ImportResolver', () => {
-  it('returns inner result when it is a ResolvedDistribution', async () => {
-    const distribution = Distribution.sparql(
-      new URL('http://example.org/sparql'),
-    );
-    const resolved = new ResolvedDistribution(distribution, []);
-    const inner = makeInnerResolver(resolved);
+  it('returns the SPARQL endpoint without importing when one is found', async () => {
+    const dataset = makeDataset();
+    const distribution = Distribution.sparql(new URL(SPARQL_URL));
+    const inner = innerWithSparqlEndpoint(dataset, distribution, [
+      sparqlProbeResult(),
+    ]);
     const mockImporter = { import: vi.fn() };
 
     const resolver = new ImportResolver(inner, {
       importer: mockImporter,
       server: makeServer(),
     });
-    const result = await resolver.resolve(makeDataset());
+    const result = await resolve(resolver, dataset);
 
-    expect(result).toBe(resolved);
+    expect(result).toBeInstanceOf(ResolvedDistribution);
+    expect((result as ResolvedDistribution).distribution).toBe(distribution);
     expect(mockImporter.import).not.toHaveBeenCalled();
   });
 
-  it('falls back to import when inner resolver returns NoDistributionAvailable', async () => {
+  it('falls back to import when no SPARQL endpoint is found', async () => {
     const dataset = makeDataset();
-    const inner = makeInnerResolver(
-      new NoDistributionAvailable(dataset, 'No endpoint', [
-        dataDumpProbeResult,
-      ]),
-    );
+    const inner = innerNoSparqlEndpoint(dataset, [dataDumpProbeResult]);
 
     const mockImporter = {
       import: vi
@@ -99,7 +147,7 @@ describe('ImportResolver', () => {
       importer: mockImporter,
       server,
     });
-    const result = await resolver.resolve(dataset);
+    const result = await resolve(resolver, dataset);
 
     expect(result).toBeInstanceOf(ResolvedDistribution);
     expect(mockImporter.import).toHaveBeenCalledWith([
@@ -117,11 +165,7 @@ describe('ImportResolver', () => {
 
   it('sets importedFrom on ResolvedDistribution when import succeeds', async () => {
     const dataset = makeDataset();
-    const inner = makeInnerResolver(
-      new NoDistributionAvailable(dataset, 'No endpoint', [
-        dataDumpProbeResult,
-      ]),
-    );
+    const inner = innerNoSparqlEndpoint(dataset, [dataDumpProbeResult]);
 
     const importedDistribution = Distribution.sparql(
       new URL('http://localhost:7878/sparql'),
@@ -134,30 +178,29 @@ describe('ImportResolver', () => {
         ),
     };
 
-    const server = makeServer();
     const resolver = new ImportResolver(inner, {
       importer: mockImporter,
-      server,
+      server: makeServer(),
     });
-    const result = await resolver.resolve(dataset);
+    const result = await resolve(resolver, dataset);
 
     const resolved = result as ResolvedDistribution;
     expect(resolved.importedFrom).toBe(importedDistribution);
   });
 
-  it('importedFrom is undefined when inner resolver succeeds directly', async () => {
-    const distribution = Distribution.sparql(
-      new URL('http://example.org/sparql'),
-    );
-    const resolved = new ResolvedDistribution(distribution, []);
-    const inner = makeInnerResolver(resolved);
+  it('importedFrom is undefined when a SPARQL endpoint is used directly', async () => {
+    const dataset = makeDataset();
+    const distribution = Distribution.sparql(new URL(SPARQL_URL));
+    const inner = innerWithSparqlEndpoint(dataset, distribution, [
+      sparqlProbeResult(),
+    ]);
     const mockImporter = { import: vi.fn() };
 
     const resolver = new ImportResolver(inner, {
       importer: mockImporter,
       server: makeServer(),
     });
-    const result = await resolver.resolve(makeDataset());
+    const result = await resolve(resolver, dataset);
 
     expect(result).toBeInstanceOf(ResolvedDistribution);
     expect((result as ResolvedDistribution).importedFrom).toBeUndefined();
@@ -165,11 +208,7 @@ describe('ImportResolver', () => {
 
   it('returns NoDistributionAvailable with importFailed when import fails', async () => {
     const dataset = makeDataset();
-    const inner = makeInnerResolver(
-      new NoDistributionAvailable(dataset, 'No endpoint', [
-        dataDumpProbeResult,
-      ]),
-    );
+    const inner = innerNoSparqlEndpoint(dataset, [dataDumpProbeResult]);
 
     const mockImporter = {
       import: vi
@@ -189,7 +228,7 @@ describe('ImportResolver', () => {
       importer: mockImporter,
       server: makeServer(),
     });
-    const result = await resolver.resolve(dataset);
+    const result = await resolve(resolver, dataset);
 
     expect(result).toBeInstanceOf(NoDistributionAvailable);
     const noDistribution = result as NoDistributionAvailable;
@@ -200,11 +239,7 @@ describe('ImportResolver', () => {
 
   it('returns NoDistributionAvailable when importer returns NotSupported', async () => {
     const dataset = makeDataset();
-    const inner = makeInnerResolver(
-      new NoDistributionAvailable(dataset, 'No endpoint', [
-        dataDumpProbeResult,
-      ]),
-    );
+    const inner = innerNoSparqlEndpoint(dataset, [dataDumpProbeResult]);
 
     const mockImporter = {
       import: vi.fn().mockResolvedValue(new NotSupported()),
@@ -215,9 +250,7 @@ describe('ImportResolver', () => {
       importer: mockImporter,
       server: makeServer(),
     });
-    const result = await resolver.resolve(dataset, {
-      onImportFailed,
-    });
+    const result = await resolve(resolver, dataset, { onImportFailed });
 
     expect(result).toBeInstanceOf(NoDistributionAvailable);
     const noDistribution = result as NoDistributionAvailable;
@@ -229,15 +262,12 @@ describe('ImportResolver', () => {
   });
 
   describe('import strategy', () => {
-    it('ignores inner ResolvedDistribution and imports instead', async () => {
+    it('ignores an available SPARQL endpoint and imports instead', async () => {
       const dataset = makeDataset();
-      const distribution = Distribution.sparql(
-        new URL('http://example.org/sparql'),
-      );
-      const resolved = new ResolvedDistribution(distribution, [
+      const distribution = Distribution.sparql(new URL(SPARQL_URL));
+      const inner = innerWithSparqlEndpoint(dataset, distribution, [
         dataDumpProbeResult,
       ]);
-      const inner = makeInnerResolver(resolved);
 
       const mockImporter = {
         import: vi
@@ -256,9 +286,9 @@ describe('ImportResolver', () => {
         server,
         strategy: 'import',
       });
-      const result = await resolver.resolve(dataset);
+      const result = await resolve(resolver, dataset);
 
-      expect(inner.resolve).toHaveBeenCalled();
+      expect(inner.probe).toHaveBeenCalled();
       expect(mockImporter.import).toHaveBeenCalledWith([
         dataset.distributions[0],
       ]);
@@ -273,13 +303,10 @@ describe('ImportResolver', () => {
 
     it('returns NoDistributionAvailable with probe results from inner when import fails', async () => {
       const dataset = makeDataset();
-      const distribution = Distribution.sparql(
-        new URL('http://example.org/sparql'),
-      );
-      const resolved = new ResolvedDistribution(distribution, [
+      const distribution = Distribution.sparql(new URL(SPARQL_URL));
+      const inner = innerWithSparqlEndpoint(dataset, distribution, [
         dataDumpProbeResult,
       ]);
-      const inner = makeInnerResolver(resolved);
 
       const mockImporter = {
         import: vi
@@ -300,7 +327,7 @@ describe('ImportResolver', () => {
         server: makeServer(),
         strategy: 'import',
       });
-      const result = await resolver.resolve(dataset);
+      const result = await resolve(resolver, dataset);
 
       expect(result).toBeInstanceOf(NoDistributionAvailable);
       const noDistribution = result as NoDistributionAvailable;
@@ -309,20 +336,21 @@ describe('ImportResolver', () => {
     });
 
     it('default strategy preserves existing sparql-first behaviour', async () => {
-      const distribution = Distribution.sparql(
-        new URL('http://example.org/sparql'),
-      );
-      const resolved = new ResolvedDistribution(distribution, []);
-      const inner = makeInnerResolver(resolved);
+      const dataset = makeDataset();
+      const distribution = Distribution.sparql(new URL(SPARQL_URL));
+      const inner = innerWithSparqlEndpoint(dataset, distribution, [
+        sparqlProbeResult(),
+      ]);
       const mockImporter = { import: vi.fn() };
 
       const resolver = new ImportResolver(inner, {
         importer: mockImporter,
         server: makeServer(),
       });
-      const result = await resolver.resolve(makeDataset());
+      const result = await resolve(resolver, dataset);
 
-      expect(result).toBe(resolved);
+      expect(result).toBeInstanceOf(ResolvedDistribution);
+      expect((result as ResolvedDistribution).distribution).toBe(distribution);
       expect(mockImporter.import).not.toHaveBeenCalled();
     });
   });
@@ -330,11 +358,7 @@ describe('ImportResolver', () => {
   describe('server integration', () => {
     it('starts server after import and uses its endpoint', async () => {
       const dataset = makeDataset();
-      const inner = makeInnerResolver(
-        new NoDistributionAvailable(dataset, 'No endpoint', [
-          dataDumpProbeResult,
-        ]),
-      );
+      const inner = innerNoSparqlEndpoint(dataset, [dataDumpProbeResult]);
 
       const mockImporter = {
         import: vi
@@ -353,7 +377,7 @@ describe('ImportResolver', () => {
         importer: mockImporter,
         server,
       });
-      const result = await resolver.resolve(dataset);
+      const result = await resolve(resolver, dataset);
 
       expect(result).toBeInstanceOf(ResolvedDistribution);
       expect(server.start).toHaveBeenCalled();
@@ -363,12 +387,12 @@ describe('ImportResolver', () => {
       );
     });
 
-    it('does not start server when inner resolver succeeds', async () => {
-      const distribution = Distribution.sparql(
-        new URL('http://example.org/sparql'),
-      );
-      const resolved = new ResolvedDistribution(distribution, []);
-      const inner = makeInnerResolver(resolved);
+    it('does not start server when a SPARQL endpoint is used', async () => {
+      const dataset = makeDataset();
+      const distribution = Distribution.sparql(new URL(SPARQL_URL));
+      const inner = innerWithSparqlEndpoint(dataset, distribution, [
+        sparqlProbeResult(),
+      ]);
       const mockImporter = { import: vi.fn() };
       const server = makeServer();
 
@@ -376,7 +400,7 @@ describe('ImportResolver', () => {
         importer: mockImporter,
         server,
       });
-      await resolver.resolve(makeDataset());
+      await resolve(resolver, dataset);
 
       expect(server.start).not.toHaveBeenCalled();
     });
@@ -396,9 +420,7 @@ describe('ImportResolver', () => {
         }),
         0,
       );
-      const inner = makeInnerResolver(
-        new NoDistributionAvailable(dataset, 'No endpoint', [probeResult]),
-      );
+      const inner = innerNoSparqlEndpoint(dataset, [probeResult]);
 
       const mockImporter = {
         import: vi
@@ -415,7 +437,7 @@ describe('ImportResolver', () => {
         importer: mockImporter,
         server: makeServer(),
       });
-      await resolver.resolve(dataset);
+      await resolve(resolver, dataset);
 
       expect(dataset.distributions[0].lastModified).toEqual(lastModified);
       expect(mockImporter.import).toHaveBeenCalledWith([
@@ -451,9 +473,7 @@ describe('ImportResolver', () => {
         }),
         0,
       );
-      const inner = makeInnerResolver(
-        new NoDistributionAvailable(dataset, 'No endpoint', [probeResult]),
-      );
+      const inner = innerNoSparqlEndpoint(dataset, [probeResult]);
 
       const mockImporter = {
         import: vi
@@ -470,7 +490,7 @@ describe('ImportResolver', () => {
         importer: mockImporter,
         server: makeServer(),
       });
-      await resolver.resolve(dataset);
+      await resolve(resolver, dataset);
 
       expect(dataset.distributions[0].lastModified).toEqual(
         realHttpLastModified,
@@ -505,9 +525,7 @@ describe('ImportResolver', () => {
         }),
         0,
       );
-      const inner = makeInnerResolver(
-        new NoDistributionAvailable(dataset, 'No endpoint', [probeResult]),
-      );
+      const inner = innerNoSparqlEndpoint(dataset, [probeResult]);
 
       const mockImporter = {
         import: vi
@@ -524,18 +542,14 @@ describe('ImportResolver', () => {
         importer: mockImporter,
         server: makeServer(),
       });
-      await resolver.resolve(dataset);
+      await resolve(resolver, dataset);
 
       expect(dataset.distributions[0].lastModified).toEqual(newerRegisterDate);
     });
 
     it('preserves subjectFilter from imported distribution', async () => {
       const dataset = makeDataset();
-      const inner = makeInnerResolver(
-        new NoDistributionAvailable(dataset, 'No endpoint', [
-          dataDumpProbeResult,
-        ]),
-      );
+      const inner = innerNoSparqlEndpoint(dataset, [dataDumpProbeResult]);
 
       const importedDistribution = new Distribution(
         new URL('http://example.org/data.nt'),
@@ -556,7 +570,7 @@ describe('ImportResolver', () => {
         importer: mockImporter,
         server,
       });
-      const result = await resolver.resolve(dataset);
+      const result = await resolve(resolver, dataset);
 
       const resolved = result as ResolvedDistribution;
       expect(resolved.distribution.subjectFilter).toBe(
@@ -565,14 +579,11 @@ describe('ImportResolver', () => {
     });
 
     it('cleanup stops server', async () => {
+      const dataset = makeDataset();
+      const distribution = Distribution.sparql(new URL(SPARQL_URL));
       const server = makeServer();
       const resolver = new ImportResolver(
-        makeInnerResolver(
-          new ResolvedDistribution(
-            Distribution.sparql(new URL('http://example.org/sparql')),
-            [],
-          ),
-        ),
+        innerWithSparqlEndpoint(dataset, distribution, [sparqlProbeResult()]),
         { importer: { import: vi.fn() }, server },
       );
 

--- a/packages/pipeline/test/distribution/resolveDistributions.test.ts
+++ b/packages/pipeline/test/distribution/resolveDistributions.test.ts
@@ -2,6 +2,7 @@ import { resolveDistributions } from '../../src/distribution/index.js';
 import {
   ResolvedDistribution,
   NoDistributionAvailable,
+  ProbedDistributions,
   type DistributionResolver,
 } from '../../src/distribution/index.js';
 import { Dataset, Distribution } from '@lde/dataset';
@@ -24,7 +25,11 @@ async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
 function mockResolver(
   result: ResolvedDistribution | NoDistributionAvailable,
 ): DistributionResolver {
-  return { resolve: async () => result };
+  return {
+    probe: async (dataset) =>
+      new ProbedDistributions(dataset, result.probeResults, null),
+    resolve: async () => result,
+  };
 }
 
 describe('resolveDistributions', () => {
@@ -150,6 +155,12 @@ describe('resolveDistributions', () => {
     });
 
     const customResolver: DistributionResolver = {
+      async probe(dataset) {
+        return new ProbedDistributions(dataset, [probeResult], {
+          distribution,
+          probeResult,
+        });
+      },
       async resolve() {
         return new ResolvedDistribution(distribution, [probeResult]);
       },

--- a/packages/pipeline/test/distribution/resolver.test.ts
+++ b/packages/pipeline/test/distribution/resolver.test.ts
@@ -9,6 +9,11 @@ import {
 import { Dataset, Distribution } from '@lde/dataset';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+/** Run both phases, as the pipeline does. */
+async function resolve(resolver: SparqlDistributionResolver, dataset: Dataset) {
+  return resolver.resolve(await resolver.probe(dataset));
+}
+
 describe('SparqlDistributionResolver', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());
@@ -35,7 +40,7 @@ describe('SparqlDistributionResolver', () => {
       distributions: [distribution],
     });
 
-    const result = await resolver.resolve(dataset);
+    const result = await resolve(resolver, dataset);
 
     expect(result).toBeInstanceOf(ResolvedDistribution);
     const resolved = result as ResolvedDistribution;
@@ -63,7 +68,7 @@ describe('SparqlDistributionResolver', () => {
       ],
     });
 
-    const result = await resolver.resolve(dataset);
+    const result = await resolve(resolver, dataset);
 
     expect(result).toBeInstanceOf(NoDistributionAvailable);
     const noDistribution = result as NoDistributionAvailable;
@@ -83,7 +88,7 @@ describe('SparqlDistributionResolver', () => {
       ],
     });
 
-    const result = await resolver.resolve(dataset);
+    const result = await resolve(resolver, dataset);
 
     expect(result).toBeInstanceOf(NoDistributionAvailable);
     const noDistribution = result as NoDistributionAvailable;
@@ -109,7 +114,7 @@ describe('SparqlDistributionResolver', () => {
 
     const originalLength = dataset.distributions.length;
 
-    await resolver.resolve(dataset);
+    await resolve(resolver, dataset);
 
     expect(dataset.distributions.length).toBe(originalLength);
   });

--- a/packages/pipeline/test/fixtures/provenanceRecords.trig
+++ b/packages/pipeline/test/fixtures/provenanceRecords.trig
@@ -1,0 +1,32 @@
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix lde: <https://w3id.org/lde/provenance#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# The pipeline under test.
+<http://example.org/pipeline/dkg> {
+  <http://example.org/dataset/1>
+    a prov:Entity ;
+    prov:generatedAtTime "2026-06-11T00:00:00.000Z"^^xsd:dateTime ;
+    lde:sourceFingerprint "2024-06-01T00:00:00.000Z|1000" ;
+    lde:pipelineVersion "v1" ;
+    lde:status "success" .
+
+  # A failed run with no establishable fingerprint: the fingerprint triple is
+  # absent, so get() must reconstruct sourceFingerprint as null.
+  <http://example.org/dataset/3>
+    a prov:Entity ;
+    prov:generatedAtTime "2026-06-11T00:00:00.000Z"^^xsd:dateTime ;
+    lde:pipelineVersion "v1" ;
+    lde:status "failed" .
+}
+
+# A different pipeline sharing the same triplestore. Its record for dataset/1
+# must never leak into the pipeline-under-test's get().
+<http://example.org/pipeline/other> {
+  <http://example.org/dataset/1>
+    a prov:Entity ;
+    prov:generatedAtTime "2026-01-01T00:00:00.000Z"^^xsd:dateTime ;
+    lde:sourceFingerprint "other-fingerprint|999" ;
+    lde:pipelineVersion "other-v9" ;
+    lde:status "success" .
+}

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -6,6 +6,7 @@ import { NotSupported } from '../src/sparql/executor.js';
 import {
   ResolvedDistribution,
   NoDistributionAvailable,
+  ProbedDistributions,
   type DistributionResolver,
   type ResolveCallbacks,
 } from '../src/distribution/resolver.js';
@@ -19,6 +20,9 @@ import type { Writer } from '../src/writer/writer.js';
 import type { ProgressReporter } from '../src/progressReporter.js';
 import type { StageOutputResolver } from '../src/stageOutputResolver.js';
 import type { DatasetSelector } from '../src/selector.js';
+import { sourceFingerprint } from '../src/provenance/sourceFingerprint.js';
+import type { ProvenanceStore } from '../src/provenance/store.js';
+import type { ProcessingRecord } from '../src/provenance/record.js';
 import { Paginator } from '@lde/dataset-registry-client';
 import { DataFactory } from 'n3';
 import type { Quad } from '@rdfjs/types';
@@ -46,12 +50,17 @@ function makeResolver(
   probes?: Array<{ distribution: Distribution; result: ProbeResultType }>,
 ): DistributionResolver {
   return {
-    resolve: vi.fn(async (_dataset: Dataset, callbacks?: ResolveCallbacks) => {
+    probe: vi.fn(async (dataset: Dataset, callbacks?: ResolveCallbacks) => {
       for (const p of probes ?? []) {
         callbacks?.onProbe?.(p.distribution, p.result);
       }
-      return result;
+      return new ProbedDistributions(
+        dataset,
+        (probes ?? []).map((p) => p.result),
+        null,
+      );
     }),
+    resolve: vi.fn(async () => result),
   };
 }
 
@@ -730,12 +739,14 @@ describe('Pipeline', () => {
       );
 
       const resolver: DistributionResolver = {
-        resolve: vi.fn(
-          async (_dataset: Dataset, callbacks?: ResolveCallbacks) => {
-            callbacks?.onImportStart?.();
-            return resolved;
-          },
+        probe: vi.fn(
+          async (probedDataset: Dataset) =>
+            new ProbedDistributions(probedDataset, [], null),
         ),
+        resolve: vi.fn(async (_probed, callbacks?: ResolveCallbacks) => {
+          callbacks?.onImportStart?.();
+          return resolved;
+        }),
       };
 
       const pipeline = new Pipeline({
@@ -1087,6 +1098,10 @@ describe('Pipeline', () => {
     it('calls resolver.cleanup after processing a dataset', async () => {
       const cleanup = vi.fn().mockResolvedValue(undefined);
       const resolver: DistributionResolver = {
+        probe: vi.fn(
+          async (probedDataset: Dataset) =>
+            new ProbedDistributions(probedDataset, [], null),
+        ),
         resolve: vi.fn().mockResolvedValue(makeResolvedDistribution()),
         cleanup,
       };
@@ -1106,6 +1121,10 @@ describe('Pipeline', () => {
     it('calls resolver.cleanup even when a stage throws', async () => {
       const cleanup = vi.fn().mockResolvedValue(undefined);
       const resolver: DistributionResolver = {
+        probe: vi.fn(
+          async (probedDataset: Dataset) =>
+            new ProbedDistributions(probedDataset, [], null),
+        ),
         resolve: vi.fn().mockResolvedValue(makeResolvedDistribution()),
         cleanup,
       };
@@ -1129,6 +1148,10 @@ describe('Pipeline', () => {
 
     it('works when resolver has no cleanup method', async () => {
       const resolver: DistributionResolver = {
+        probe: vi.fn(
+          async (probedDataset: Dataset) =>
+            new ProbedDistributions(probedDataset, [], null),
+        ),
         resolve: vi.fn().mockResolvedValue(makeResolvedDistribution()),
       };
 
@@ -1258,6 +1281,272 @@ describe('Pipeline', () => {
 
       expect(reporter.timeoutTightened).toHaveBeenCalledWith(tightenEvent);
       expect(reporter.timeoutRelaxed).toHaveBeenCalledWith(relaxEvent);
+    });
+  });
+
+  describe('provenance store gate', () => {
+    // A data-dump source with a deterministic fingerprint, so a stored record
+    // can be made to match (or not) the current run.
+    const dumpDistribution = new Distribution(
+      new URL('http://example.org/data.nt'),
+      'application/n-triples',
+    );
+    const dumpProbe = new DataDumpProbeResult(
+      'http://example.org/data.nt',
+      new Response('', {
+        status: 200,
+        headers: {
+          'Content-Length': '1000',
+          'Last-Modified': 'Sat, 01 Jun 2024 00:00:00 GMT',
+        },
+      }),
+      0,
+    );
+    const currentFingerprint = sourceFingerprint(dumpDistribution, dumpProbe);
+
+    /** A resolver whose probe selects the data dump, then resolves/imports it. */
+    function makeDumpResolver(
+      resolveResult:
+        | ResolvedDistribution
+        | NoDistributionAvailable = new ResolvedDistribution(
+        sparqlDistribution,
+        [dumpProbe],
+        dumpDistribution,
+        1,
+        100,
+      ),
+    ): DistributionResolver & {
+      probe: ReturnType<typeof vi.fn>;
+      resolve: ReturnType<typeof vi.fn>;
+    } {
+      return {
+        probe: vi.fn(
+          async (probedDataset: Dataset) =>
+            new ProbedDistributions(probedDataset, [dumpProbe], {
+              distribution: dumpDistribution,
+              probeResult: dumpProbe,
+            }),
+        ),
+        resolve: vi.fn(async () => resolveResult),
+      };
+    }
+
+    function makeStore(
+      stored: ProcessingRecord | null,
+    ): ProvenanceStore & {
+      get: ReturnType<typeof vi.fn>;
+      set: ReturnType<typeof vi.fn>;
+    } {
+      return {
+        get: vi.fn().mockResolvedValue(stored),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+    }
+
+    it('throws when a store is configured without a pipelineVersion', () => {
+      expect(
+        () =>
+          new Pipeline({
+            datasetSelector: makeDatasetSelector(dataset),
+            stages: [makeStage('stage1')],
+            writers: writer,
+            distributionResolver: makeResolver(makeResolvedDistribution()),
+            provenanceStore: makeStore(null),
+          }),
+      ).toThrow(
+        'pipelineVersion is required when a provenanceStore is configured',
+      );
+    });
+
+    it('skips an unchanged dataset before importing', async () => {
+      const resolver = makeDumpResolver();
+      const store = makeStore({
+        sourceFingerprint: currentFingerprint,
+        pipelineVersion: 'v1',
+        generatedAt: '2026-06-01T00:00:00.000Z',
+        status: 'success',
+      });
+      const stage = makeStage('stage1');
+      const reporter = makeReporter();
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [stage],
+        writers: writer,
+        distributionResolver: resolver,
+        provenanceStore: store,
+        pipelineVersion: 'v1',
+        reporter,
+      });
+
+      await pipeline.run();
+
+      // The decisive guarantee: gated out before the import/resolve phase.
+      expect(resolver.probe).toHaveBeenCalledTimes(1);
+      expect(resolver.resolve).not.toHaveBeenCalled();
+      expect(stage.run).not.toHaveBeenCalled();
+      expect(store.set).not.toHaveBeenCalled();
+      expect(reporter.datasetSkipped).toHaveBeenCalledWith(
+        dataset,
+        'Unchanged since last run',
+      );
+    });
+
+    it('reprocesses and records a dataset with no prior record', async () => {
+      const resolver = makeDumpResolver();
+      const store = makeStore(null);
+      const stage = makeStage('stage1');
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [stage],
+        writers: writer,
+        distributionResolver: resolver,
+        provenanceStore: store,
+        pipelineVersion: 'v1',
+      });
+
+      await pipeline.run();
+
+      expect(resolver.resolve).toHaveBeenCalledTimes(1);
+      expect(stage.run).toHaveBeenCalledTimes(1);
+      expect(store.set).toHaveBeenCalledWith(
+        dataset.iri,
+        expect.objectContaining({
+          sourceFingerprint: currentFingerprint,
+          pipelineVersion: 'v1',
+          status: 'success',
+        }),
+      );
+    });
+
+    it('reprocesses when the stored pipelineVersion differs', async () => {
+      const resolver = makeDumpResolver();
+      const store = makeStore({
+        sourceFingerprint: currentFingerprint,
+        pipelineVersion: 'v1',
+        generatedAt: '2026-06-01T00:00:00.000Z',
+        status: 'success',
+      });
+      const stage = makeStage('stage1');
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [stage],
+        writers: writer,
+        distributionResolver: resolver,
+        provenanceStore: store,
+        pipelineVersion: 'v2', // rotated → full reprocess
+      });
+
+      await pipeline.run();
+
+      expect(resolver.resolve).toHaveBeenCalledTimes(1);
+      expect(stage.run).toHaveBeenCalledTimes(1);
+      expect(store.set).toHaveBeenCalledWith(
+        dataset.iri,
+        expect.objectContaining({ pipelineVersion: 'v2', status: 'success' }),
+      );
+    });
+
+    it('records a failed outcome when no distribution resolves', async () => {
+      const resolver = makeDumpResolver(
+        new NoDistributionAvailable(dataset, 'Import failed', [dumpProbe]),
+      );
+      const store = makeStore(null);
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [makeStage('stage1')],
+        writers: writer,
+        distributionResolver: resolver,
+        provenanceStore: store,
+        pipelineVersion: 'v1',
+      });
+
+      await pipeline.run();
+
+      expect(store.set).toHaveBeenCalledWith(
+        dataset.iri,
+        expect.objectContaining({
+          sourceFingerprint: currentFingerprint,
+          status: 'failed',
+        }),
+      );
+    });
+
+    it('does not gate or record when no store is configured', async () => {
+      const resolver = makeDumpResolver();
+      const stage = makeStage('stage1');
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [stage],
+        writers: writer,
+        distributionResolver: resolver,
+      });
+
+      await pipeline.run();
+
+      // Today's behaviour: always resolve and run.
+      expect(resolver.resolve).toHaveBeenCalledTimes(1);
+      expect(stage.run).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('resolver phase errors', () => {
+    it('skips a dataset and never resolves when probing throws', async () => {
+      const resolver: DistributionResolver = {
+        probe: vi.fn().mockRejectedValue(new Error('probe boom')),
+        resolve: vi.fn(),
+      };
+      const stage = makeStage('stage1');
+      const reporter = makeReporter();
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [stage],
+        writers: writer,
+        distributionResolver: resolver,
+        reporter,
+      });
+
+      await pipeline.run();
+
+      expect(resolver.resolve).not.toHaveBeenCalled();
+      expect(stage.run).not.toHaveBeenCalled();
+      expect(reporter.datasetSkipped).toHaveBeenCalledWith(
+        dataset,
+        expect.stringContaining('Distribution probing failed'),
+      );
+    });
+
+    it('skips a dataset when resolution throws', async () => {
+      const resolver: DistributionResolver = {
+        probe: vi.fn(
+          async (probedDataset: Dataset) =>
+            new ProbedDistributions(probedDataset, [], null),
+        ),
+        resolve: vi.fn().mockRejectedValue(new Error('resolve boom')),
+      };
+      const stage = makeStage('stage1');
+      const reporter = makeReporter();
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [stage],
+        writers: writer,
+        distributionResolver: resolver,
+        reporter,
+      });
+
+      await pipeline.run();
+
+      expect(stage.run).not.toHaveBeenCalled();
+      expect(reporter.datasetSkipped).toHaveBeenCalledWith(
+        dataset,
+        expect.stringContaining('Distribution resolution failed'),
+      );
     });
   });
 });

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -1331,9 +1331,7 @@ describe('Pipeline', () => {
       };
     }
 
-    function makeStore(
-      stored: ProcessingRecord | null,
-    ): ProvenanceStore & {
+    function makeStore(stored: ProcessingRecord | null): ProvenanceStore & {
       get: ReturnType<typeof vi.fn>;
       set: ReturnType<typeof vi.fn>;
     } {
@@ -1473,6 +1471,79 @@ describe('Pipeline', () => {
           status: 'failed',
         }),
       );
+    });
+
+    it("records 'failed' when a stage throws", async () => {
+      const resolver = makeDumpResolver();
+      const store = makeStore(null);
+      const failingStage = makeStage('failing');
+      vi.spyOn(failingStage, 'run').mockRejectedValue(new Error('stage boom'));
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [failingStage],
+        writers: writer,
+        distributionResolver: resolver,
+        provenanceStore: store,
+        pipelineVersion: 'v1',
+      });
+
+      await pipeline.run();
+
+      // The dataset produced no output, so it must not be recorded as success.
+      expect(store.set).toHaveBeenCalledWith(
+        dataset.iri,
+        expect.objectContaining({ status: 'failed' }),
+      );
+    });
+
+    it('reprocesses without crashing when the store read fails', async () => {
+      const resolver = makeDumpResolver();
+      const store: ProvenanceStore & { get: ReturnType<typeof vi.fn> } = {
+        get: vi.fn().mockRejectedValue(new Error('store unreachable')),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+      const stage = makeStage('stage1');
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [stage],
+        writers: writer,
+        distributionResolver: resolver,
+        provenanceStore: store,
+        pipelineVersion: 'v1',
+      });
+
+      // A store read failure must not abort the run; it falls through to
+      // reprocessing rather than wrongly skipping or crashing.
+      await expect(pipeline.run()).resolves.toBeUndefined();
+      expect(resolver.resolve).toHaveBeenCalledTimes(1);
+      expect(stage.run).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues the run when the store write fails', async () => {
+      const dataset1 = makeDataset('http://example.org/dataset/1');
+      const dataset2 = makeDataset('http://example.org/dataset/2');
+      const resolver = makeDumpResolver();
+      const store: ProvenanceStore & { set: ReturnType<typeof vi.fn> } = {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockRejectedValue(new Error('disk full')),
+      };
+      const stage = makeStage('stage1');
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset1, dataset2),
+        stages: [stage],
+        writers: writer,
+        distributionResolver: resolver,
+        provenanceStore: store,
+        pipelineVersion: 'v1',
+      });
+
+      await expect(pipeline.run()).resolves.toBeUndefined();
+      // Both datasets are processed despite each write throwing.
+      expect(stage.run).toHaveBeenCalledTimes(2);
+      expect(store.set).toHaveBeenCalledTimes(2);
     });
 
     it('does not gate or record when no store is configured', async () => {

--- a/packages/pipeline/test/provenance/fileLoadedSparqlProvenanceStore.test.ts
+++ b/packages/pipeline/test/provenance/fileLoadedSparqlProvenanceStore.test.ts
@@ -1,0 +1,175 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+import { mkdtemp, rm, readdir, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Parser } from 'n3';
+import type { Quad } from '@rdfjs/types';
+import {
+  startSparqlEndpoint,
+  teardownSparqlEndpoint,
+} from '@lde/local-sparql-endpoint';
+import { FileLoadedSparqlProvenanceStore } from '../../src/provenance/fileLoadedSparqlProvenanceStore.js';
+
+const PORT = 3004;
+const QUERY_ENDPOINT = `http://localhost:${PORT}/sparql`;
+const FIXTURE = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../fixtures/provenanceRecords.trig',
+);
+
+const PIPELINE_IRI = 'http://example.org/pipeline/dkg';
+const DATASET_IRI = 'http://example.org/dataset/1';
+const PROV = 'http://www.w3.org/ns/prov#';
+const LDE = 'https://w3id.org/lde/provenance#';
+
+/** Read the single provenance file written into `dir` and parse its quads. */
+async function readQuads(dir: string): Promise<Quad[]> {
+  const files = await readdir(dir);
+  const nquads = files.filter((file) => file.endsWith('.nq'));
+  expect(nquads).toHaveLength(1);
+  const content = await readFile(join(dir, nquads[0]), 'utf8');
+  return new Parser({ format: 'N-Quads' }).parse(content) as Quad[];
+}
+
+function objectOf(quads: Quad[], predicate: string): string | undefined {
+  return quads.find((quad) => quad.predicate.value === predicate)?.object.value;
+}
+
+describe('FileLoadedSparqlProvenanceStore', () => {
+  let outputDir: string;
+
+  beforeEach(async () => {
+    outputDir = await mkdtemp(join(tmpdir(), 'lde-provenance-'));
+  });
+
+  afterEach(async () => {
+    await rm(outputDir, { recursive: true, force: true });
+  });
+
+  function store(): FileLoadedSparqlProvenanceStore {
+    return new FileLoadedSparqlProvenanceStore({
+      queryEndpoint: new URL('http://example.org/sparql'),
+      pipelineIri: new URL(PIPELINE_IRI),
+      outputDir,
+    });
+  }
+
+  describe('set', () => {
+    it('writes the record as PROV-O quads in the pipeline provenance graph', async () => {
+      await store().set(new URL(DATASET_IRI), {
+        sourceFingerprint: '2024-06-01T00:00:00.000Z|1000',
+        pipelineVersion: 'v1',
+        generatedAt: '2026-06-11T00:00:00.000Z',
+        status: 'success',
+      });
+
+      const quads = await readQuads(outputDir);
+
+      // Every quad lands in the pipeline provenance graph, keyed by dataset URI.
+      expect(quads.length).toBeGreaterThan(0);
+      for (const quad of quads) {
+        expect(quad.graph.value).toBe(PIPELINE_IRI);
+        expect(quad.subject.value).toBe(DATASET_IRI);
+      }
+
+      expect(objectOf(quads, `${PROV}generatedAtTime`)).toBe(
+        '2026-06-11T00:00:00.000Z',
+      );
+      expect(objectOf(quads, `${LDE}sourceFingerprint`)).toBe(
+        '2024-06-01T00:00:00.000Z|1000',
+      );
+      expect(objectOf(quads, `${LDE}pipelineVersion`)).toBe('v1');
+      expect(objectOf(quads, `${LDE}status`)).toBe('success');
+    });
+
+    it('omits the fingerprint triple when the fingerprint is null', async () => {
+      await store().set(new URL(DATASET_IRI), {
+        sourceFingerprint: null,
+        pipelineVersion: 'v1',
+        generatedAt: '2026-06-11T00:00:00.000Z',
+        status: 'failed',
+      });
+
+      const quads = await readQuads(outputDir);
+
+      // No fingerprint triple at all, so get() reconstructs it as null rather
+      // than an empty-string literal that could spuriously compare equal.
+      expect(objectOf(quads, `${LDE}sourceFingerprint`)).toBeUndefined();
+      expect(objectOf(quads, `${LDE}pipelineVersion`)).toBe('v1');
+      expect(objectOf(quads, `${LDE}status`)).toBe('failed');
+    });
+  });
+
+  describe('get', () => {
+    beforeAll(async () => {
+      await startSparqlEndpoint(PORT, FIXTURE);
+    }, 60_000);
+
+    afterAll(async () => {
+      await teardownSparqlEndpoint();
+    });
+
+    function getStore(pipelineIri: string): FileLoadedSparqlProvenanceStore {
+      return new FileLoadedSparqlProvenanceStore({
+        queryEndpoint: new URL(QUERY_ENDPOINT),
+        pipelineIri: new URL(pipelineIri),
+        outputDir,
+      });
+    }
+
+    it('reads back a stored record from the pipeline graph', async () => {
+      const record = await getStore(PIPELINE_IRI).get(new URL(DATASET_IRI));
+
+      expect(record).toEqual({
+        sourceFingerprint: '2024-06-01T00:00:00.000Z|1000',
+        pipelineVersion: 'v1',
+        generatedAt: '2026-06-11T00:00:00.000Z',
+        status: 'success',
+      });
+    });
+
+    it('returns null for a dataset with no record', async () => {
+      const record = await getStore(PIPELINE_IRI).get(
+        new URL('http://example.org/dataset/absent'),
+      );
+
+      expect(record).toBeNull();
+    });
+
+    it('reconstructs a null fingerprint when the fingerprint triple is absent', async () => {
+      const record = await getStore(PIPELINE_IRI).get(
+        new URL('http://example.org/dataset/3'),
+      );
+
+      expect(record).toEqual({
+        sourceFingerprint: null,
+        pipelineVersion: 'v1',
+        generatedAt: '2026-06-11T00:00:00.000Z',
+        status: 'failed',
+      });
+    });
+
+    it('is scoped by pipeline IRI: another pipeline’s record does not leak', async () => {
+      // dataset/1 has a record in both the dkg and the other pipeline graph.
+      // Querying as dkg must return dkg's record, never the other one.
+      const record = await getStore(PIPELINE_IRI).get(new URL(DATASET_IRI));
+      expect(record?.pipelineVersion).toBe('v1');
+
+      // Querying as the other pipeline returns its own, different record.
+      const other = await getStore('http://example.org/pipeline/other').get(
+        new URL(DATASET_IRI),
+      );
+      expect(other?.pipelineVersion).toBe('other-v9');
+      expect(other?.sourceFingerprint).toBe('other-fingerprint|999');
+    });
+  });
+});

--- a/packages/pipeline/test/provenance/fileLoadedSparqlProvenanceStore.test.ts
+++ b/packages/pipeline/test/provenance/fileLoadedSparqlProvenanceStore.test.ts
@@ -171,5 +171,17 @@ describe('FileLoadedSparqlProvenanceStore', () => {
       expect(other?.pipelineVersion).toBe('other-v9');
       expect(other?.sourceFingerprint).toBe('other-fingerprint|999');
     });
+
+    it('rejects an IRI with characters that could break out of the SPARQL query', async () => {
+      // A real URL normalises unsafe characters, so simulate a non-normalised
+      // IRI reaching the store to confirm it is rejected before querying.
+      const unsafe = {
+        toString: () => 'http://example.org/d> } GRAPH <evil> { ?s ?p ?o',
+      } as unknown as URL;
+
+      await expect(getStore(PIPELINE_IRI).get(unsafe)).rejects.toThrow(
+        'unsafe characters',
+      );
+    });
   });
 });

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 95.37,
-          lines: 94.77,
-          branches: 89.91,
-          statements: 94.33,
+          functions: 95.55,
+          lines: 95.12,
+          branches: 89.83,
+          statements: 94.58,
         },
       },
     },

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 95.2,
-          lines: 94.47,
-          branches: 89.78,
-          statements: 94.04,
+          functions: 95.37,
+          lines: 94.77,
+          branches: 89.91,
+          statements: 94.33,
         },
       },
     },

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 95.55,
-          lines: 95.12,
-          branches: 89.83,
-          statements: 94.58,
+          lines: 95.17,
+          branches: 89.87,
+          statements: 94.64,
         },
       },
     },


### PR DESCRIPTION
## What

Lands slices C, D and E of the skip-unchanged-datasets feature (#450), completing the opt-in skip mechanism on top of the source-change fingerprint + reprocess decision merged in #451. With a store and a `pipelineVersion` configured, the pipeline now skips a dataset whose source and logic are both unchanged **before paying the import cost**.

## Slice C — `ProvenanceStore` + file-loaded reference impl

- **`ProvenanceStore`** interface (`get`/`set`, keyed by dataset URI): the framework owns the skip decision, the store owns only persistence.
- **`FileLoadedSparqlProvenanceStore`** — for a triplestore served read-only and rebuilt by bulk-loading files (e.g. QLever). `get` runs a named-graph-scoped SPARQL `SELECT` against the live endpoint; `set` writes one flat PROV-O N-Quads file per dataset (via `FileWriter`, in the pipeline-scoped graph) for the next bulk-load. No SPARQL UPDATE, so it works read-only.
- Records are flat PROV-O on the dataset entity — `prov:generatedAtTime` plus `sourceFingerprint`/`pipelineVersion`/`status` under `https://w3id.org/lde/provenance#`. A `null` fingerprint omits its triple and reads back as `null`. Scoped per pipeline IRI so pipelines sharing a store don't collide.

## Slice D — two-phase distribution resolver

The resolver is split so the gate can run before any import:

- `DistributionResolver.probe(dataset) → ProbedDistributions` — probes every distribution and selects the source-to-be (SPARQL endpoint or import candidate) **without importing**.
- `DistributionResolver.resolve(probed) → Resolved | NoneAvailable` — imports a data dump only when the probed source is one.
- `ProbedDistributions` carries `{ dataset, probeResults, source }`; `isSparql()` on the source routes "live endpoint → null fingerprint, no import" vs "dump → fingerprint + import". `SparqlDistributionResolver`, `ImportResolver`, and `resolveDistributions` all updated.

## Slice E — pipeline skip gate

- `Pipeline` accepts an optional `provenanceStore` and a `pipelineVersion` (**required** when a store is set — a skip-enabled pipeline with no version would silently freeze). Per dataset: probe → derive fingerprint → read record → skip before import iff both change fields match; otherwise resolve, run stages, and record the outcome.
- A failed resolution is recorded as `'failed'`, so a deterministically failing import is not retried every run (retried only on a fingerprint change or version rotation).
- With no store configured, every dataset is reprocessed — today's behaviour, unchanged.
- README documents the opt-in and the skip rule.

## Tests

- Store: round-trip via files + `get` against `@lde/local-sparql-endpoint` (record read, `null` for missing, `null`-fingerprint reconstruction, per-pipeline scoping). New test port 3004.
- Resolver split: existing `SparqlDistributionResolver` / `ImportResolver` / `resolveDistributions` suites updated to the two-phase interface.
- Gate (the decisive guarantee): an unchanged dataset is skipped **before** `resolve` is called; a changed/new/version-rotated dataset is resolved, run, and recorded; failed resolution records `'failed'`; no-store path unchanged; probe/resolve errors skip cleanly.

All affected workspace projects pass lint, typecheck, test, build.

Part of #450.
