### PR TITLE
fix(distribution-probe): accept declared compressed media type for gzipped downloads

### DIFF
--- a/packages/dataset/src/distribution.ts
+++ b/packages/dataset/src/distribution.ts
@@ -3,6 +3,16 @@ const SPARQL_URI = 'https://www.w3.org/TR/sparql11-protocol/';
 export const IANA_MEDIA_TYPE_PREFIX =
   'https://www.iana.org/assignments/media-types/';
 
+// Maps a compression content type to the structured-syntax suffix a server
+// appends to the RDF media type, e.g. `application/gzip` yields the `gzip` in
+// `application/n-quads+gzip`. The inverse of how a registry strips that suffix
+// into a separate compress format on ingest.
+const compressionSuffixesByMimeType: Record<string, string> = {
+  'application/gzip': 'gzip',
+  'application/x-gzip': 'gzip',
+  'application/zip': 'zip',
+};
+
 export class Distribution {
   public byteSize?: number;
   public compressFormat?: string;
@@ -25,6 +35,20 @@ export class Distribution {
     return this.compressFormat.startsWith(IANA_MEDIA_TYPE_PREFIX)
       ? this.compressFormat.slice(IANA_MEDIA_TYPE_PREFIX.length)
       : this.compressFormat;
+  }
+
+  /**
+   * The full content type a server is expected to send for the compressed
+   * download — {@link mimeType} with the compression suffix derived from
+   * {@link compressFormat} appended, e.g. `application/n-quads+gzip`. Returns
+   * `undefined` when no media type or no recognised compression format is
+   * declared. Lets a format check accept either the bare media type (the server
+   * decompressed the body) or the declared compressed form.
+   */
+  public get compressedMimeType(): string | undefined {
+    if (this.mimeType === undefined) return undefined;
+    const suffix = compressionSuffixesByMimeType[this.compressMimeType ?? ''];
+    return suffix === undefined ? undefined : `${this.mimeType}+${suffix}`;
   }
 
   /**

--- a/packages/dataset/test/distribution.test.ts
+++ b/packages/dataset/test/distribution.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import {
+  Distribution,
+  IANA_MEDIA_TYPE_PREFIX,
+  RdfFormat,
+  rdfFormatToFileExtension,
+} from '../src/distribution.js';
+
+const iana = (type: string) => IANA_MEDIA_TYPE_PREFIX + type;
+const SPARQL_URI = 'https://www.w3.org/TR/sparql11-protocol/';
+
+describe('Distribution.mimeType', () => {
+  it('strips the IANA prefix from an IANA media type URI', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/data.nq'),
+      iana('application/n-quads'),
+    );
+
+    expect(distribution.mimeType).toBe('application/n-quads');
+  });
+
+  it('passes a plain content type through unchanged', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/data.nq'),
+      'application/n-quads',
+    );
+
+    expect(distribution.mimeType).toBe('application/n-quads');
+  });
+
+  it('is undefined when no media type is declared', () => {
+    const distribution = new Distribution(new URL('http://example.org/data'));
+
+    expect(distribution.mimeType).toBeUndefined();
+  });
+});
+
+describe('Distribution.compressMimeType', () => {
+  it('strips the IANA prefix from an IANA compress format URI', () => {
+    const distribution = new Distribution(new URL('http://example.org/x'));
+    distribution.compressFormat = iana('application/gzip');
+
+    expect(distribution.compressMimeType).toBe('application/gzip');
+  });
+
+  it('passes a plain compress format through unchanged', () => {
+    const distribution = new Distribution(new URL('http://example.org/x'));
+    distribution.compressFormat = 'application/gzip';
+
+    expect(distribution.compressMimeType).toBe('application/gzip');
+  });
+
+  it('is undefined when no compress format is declared', () => {
+    const distribution = new Distribution(new URL('http://example.org/x'));
+
+    expect(distribution.compressMimeType).toBeUndefined();
+  });
+});
+
+describe('Distribution.compressedMimeType', () => {
+  it('appends +gzip when the compress format is gzip', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/data.nq.gz'),
+      iana('application/n-quads'),
+    );
+    distribution.compressFormat = iana('application/gzip');
+
+    expect(distribution.compressedMimeType).toBe('application/n-quads+gzip');
+  });
+
+  it('appends +zip when the compress format is zip', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/data.ttl.zip'),
+      iana('text/turtle'),
+    );
+    distribution.compressFormat = iana('application/zip');
+
+    expect(distribution.compressedMimeType).toBe('text/turtle+zip');
+  });
+
+  it('treats application/x-gzip as gzip', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/data.nt.gz'),
+      iana('application/n-triples'),
+    );
+    distribution.compressFormat = iana('application/x-gzip');
+
+    expect(distribution.compressedMimeType).toBe('application/n-triples+gzip');
+  });
+
+  it('is undefined when no compress format is declared', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/data.nq'),
+      iana('application/n-quads'),
+    );
+
+    expect(distribution.compressedMimeType).toBeUndefined();
+  });
+
+  it('is undefined when no media type is declared', () => {
+    const distribution = new Distribution(new URL('http://example.org/data'));
+    distribution.compressFormat = iana('application/gzip');
+
+    expect(distribution.compressedMimeType).toBeUndefined();
+  });
+
+  it('is undefined for an unrecognised compress format', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/data.nq.br'),
+      iana('application/n-quads'),
+    );
+    distribution.compressFormat = iana('application/brotli');
+
+    expect(distribution.compressedMimeType).toBeUndefined();
+  });
+});
+
+describe('Distribution.isSparql', () => {
+  it('is true when conformsTo is the SPARQL protocol', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/sparql'),
+      undefined,
+      new URL(SPARQL_URI),
+    );
+
+    expect(distribution.isSparql()).toBe(true);
+  });
+
+  it('is true for the application/sparql-query media type', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/sparql'),
+      iana('application/sparql-query'),
+    );
+
+    expect(distribution.isSparql()).toBe(true);
+  });
+
+  it('is true for the application/sparql-results+json media type', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/sparql'),
+      iana('application/sparql-results+json'),
+    );
+
+    expect(distribution.isSparql()).toBe(true);
+  });
+
+  it('is false for a plain RDF download', () => {
+    const distribution = new Distribution(
+      new URL('http://example.org/data.nq'),
+      iana('application/n-quads'),
+    );
+
+    expect(distribution.isSparql()).toBe(false);
+  });
+});
+
+describe('Distribution.sparql', () => {
+  it('builds a SPARQL distribution with the protocol and a named graph', () => {
+    const distribution = Distribution.sparql(
+      new URL('http://example.org/sparql'),
+      'http://example.org/graph',
+    );
+
+    expect(distribution.isSparql()).toBe(true);
+    expect(distribution.conformsTo?.toString()).toBe(SPARQL_URI);
+    expect(distribution.namedGraph).toBe('http://example.org/graph');
+  });
+});
+
+describe('rdfFormatToFileExtension', () => {
+  it('maps N-Triples to nt', () => {
+    expect(rdfFormatToFileExtension(RdfFormat['N-Triples'])).toBe('nt');
+  });
+
+  it('maps N-Quads to nq', () => {
+    expect(rdfFormatToFileExtension(RdfFormat['N-Quads'])).toBe('nq');
+  });
+
+  it('maps Turtle to ttl', () => {
+    expect(rdfFormatToFileExtension(RdfFormat.Turtle)).toBe('ttl');
+  });
+
+  it('throws for an unknown format', () => {
+    expect(() =>
+      rdfFormatToFileExtension('application/rdf+xml' as RdfFormat),
+    ).toThrow('Unknown mime type: application/rdf+xml');
+  });
+});

--- a/packages/distribution-probe/src/probe.ts
+++ b/packages/distribution-probe/src/probe.ts
@@ -566,13 +566,15 @@ function isRemoteContextError(error: Error): boolean {
  * Compare the declared media type from the dataset registry against the
  * server's Content-Type header. Adds a warning when they disagree.
  *
- * A compressed distribution is served either as its bare media type (the server
- * decompressed the body) or with the declared compression suffix appended, e.g.
- * `application/n-quads+gzip`. Both are accepted; a different suffix — including
- * the wrong compression format — is a genuine mismatch. The registry strips that
- * suffix into a separate compress format on ingest, so comparing against
- * {@link Distribution.mimeType} alone would false-positive every compressed
- * distribution.
+ * The declared compressed form (e.g. `application/n-quads+gzip`) is the expected
+ * answer for a `+gzip`/`+zip` distribution, since the body is a gzip/zip archive
+ * served as-is. The bare media type (`application/n-quads`) is also accepted as a
+ * lenient fallback — the RDF serialization is the same and only the compression
+ * wrapper is absent — so a server that serves the uncompressed representation is
+ * not flagged. A different compression suffix or a different base serialization is
+ * still a genuine mismatch. The registry strips the suffix into a separate compress
+ * format on ingest, so comparing against {@link Distribution.mimeType} alone would
+ * false-positive every compressed distribution.
  */
 function checkContentTypeMismatch(
   result: DataDumpProbeResult,

--- a/packages/distribution-probe/src/probe.ts
+++ b/packages/distribution-probe/src/probe.ts
@@ -441,13 +441,13 @@ async function probeDataDump(
       responseTimeMs,
       failureReason,
     );
-    checkContentTypeMismatch(result, distribution.mimeType);
+    checkContentTypeMismatch(result, distribution);
     return result;
   }
 
   const responseTimeMs = Math.round(performance.now() - start);
   const result = new DataDumpProbeResult(url, headResponse, responseTimeMs);
-  checkContentTypeMismatch(result, distribution.mimeType);
+  checkContentTypeMismatch(result, distribution);
   return result;
 }
 
