### PR TITLE
docs: fix 404 SHACL shapes URL in sampler example

### DIFF
--- a/packages/pipeline-shacl-sampler/README.md
+++ b/packages/pipeline-shacl-sampler/README.md
@@ -23,7 +23,8 @@ import { Pipeline, FileWriter } from '@lde/pipeline';
 import { shaclSampleStages } from '@lde/pipeline-shacl-sampler';
 import { ShaclValidator } from '@lde/pipeline-shacl-validator';
 
-const shapesFile = 'https://docs.nde.nl/schema-profile/shacl.ttl';
+const shapesFile =
+  'https://raw.githubusercontent.com/netwerk-digitaal-erfgoed/schema-profile/main/shacl.ttl';
 const validator = new ShaclValidator({
   shapesFile,
   reportWriters: [new FileWriter({ outputDir: './validation', format: 'turtle' })],


### PR DESCRIPTION
The usage example in `packages/pipeline-shacl-sampler/README.md` pointed at `https://docs.nde.nl/schema-profile/shacl.ttl`, which returns a 404.

The canonical SCHEMA-AP-NDE shapes file lives in the `netwerk-digitaal-erfgoed/schema-profile` repository, so the example now uses its dereferenceable raw GitHub URL (verified to return 200).

Fix #464
