### PR TITLE
feat(pipeline-void): canonicalise namespace aliases when partitioning by class

### DIFF
--- a/packages/pipeline-void/README.md
+++ b/packages/pipeline-void/README.md
@@ -10,14 +10,15 @@ Returns all VoID stages in their recommended execution order. The ordering is op
 
 Accepts an optional `VoidStagesOptions` object:
 
-| Option           | Default | Description                                                                                                     |
-| ---------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
-| `batchSize`      | 10      | Maximum class bindings per executor call (per-class stages only)                                                |
-| `maxConcurrency` | 10      | Maximum concurrent in-flight executor batches (per-class stages only)                                           |
-| `perClass`       | —       | Override per-class iteration for all five per-class stages                                                      |
-| `uriSpaces`      | —       | When provided, includes the object URI space stage                                                              |
-| `vocabularies`   | —       | Additional vocabulary namespace URIs to detect beyond the built-in defaults                                     |
-| `transforms`     | —       | Transforms to attach to bundled stages, keyed by `VOID_STAGE_NAMES` (see [Stage transforms](#stage-transforms)) |
+| Option             | Default | Description                                                                                                                       |
+| ------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `batchSize`        | 10      | Maximum class bindings per executor call (per-class stages only)                                                                  |
+| `maxConcurrency`   | 10      | Maximum concurrent in-flight executor batches (per-class stages only)                                                             |
+| `perClass`         | —       | Override per-class iteration for all five per-class stages                                                                        |
+| `uriSpaces`        | —       | When provided, includes the object URI space stage                                                                                |
+| `vocabularies`     | —       | Additional vocabulary namespace URIs to detect beyond the built-in defaults                                                       |
+| `namespaceAliases` | —       | Namespace pairs whose alias form is treated as canonical when partitioning by class (see [Namespace aliases](#namespace-aliases)) |
+| `transforms`       | —       | Transforms to attach to bundled stages, keyed by `VOID_STAGE_NAMES` (see [Stage transforms](#stage-transforms))                   |
 
 Per-request timeouts are configured at the `Pipeline` level via `PipelineOptions.timeout`, not per VoID stage.
 
@@ -71,6 +72,22 @@ Global and domain-specific factories accept `VoidStageOptions` (`transform`) and
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `detectVocabularies()`   | [`entity-properties.rq`](queries/entity-properties.rq) — Entity properties with automatic `void:vocabulary` detection. Accepts `DetectVocabulariesOptions` with an optional `vocabularies` array to extend the built-in defaults. |
 | `uriSpaces(uriSpaceMap)` | [`object-uri-space.rq`](queries/object-uri-space.rq) — Object URI namespace linksets, aggregated against a provided URI space map                                                                                                 |
+
+## Namespace aliases
+
+Some vocabularies are published under more than one namespace IRI — most commonly schema.org, served under both `http://schema.org/` (historical) and `https://schema.org/` (current). To RDF these are distinct IRIs, so a dataset that mixes the two forms produces a separate `void:classPartition` for each variant of the same class, each counted over a disjoint subset.
+
+Pass `namespaceAliases` to treat an alias namespace as its canonical equivalent. Every class-keyed query then rewrites alias-namespace types to canonical before grouping — and the class selector collapses the variants — so each class appears once, with `void:entities` summed and its property partitions merged. The per-class queries still match resources typed with either variant, so no resource is dropped.
+
+```typescript
+const stages = await voidStages({
+  namespaceAliases: [
+    { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+  ],
+});
+```
+
+Canonicalisation applies to class IRIs (`void:class`, including object-class partitions), not to predicates. With no aliases configured the queries are unchanged.
 
 ## Stage transforms
 

--- a/packages/pipeline-void/package.json
+++ b/packages/pipeline-void/package.json
@@ -31,6 +31,9 @@
     "n3": "^2.0.1",
     "tslib": "^2.3.0"
   },
+  "devDependencies": {
+    "@comunica/query-sparql-rdfjs-lite": "^4.5.0"
+  },
   "peerDependencies": {
     "@lde/dataset": "0.7.5",
     "@lde/pipeline": "0.30.12"

--- a/packages/pipeline-void/queries/class-partition.rq
+++ b/packages/pipeline-void/queries/class-partition.rq
@@ -10,7 +10,7 @@ WHERE {
     {
         SELECT (COUNT(?type) AS ?entities) ?type {
             #subjectFilter#
-            ?s a ?type .
+            #typePattern(?s, ?type)#
         }
         GROUP BY ?type
     }

--- a/packages/pipeline-void/queries/class-properties-objects.rq
+++ b/packages/pipeline-void/queries/class-properties-objects.rq
@@ -10,7 +10,8 @@ WHERE {
             {
                 SELECT ?class ?p ?o {
                     #subjectFilter#
-                    ?s a ?class ; ?p ?o .
+                    #typePatternFiltered(?s, ?class)#
+                    ?s ?p ?o .
                 }
             }
         }

--- a/packages/pipeline-void/queries/class-properties-subjects.rq
+++ b/packages/pipeline-void/queries/class-properties-subjects.rq
@@ -15,7 +15,8 @@ WHERE {
             {
                 SELECT ?class ?p ?s {
                     #subjectFilter#
-                    ?s a ?class ; ?p [] .
+                    #typePatternFiltered(?s, ?class)#
+                    ?s ?p [] .
                 }
             }
         }

--- a/packages/pipeline-void/queries/class-property-datatypes.rq
+++ b/packages/pipeline-void/queries/class-property-datatypes.rq
@@ -13,8 +13,8 @@ WHERE {
       {
         SELECT ?class ?p ?o {
           #subjectFilter#
-          ?s a ?class ;
-            ?p ?o .
+          #typePatternFiltered(?s, ?class)#
+          ?s ?p ?o .
           FILTER (ISLITERAL(?o))
         }
       }

--- a/packages/pipeline-void/queries/class-property-languages.rq
+++ b/packages/pipeline-void/queries/class-property-languages.rq
@@ -14,8 +14,8 @@ WHERE {
         # Pre-filter to distinct literals to minimize LANG calls
         SELECT DISTINCT ?class ?p ?o {
           #subjectFilter#
-          ?s a ?class ;
-            ?p ?o .
+          #typePatternFiltered(?s, ?class)#
+          ?s ?p ?o .
           FILTER(ISLITERAL(?o))
         }
       }

--- a/packages/pipeline-void/queries/class-property-object-classes.rq
+++ b/packages/pipeline-void/queries/class-property-object-classes.rq
@@ -13,12 +13,12 @@ WHERE {
       {
         SELECT ?class ?p ?o {
           #subjectFilter#
-          ?s a ?class ;
-            ?p ?o .
+          #typePatternFiltered(?s, ?class)#
+          ?s ?p ?o .
           FILTER (ISIRI(?o))
         }
       }
-      ?o a ?objectClass .
+      #typePattern(?o, ?objectClass)#
     }
     GROUP BY ?class ?p ?objectClass
   }

--- a/packages/pipeline-void/src/index.ts
+++ b/packages/pipeline-void/src/index.ts
@@ -5,5 +5,6 @@ export type {
   QuadTransform,
 } from '@lde/pipeline';
 export * from './stage.js';
+export * from './namespaceAlias.js';
 export * from './vocabularyTransform.js';
 export * from './uriSpaceTransform.js';

--- a/packages/pipeline-void/src/namespaceAlias.ts
+++ b/packages/pipeline-void/src/namespaceAlias.ts
@@ -1,0 +1,94 @@
+import { assertSafeIri } from '@lde/dataset';
+
+/**
+ * A pair of namespace IRI prefixes that denote the same vocabulary, where
+ * {@link alias} IRIs are to be treated as their {@link canonical} equivalents.
+ *
+ * The canonical example is schema.org, which datasets publish under both
+ * `http://schema.org/` (historical) and `https://schema.org/` (current). To
+ * RDF these are distinct IRIs, so without canonicalisation a dataset that
+ * mixes both forms yields two `void:classPartition` nodes for what is
+ * conceptually one class, each counted over a disjoint subset.
+ */
+export interface NamespaceAlias {
+  /** The canonical namespace IRI prefix that {@link alias} IRIs are rewritten to. */
+  canonical: string;
+  /** The alias namespace IRI prefix, rewritten to {@link canonical}. */
+  alias: string;
+}
+
+/**
+ * Reject namespaces that could break out of the SPARQL string literals and
+ * IRI references the canonicalisation expression interpolates them into.
+ */
+function assertSafeNamespace(namespace: string): void {
+  assertSafeIri(namespace);
+  if (namespace.includes('"') || namespace.includes('\\')) {
+    throw new Error(
+      `Namespace contains characters unsafe for a SPARQL string literal: ${namespace}`,
+    );
+  }
+}
+
+/**
+ * A SPARQL expression that rewrites `?${rawVariable}` from any configured alias
+ * namespace to its canonical form, leaving IRIs in no alias namespace
+ * untouched. Aliases are tested in order; the first matching prefix wins.
+ */
+function canonicalizeExpression(
+  rawVariable: string,
+  aliases: readonly NamespaceAlias[],
+): string {
+  return aliases.reduceRight((otherwise, { canonical, alias }) => {
+    assertSafeNamespace(canonical);
+    assertSafeNamespace(alias);
+    return `IF(STRSTARTS(STR(?${rawVariable}), "${alias}"), IRI(CONCAT("${canonical}", STRAFTER(STR(?${rawVariable}), "${alias}"))), ${otherwise})`;
+  }, `?${rawVariable}`);
+}
+
+/**
+ * `#typePattern(?subject, ?type)#` — match the type of `?subject`, binding the
+ * canonical form to `?type`. Used where `?type` is grouped or derived (not
+ * injected), so a plain `BIND` can assign it.
+ */
+const TYPE_PATTERN = /#typePattern\(\?(\w+),\s*\?(\w+)\)#/g;
+
+/**
+ * `#typePatternFiltered(?subject, ?type)#` — match the type of `?subject` and
+ * keep only those whose canonical form equals `?type`. Used where `?type` is
+ * supplied through an injected `VALUES` clause (the per-class stages): SPARQL
+ * forbids `BIND(… AS ?type)` for an already-bound variable, so the canonical
+ * form is bound to a helper variable and compared with `FILTER`.
+ */
+const TYPE_PATTERN_FILTERED = /#typePatternFiltered\(\?(\w+),\s*\?(\w+)\)#/g;
+
+/**
+ * Replace the type-pattern placeholders in a VoID query with patterns that
+ * canonicalise alias-namespace types. With no aliases configured both
+ * placeholders collapse to a plain `?subject a ?type .` triple, leaving the
+ * query — and its performance — unchanged.
+ */
+export function applyNamespaceAliases(
+  query: string,
+  aliases: readonly NamespaceAlias[],
+): string {
+  const bindForm = (subject: string, type: string): string => {
+    if (aliases.length === 0) return `?${subject} a ?${type} .`;
+    const raw = `${type}Raw`;
+    return `?${subject} a ?${raw} .\n    BIND(${canonicalizeExpression(raw, aliases)} AS ?${type})`;
+  };
+  const filterForm = (subject: string, type: string): string => {
+    if (aliases.length === 0) return `?${subject} a ?${type} .`;
+    const actual = `${type}Actual`;
+    const canonical = `${type}Canonical`;
+    return `?${subject} a ?${actual} .\n    BIND(${canonicalizeExpression(actual, aliases)} AS ?${canonical})\n    FILTER(?${canonical} = ?${type})`;
+  };
+
+  return query
+    .replaceAll(TYPE_PATTERN, (_match, subject, type) =>
+      bindForm(subject, type),
+    )
+    .replaceAll(TYPE_PATTERN_FILTERED, (_match, subject, type) =>
+      filterForm(subject, type),
+    );
+}

--- a/packages/pipeline-void/src/stage.ts
+++ b/packages/pipeline-void/src/stage.ts
@@ -17,6 +17,10 @@ import {
   defaultVocabularies,
 } from './vocabularyTransform.js';
 import { withUriSpaces } from './uriSpaceTransform.js';
+import {
+  applyNamespaceAliases,
+  type NamespaceAlias,
+} from './namespaceAlias.js';
 
 const queriesDir = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -76,6 +80,15 @@ export interface VoidStageOptions {
    * with these, built-in first.
    */
   transform?: VoidStageTransform;
+  /**
+   * Namespace pairs whose alias form is treated as its canonical equivalent
+   * when partitioning by class. Each class-keyed query rewrites alias-namespace
+   * types to canonical before grouping, so a dataset that mixes e.g.
+   * `http://schema.org/` and `https://schema.org/` yields a single
+   * `void:classPartition` per class with summed `void:entities`, rather than
+   * one partition per namespace variant. Defaults to no aliases (no rewriting).
+   */
+  namespaceAliases?: readonly NamespaceAlias[];
 }
 
 /**
@@ -126,9 +139,14 @@ async function createVoidStage(
     perClass?: boolean;
     batchSize?: number;
     maxConcurrency?: number;
+    namespaceAliases?: readonly NamespaceAlias[];
   },
 ): Promise<Stage> {
-  const query = await readQueryFile(resolve(queriesDir, filename));
+  const namespaceAliases = options?.namespaceAliases ?? [];
+  const query = applyNamespaceAliases(
+    await readQueryFile(resolve(queriesDir, filename)),
+    namespaceAliases,
+  );
   const executor: AttachedExecutor = {
     executor: new SparqlConstructExecutor({ query }),
     transform: options?.transform,
@@ -137,7 +155,9 @@ async function createVoidStage(
   return new Stage({
     name: filename,
     executors: executor,
-    itemSelector: options?.perClass ? classSelector() : undefined,
+    itemSelector: options?.perClass
+      ? classSelector(namespaceAliases)
+      : undefined,
     batchSize: options?.batchSize,
     maxConcurrency: options?.maxConcurrency,
   });
@@ -151,7 +171,17 @@ function asTransforms(
   return Array.isArray(transform) ? [...transform] : [transform];
 }
 
-function classSelector(): ItemSelector {
+function classSelector(
+  namespaceAliases: readonly NamespaceAlias[] = [],
+): ItemSelector {
+  // Canonicalise the selected classes so alias-namespace variants collapse to
+  // a single class. The per-class queries match all variants (see their
+  // `#typePatternFiltered#`), so iterating the canonical class once still
+  // counts every resource.
+  const typePattern = applyNamespaceAliases(
+    '#typePattern(?s, ?class)#',
+    namespaceAliases,
+  );
   return {
     // Forward `options` so the Pipeline’s per-dataset TimeoutPolicy
     // reaches the inner SparqlItemSelector — without this the adaptive
@@ -166,7 +196,7 @@ function classSelector(): ItemSelector {
       const selectorQuery = [
         'SELECT DISTINCT ?class',
         fromClause,
-        `WHERE { ${subjectFilter} ?s a ?class . }`,
+        `WHERE { ${subjectFilter} ${typePattern} }`,
         'LIMIT 1000',
       ].join('\n');
 

--- a/packages/pipeline-void/test/classPartitionDedup.test.ts
+++ b/packages/pipeline-void/test/classPartitionDedup.test.ts
@@ -1,0 +1,115 @@
+import { applyNamespaceAliases, type NamespaceAlias } from '../src/index.js';
+import { QueryEngine } from '@comunica/query-sparql-rdfjs-lite';
+import { Store, DataFactory } from 'n3';
+import type { Quad } from '@rdfjs/types';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+const { namedNode, literal } = DataFactory;
+
+const VOID = 'http://rdfs.org/ns/void#';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+const schemaOrg: NamespaceAlias[] = [
+  { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+];
+
+const queriesDir = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'queries',
+);
+
+/**
+ * A store mixing `http://schema.org/` and `https://schema.org/` types for the
+ * same conceptual class — three CreativeWorks typed with the http variant and
+ * two with the https variant — the shape that produced duplicate
+ * `void:classPartition` nodes before canonicalisation.
+ */
+function mixedNamespaceStore(): Store {
+  const store = new Store();
+  const type = namedNode(RDF_TYPE);
+  for (let index = 0; index < 3; index++) {
+    const subject = namedNode(`urn:http:${index}`);
+    store.addQuad(subject, type, namedNode('http://schema.org/CreativeWork'));
+    store.addQuad(subject, namedNode('http://schema.org/name'), literal('a'));
+  }
+  for (let index = 0; index < 2; index++) {
+    const subject = namedNode(`urn:https:${index}`);
+    store.addQuad(subject, type, namedNode('https://schema.org/CreativeWork'));
+    store.addQuad(
+      subject,
+      namedNode('https://schema.org/encodingFormat'),
+      literal('b'),
+    );
+  }
+  return store;
+}
+
+async function runQuery(
+  file: string,
+  store: Store,
+  subjectFilter: string,
+): Promise<Quad[]> {
+  const query = applyNamespaceAliases(
+    await readFile(resolve(queriesDir, file), 'utf-8'),
+    schemaOrg,
+  )
+    .replaceAll('#subjectFilter#', subjectFilter)
+    .replaceAll('?dataset', '<urn:dataset>');
+
+  const result: Quad[] = [];
+  const stream = await new QueryEngine().queryQuads(query, {
+    sources: [store],
+  });
+  for await (const quad of stream) result.push(quad);
+  return result;
+}
+
+const objectsOf = (quads: Quad[], predicate: string): string[] =>
+  quads
+    .filter((quad) => quad.predicate.value === predicate)
+    .map((quad) => quad.object.value);
+
+describe('class partition deduplication across namespace aliases', () => {
+  beforeAll(() => {
+    // The Comunica engine pulls in many modules; give the first import room.
+  });
+
+  it('emits a single class partition with summed entities', async () => {
+    const quads = await runQuery(
+      'class-partition.rq',
+      mixedNamespaceStore(),
+      '',
+    );
+
+    expect(objectsOf(quads, `${VOID}class`)).toEqual([
+      'https://schema.org/CreativeWork',
+    ]);
+    // 3 http-typed + 2 https-typed resources, summed into one partition.
+    expect(objectsOf(quads, `${VOID}entities`)).toEqual(['5']);
+  });
+
+  it('counts both namespace variants under the canonical class partition', async () => {
+    // The selector injects the canonical class; the query must still match the
+    // alias-typed resources.
+    const quads = await runQuery(
+      'class-properties-subjects.rq',
+      mixedNamespaceStore(),
+      'VALUES ?class { <https://schema.org/CreativeWork> }',
+    );
+
+    expect(new Set(objectsOf(quads, `${VOID}class`))).toEqual(
+      new Set(['https://schema.org/CreativeWork']),
+    );
+    // Properties from both the http and https subsets attach to the one class.
+    expect(objectsOf(quads, `${VOID}property`)).toEqual(
+      expect.arrayContaining([
+        'http://schema.org/name',
+        'https://schema.org/encodingFormat',
+      ]),
+    );
+  });
+});

--- a/packages/pipeline-void/test/namespaceAlias.test.ts
+++ b/packages/pipeline-void/test/namespaceAlias.test.ts
@@ -1,0 +1,94 @@
+import { applyNamespaceAliases, type NamespaceAlias } from '../src/index.js';
+import { Parser } from '@traqula/parser-sparql-1-1';
+import { readFile, readdir } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+const schemaOrg: NamespaceAlias[] = [
+  { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+];
+
+const queriesDir = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'queries',
+);
+
+describe('applyNamespaceAliases', () => {
+  it('leaves placeholders as a plain type triple when no aliases are given', () => {
+    expect(applyNamespaceAliases('#typePattern(?s, ?type)#', [])).toBe(
+      '?s a ?type .',
+    );
+    expect(applyNamespaceAliases('#typePatternFiltered(?s, ?class)#', [])).toBe(
+      '?s a ?class .',
+    );
+  });
+
+  it('binds the canonical type for a grouped variable', () => {
+    const result = applyNamespaceAliases('#typePattern(?s, ?type)#', schemaOrg);
+    expect(result).toContain('?s a ?typeRaw .');
+    expect(result).toContain('STRSTARTS(STR(?typeRaw), "http://schema.org/")');
+    expect(result).toContain('"https://schema.org/"');
+    expect(result).toContain('AS ?type');
+  });
+
+  it('filters by canonical type for an injected variable', () => {
+    const result = applyNamespaceAliases(
+      '#typePatternFiltered(?s, ?class)#',
+      schemaOrg,
+    );
+    // The injected ?class must not be reassigned with BIND, so the canonical
+    // form is bound to a helper and compared with FILTER.
+    expect(result).toContain('?s a ?classActual .');
+    expect(result).toContain('AS ?classCanonical');
+    expect(result).toContain('FILTER(?classCanonical = ?class)');
+    expect(result).not.toContain('AS ?class)');
+  });
+
+  it('nests aliases so the first matching prefix wins', () => {
+    const result = applyNamespaceAliases('#typePattern(?o, ?objectClass)#', [
+      { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+      { canonical: 'https://example.org/', alias: 'http://example.org/' },
+    ]);
+    expect(result).toContain('http://schema.org/');
+    expect(result).toContain('http://example.org/');
+  });
+
+  it('rejects namespaces that could break out of a SPARQL literal', () => {
+    expect(() =>
+      applyNamespaceAliases('#typePattern(?s, ?type)#', [
+        { canonical: 'https://schema.org/', alias: 'http://schema.org/"evil' },
+      ]),
+    ).toThrow(/unsafe/);
+  });
+});
+
+describe('canonicalised queries parse as valid SPARQL', () => {
+  const parser = new Parser();
+
+  // Substitute the runtime placeholders the executor fills in, plus a VALUES
+  // clause mimicking the per-class binding injection, so the parsed query
+  // matches what actually runs against the endpoint.
+  const prepare = (query: string): string =>
+    query
+      .replaceAll(
+        '#subjectFilter#',
+        'VALUES ?class { <https://schema.org/Thing> }',
+      )
+      .replaceAll('?dataset', '<https://example.org/dataset>');
+
+  it('parses every class-keyed query with schema.org aliases applied', async () => {
+    const files = (await readdir(queriesDir)).filter((file) =>
+      file.endsWith('.rq'),
+    );
+    for (const file of files) {
+      const raw = await readFile(resolve(queriesDir, file), 'utf-8');
+      const canonicalised = applyNamespaceAliases(raw, schemaOrg);
+      expect(
+        () => parser.parse(prepare(canonicalised)),
+        `${file} should parse`,
+      ).not.toThrow();
+    }
+  });
+});

--- a/packages/pipeline-void/vite.config.ts
+++ b/packages/pipeline-void/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
     test: {
       coverage: {
         thresholds: {
-          functions: 96.66,
-          lines: 92.7,
-          branches: 88.37,
-          statements: 93,
+          functions: 97.36,
+          lines: 94.11,
+          branches: 90.74,
+          statements: 94.4,
         },
       },
     },


### PR DESCRIPTION
## Problem

When a dataset types resources under more than one namespace variant of the same vocabulary — most commonly schema.org, published under both `http://schema.org/` and `https://schema.org/` — the VoID stages emit a **separate `void:classPartition` for each variant** of the same class. The partition node is derived from `MD5(STR(?type))`, so the two IRIs hash differently and `GROUP BY` cannot collapse them; each is counted over a disjoint subset.

This surfaced downstream as duplicate class partitions in generated summaries (see netwerk-digitaal-erfgoed/dataset-knowledge-graph#334).

## Change

Add a `namespaceAliases: { canonical, alias }[]` option to the VoID stages (mirroring `@lde/pipeline-shacl-sampler`). When set, each class-keyed query canonicalises alias-namespace class IRIs **before** grouping and partition-node hashing, so a mixed-namespace dataset yields a single `void:classPartition` per class with summed `void:entities` and merged property partitions.

Implementation notes:

- **Two rewrite forms** (`namespaceAlias.ts`): a `BIND` form for grouped/derived class variables (e.g. `class-partition.rq`, object-class partitions), and a `FILTER` form for `VALUES`-injected per-class variables — SPARQL forbids `BIND(… AS ?class)` when `?class` is already bound by an injected `VALUES`.
- The **class selector** canonicalises too, collapsing variants to one canonical class; the per-class queries still match resources typed with either variant, so no resource is dropped or double-counted.
- Canonicalisation covers class IRIs (`void:class`, including object-class partitions), not predicates.
- Namespaces are validated (`assertSafeIri` + literal-safety) before interpolation.
- **With no aliases configured the queries are byte-for-byte unchanged** — placeholders collapse to the original `?s a ?type .`.

## Tests

- `namespaceAlias.test.ts` — rewrite-form unit tests, injection-safety, and a parse-validity check that every class-keyed query (after alias substitution + `#subjectFilter#` + a `VALUES` injection) parses with the executor's own SPARQL parser.
- `classPartitionDedup.test.ts` — execution-level regression over an in-memory store mixing `http`/`https` schema.org types, asserting a single partition with summed entities and both variants' properties merged under the canonical class.

## Follow-up

The DKG pipeline will pass the schema.org alias it already gives the SHACL sampler to `voidStages` once this is released.

Addresses netwerk-digitaal-erfgoed/dataset-knowledge-graph#334.