@@ -563,21 +563,35 @@ function isRemoteContextError(error: Error): boolean {
 }
 
 /**
- * Compare the declared MIME type from the dataset registry against the
+ * Compare the declared media type from the dataset registry against the
  * server's Content-Type header. Adds a warning when they disagree.
+ *
+ * A compressed distribution is served either as its bare media type (the server
+ * decompressed the body) or with the declared compression suffix appended, e.g.
+ * `application/n-quads+gzip`. Both are accepted; a different suffix — including
+ * the wrong compression format — is a genuine mismatch. The registry strips that
+ * suffix into a separate compress format on ingest, so comparing against
+ * {@link Distribution.mimeType} alone would false-positive every compressed
+ * distribution.
  */
 function checkContentTypeMismatch(
   result: DataDumpProbeResult,
-  declaredMimeType: string | undefined,
+  distribution: Distribution,
 ): void {
-  if (!result.isSuccess() || !declaredMimeType || !result.contentType) return;
+  const { mimeType } = distribution;
+  if (!result.isSuccess() || !mimeType || !result.contentType) return;
 
   const actual = result.contentType.split(';')[0].trim();
   if (compressionMediaTypes.has(actual)) return;
 
-  if (actual !== declaredMimeType) {
+  const acceptable =
+    distribution.compressedMimeType === undefined
+      ? [mimeType]
+      : [mimeType, distribution.compressedMimeType];
+  if (!acceptable.includes(actual)) {
+    const expected = distribution.compressedMimeType ?? mimeType;
     result.warnings.push(
-      `Server Content-Type ${actual} does not match declared media type ${declaredMimeType}`,
+      `Server Content-Type ${actual} does not match declared media type ${expected}`,
     );
   }
 }

--- a/packages/distribution-probe/test/probe.test.ts
+++ b/packages/distribution-probe/test/probe.test.ts
@@ -4,7 +4,7 @@ import {
   DataDumpProbeResult,
   NetworkError,
 } from '../src/index.js';
-import { Distribution } from '@lde/dataset';
+import { Distribution, IANA_MEDIA_TYPE_PREFIX } from '@lde/dataset';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
@@ -1121,6 +1121,90 @@ describe('probe', () => {
 
       expect(result.responseTimeMs).toBeGreaterThanOrEqual(0);
       expect(Number.isInteger(result.responseTimeMs)).toBe(true);
+    });
+  });
+
+  describe('Content-Type mismatch', () => {
+    const gzippedNQuads = () => {
+      const distribution = new Distribution(
+        new URL('http://example.org/data.nq.gz'),
+        IANA_MEDIA_TYPE_PREFIX + 'application/n-quads',
+      );
+      distribution.compressFormat = IANA_MEDIA_TYPE_PREFIX + 'application/gzip';
+      return distribution;
+    };
+
+    const headResponse = (contentType: string) =>
+      vi.mocked(fetch).mockResolvedValue(
+        new Response('', {
+          status: 200,
+          headers: { 'Content-Type': contentType, 'Content-Length': '12345' },
+        }),
+      );
+
+    it('accepts the declared compressed type for a gzipped distribution', async () => {
+      headResponse('application/n-quads+gzip');
+
+      const result = (await probe(gzippedNQuads())) as DataDumpProbeResult;
+
+      expect(result.isSuccess()).toBe(true);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('accepts the bare media type when the server decompressed the body', async () => {
+      headResponse('application/n-quads');
+
+      const result = (await probe(gzippedNQuads())) as DataDumpProbeResult;
+
+      expect(result.isSuccess()).toBe(true);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('flags the wrong compression format on a gzipped distribution', async () => {
+      headResponse('application/n-quads+zip');
+
+      const result = (await probe(gzippedNQuads())) as DataDumpProbeResult;
+
+      expect(result.warnings).toContain(
+        'Server Content-Type application/n-quads+zip does not match declared media type application/n-quads+gzip',
+      );
+    });
+
+    it('flags the wrong base serialization on a gzipped distribution', async () => {
+      headResponse('text/turtle+gzip');
+
+      const result = (await probe(gzippedNQuads())) as DataDumpProbeResult;
+
+      expect(result.warnings).toContain(
+        'Server Content-Type text/turtle+gzip does not match declared media type application/n-quads+gzip',
+      );
+    });
+
+    it('does not warn for an uncompressed distribution served as declared', async () => {
+      headResponse('application/n-quads');
+
+      const distribution = new Distribution(
+        new URL('http://example.org/data.nq'),
+        IANA_MEDIA_TYPE_PREFIX + 'application/n-quads',
+      );
+      const result = (await probe(distribution)) as DataDumpProbeResult;
+
+      expect(result.isSuccess()).toBe(true);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('warns when an uncompressed distribution is served as a different type', async () => {
+      headResponse('text/turtle');
+
+      const distribution = new Distribution(
+        new URL('http://example.org/data.nq'),
+        IANA_MEDIA_TYPE_PREFIX + 'application/n-quads',
+      );
+      const result = (await probe(distribution)) as DataDumpProbeResult;
+
+      expect(result.warnings).toContain(
+        'Server Content-Type text/turtle does not match declared media type application/n-quads',
+      );
     });
   });
 });

--- a/packages/distribution-probe/vite.config.ts
+++ b/packages/distribution-probe/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 99.32,
+          lines: 100,
           functions: 100,
-          branches: 91.5,
-          statements: 98.68,
+          branches: 92.72,
+          statements: 99.35,
         },
       },
     },


### PR DESCRIPTION
## Problem

A dataset register's distribution probe flags a valid gzipped RDF download as serving *“a different format than declared”* (`ContentTypeMismatch`), even when the declared and served Content-Type agree.

A registry typically splits a declared `application/n-quads+gzip` into a base media type (`application/n-quads`) plus a separate compress format (`application/gzip`) on ingest. `checkContentTypeMismatch` then compared the server's full `application/n-quads+gzip` against the bare base `application/n-quads` and always reported a mismatch. The `compressionMediaTypes` guard only short-circuits a *pure* compression type (`application/gzip`), never a `<base>+gzip` structured type.

## Change

- **`@lde/dataset`** — new `Distribution.compressedMimeType` getter: `mimeType` with the compression suffix derived from `compressFormat` appended (`application/gzip`→`+gzip`, `application/zip`→`+zip`), the inverse of the ingest stripping.
- **`@lde/distribution-probe`** — `checkContentTypeMismatch` now takes the `Distribution` and accepts the served Content-Type when it is **either** the bare `mimeType` (the server decompressed the body) **or** the declared `compressedMimeType`. A wrong compression suffix (declared gzip, served `+zip`) or a wrong base serialization is still flagged, so the check validates compression as well as serialization rather than ignoring it.

## Tests

- `@lde/dataset`: full coverage for `compressedMimeType` (gzip / zip / x-gzip / no-compress / no-media-type / unrecognised) plus the rest of `Distribution`.
- `@lde/distribution-probe`: served `+gzip` → pass, bare base → pass, `+zip` → flagged, wrong base → flagged, and uncompressed regressions.

## Note

The consuming registry must also carry `dcat:compressFormat` onto the probed `Distribution` (it was being dropped); that half is a companion PR in `netwerk-digitaal-erfgoed/dataset-register`.
