### PR TITLE
fix: skolemize structural nodes to prevent blank-node collisions in merged graphs

### DIFF
--- a/packages/dataset/src/index.ts
+++ b/packages/dataset/src/index.ts
@@ -1,4 +1,5 @@
 export * from './dataset.js';
 export * from './distribution.js';
 export * from './mediaType.js';
+export * from './skolem.js';
 export * from './validation.js';

--- a/packages/dataset/src/skolem.ts
+++ b/packages/dataset/src/skolem.ts
@@ -1,0 +1,34 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Mint a deterministic IRI for an otherwise-anonymous structural node — a PROV
+ * `Activity`/`Usage`, a DQV measurement, a `void:Linkset`, a `void:subset` or a
+ * `void:*Partition` — by extending a `base` IRI that is already unique within
+ * the dataset's graph (typically the dataset IRI or one of its subsets) with
+ * `-`-joined `suffixes`.
+ *
+ * Use this instead of a blank node for any such node. A dataset's graph is
+ * assembled from the output of several independent pipeline stages, and
+ * blank-node labels are not preserved across separately serialised documents:
+ * two stages' `_:b0` collapse into one node when the documents are merged into
+ * one graph, silently fusing unrelated provenance, measurements and linksets
+ * (see dataset-knowledge-graph issue #352). IRIs are never relabelled, so
+ * deriving every structural node from a unique base keeps distinct nodes
+ * distinct across stages and makes a re-run idempotent rather than additive —
+ * and lets a later stage address (and extend) a subset or partition another
+ * stage emitted.
+ *
+ * Pass opaque, possibly non-IRI-safe `suffixes` (e.g. a URL) through
+ * {@link hashSuffix} first.
+ */
+export function skolemIri(base: string, ...suffixes: string[]): string {
+  return [base, ...suffixes].join('-');
+}
+
+/**
+ * An md5 hex digest, for embedding an opaque value (e.g. a URL) as a stable,
+ * IRI-safe segment in a {@link skolemIri}.
+ */
+export function hashSuffix(value: string): string {
+  return createHash('md5').update(value).digest('hex');
+}

--- a/packages/dataset/test/skolem.test.ts
+++ b/packages/dataset/test/skolem.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { hashSuffix, skolemIri } from '../src/skolem.js';
+
+describe('skolemIri', () => {
+  it('extends the base with hyphen-joined suffixes', () => {
+    expect(
+      skolemIri('https://example.org/dataset/1#subset-abc', 'activity'),
+    ).toBe('https://example.org/dataset/1#subset-abc-activity');
+    expect(
+      skolemIri(
+        'https://example.org/dataset/1#subset-abc',
+        'measurement',
+        'sampled',
+      ),
+    ).toBe('https://example.org/dataset/1#subset-abc-measurement-sampled');
+  });
+
+  it('is deterministic — same inputs yield the same IRI', () => {
+    const base = 'https://example.org/dataset/1#subset-abc';
+    expect(skolemIri(base, 'usage', hashSuffix('http://x/1'))).toBe(
+      skolemIri(base, 'usage', hashSuffix('http://x/1')),
+    );
+  });
+
+  it('keeps distinct bases and suffixes distinct (no collision)', () => {
+    const a = skolemIri(
+      'https://example.org/d1#subset',
+      'usage',
+      hashSuffix('http://x/1'),
+    );
+    const differentBase = skolemIri(
+      'https://example.org/d2#subset',
+      'usage',
+      hashSuffix('http://x/1'),
+    );
+    const differentSuffix = skolemIri(
+      'https://example.org/d1#subset',
+      'usage',
+      hashSuffix('http://x/2'),
+    );
+    expect(a).not.toBe(differentBase);
+    expect(a).not.toBe(differentSuffix);
+  });
+});
+
+describe('hashSuffix', () => {
+  it('is a deterministic md5 hex digest', () => {
+    expect(hashSuffix('http://example.org/id/1')).toBe(
+      hashSuffix('http://example.org/id/1'),
+    );
+    expect(hashSuffix('http://example.org/id/1')).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('maps distinct values to distinct digests', () => {
+    expect(hashSuffix('http://example.org/id/1')).not.toBe(
+      hashSuffix('http://example.org/id/2'),
+    );
+  });
+});

--- a/packages/pipeline-void/src/uriSpaceTransform.ts
+++ b/packages/pipeline-void/src/uriSpaceTransform.ts
@@ -1,8 +1,9 @@
 import type { ExecutorContext, QuadTransform } from '@lde/pipeline';
+import { hashSuffix, skolemIri } from '@lde/dataset';
 import type { Quad } from '@rdfjs/types';
 import { DataFactory } from 'n3';
 
-const { namedNode, quad, literal, blankNode } = DataFactory;
+const { namedNode, quad, literal } = DataFactory;
 
 const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
 const VOID = 'http://rdfs.org/ns/void#';
@@ -79,10 +80,16 @@ async function* aggregateUriSpaces(
     }
   }
 
-  // Emit aggregated Linkset quads.
+  // Emit aggregated Linkset quads. The linkset is a deterministic IRI keyed on
+  // (dataset, URI space), not a blank node: this transform's output is merged
+  // into the dataset's graph alongside other stages', where blank-node labels
+  // are not unique across stage outputs and would collapse distinct linksets
+  // into one node (see issue #352). The `.well-known/void#linkset-<hash>` shape
+  // mirrors the IRI the object-uri-space.rq CONSTRUCT already mints upstream.
   const datasetNode = namedNode(datasetIri);
-  for (const [, { count, metadata }] of aggregated) {
-    const linksetNode = blankNode();
+  const linksetBase = `${datasetIri}/.well-known/void#linkset`;
+  for (const [uriSpace, { count, metadata }] of aggregated) {
+    const linksetNode = namedNode(skolemIri(linksetBase, hashSuffix(uriSpace)));
     const targetDatasetNode = metadata[0].subject;
 
     yield quad(linksetNode, rdfType, voidLinkset);

--- a/packages/pipeline-void/test/uriSpaceTransform.test.ts
+++ b/packages/pipeline-void/test/uriSpaceTransform.test.ts
@@ -157,7 +157,11 @@ describe('withUriSpaces', () => {
     const quads = await collect(transform(quadStream(input), context));
     const linksetSubject = quads[0].subject;
 
-    // All linkset quads share the same blank node subject.
+    // The linkset is a deterministic IRI (not a blank node), so it cannot
+    // collide with another stage's nodes when merged into the dataset graph.
+    expect(linksetSubject.termType).toBe('NamedNode');
+
+    // All linkset quads share the same linkset subject.
     const linksetQuadsList = quads.filter(
       (q) => q.subject.value === linksetSubject.value,
     );
@@ -187,6 +191,40 @@ describe('withUriSpaces', () => {
         (q) => q.predicate.equals(voidTriples) && q.object.value === '42',
       ),
     ).toBeDefined();
+  });
+
+  it('mints distinct, deterministic linkset IRIs per URI space (issue #352)', async () => {
+    const input = [
+      ...linksetQuads(
+        'http://example.com/.well-known/void#linkset-1',
+        'http://vocab.getty.edu/aat/',
+        42,
+      ),
+      ...linksetQuads(
+        'http://example.com/.well-known/void#linkset-2',
+        'https://sws.geonames.org/123/',
+        5,
+      ),
+    ];
+
+    const run = async () =>
+      (await collect(transform(quadStream(input), context)))
+        .filter(
+          (q) => q.predicate.equals(rdfType) && q.object.equals(voidLinkset),
+        )
+        .map((q) => q.subject);
+
+    const subjects = await run();
+    // Two URI spaces -> two distinct linkset nodes, each an IRI.
+    expect(subjects).toHaveLength(2);
+    expect(subjects.every((s) => s.termType === 'NamedNode')).toBe(true);
+    expect(new Set(subjects.map((s) => s.value)).size).toBe(2);
+
+    // Re-running yields the same IRIs (idempotent across runs).
+    const rerun = await run();
+    expect(rerun.map((s) => s.value).sort()).toEqual(
+      subjects.map((s) => s.value).sort(),
+    );
   });
 
   it('skips incomplete Linksets missing void:triples', async () => {

--- a/packages/pipeline-void/vite.config.ts
+++ b/packages/pipeline-void/vite.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           functions: 96.66,
-          lines: 92.7,
+          lines: 92.78,
           branches: 88.37,
-          statements: 93,
+          statements: 93.06,
         },
       },
     },

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -357,7 +357,7 @@ new Pipeline({
 
 #### `provenancePlugin()`
 
-Appends [PROV-O](https://www.w3.org/TR/prov-o/) provenance quads (`prov:Entity`, `prov:Activity`, `prov:startedAtTime`, `prov:endedAtTime`) to every stage’s output.
+Appends [PROV-O](https://www.w3.org/TR/prov-o/) provenance quads (`prov:Entity`, `prov:Activity`, `prov:startedAtTime`, `prov:endedAtTime`) to every stage’s output. The `prov:Activity` is a stable IRI keyed on `(dataset, stage)`, not a blank node, so activities stay distinct – and a re-run stays idempotent – when per-dataset outputs are merged into one graph (blank-node labels are not unique across separately serialised documents and would fuse unrelated activities).
 
 #### `schemaOrgNormalizationPlugin(options?)`
 

--- a/packages/pipeline/src/distribution/report.ts
+++ b/packages/pipeline/src/distribution/report.ts
@@ -1,4 +1,5 @@
 import type { ImportFailed } from '@lde/sparql-importer';
+import { hashSuffix, skolemIri } from '@lde/dataset';
 import { DataFactory, type Quad } from 'n3';
 import {
   NetworkError,
@@ -7,7 +8,7 @@ import {
   type ProbeResultType,
 } from '@lde/distribution-probe';
 
-const { quad, namedNode, blankNode, literal } = DataFactory;
+const { quad, namedNode, literal } = DataFactory;
 
 const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
 const SCHEMA = 'https://schema.org/';
@@ -30,11 +31,17 @@ export async function* probeResultsToQuads(
   datasetIri: string,
   importResult?: ImportFailed,
 ): AsyncIterable<Quad> {
-  // Track blank nodes per URL so import errors can reference the right action.
-  const actionsByUrl = new Map<string, ReturnType<typeof blankNode>>();
+  // Track each action node per URL so import errors can reference the right
+  // action. Each action is a deterministic IRI keyed on (dataset, URL), not a
+  // blank node: this output is merged with other datasets' into one cat-built
+  // graph where blank-node labels are not unique across documents and would
+  // fuse unrelated actions into one node (see issue #474). The
+  // `.well-known/schema#action-<hash>` shape mirrors the linkset skolem.
+  const actionBase = `${datasetIri}/.well-known/schema#action`;
+  const actionsByUrl = new Map<string, ReturnType<typeof namedNode>>();
 
   for (const result of probeResults) {
-    const action = blankNode();
+    const action = namedNode(skolemIri(actionBase, hashSuffix(result.url)));
     actionsByUrl.set(result.url, action);
 
     yield quad(action, namedNode(`${RDF}type`), namedNode(`${SCHEMA}Action`));
@@ -75,7 +82,7 @@ export async function* probeResultsToQuads(
 }
 
 function* successQuads(
-  action: ReturnType<typeof blankNode>,
+  action: ReturnType<typeof namedNode>,
   result: SparqlProbeResult | DataDumpProbeResult,
   datasetIri: string,
 ): Iterable<Quad> {

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -34,6 +34,19 @@ import {
   type TimeoutPolicy,
 } from './sparql/timeoutPolicy.js';
 
+/**
+ * Context handed to a {@link PipelinePlugin.beforeStageWrite} transform: the
+ * `dataset` whose merged output is being written and the `stage` that produced
+ * it. The stage identity lets a transform mint stable IRIs keyed on
+ * `(dataset, stage)` instead of blank nodes, which would fuse across stages and
+ * datasets once the per-dataset outputs are merged into one graph (see issue
+ * #474).
+ */
+export interface BeforeStageWriteContext {
+  dataset: Dataset;
+  stage: string;
+}
+
 /** Plugin that hooks into pipeline lifecycle events. */
 export interface PipelinePlugin {
   name: string;
@@ -43,7 +56,7 @@ export interface PipelinePlugin {
    * – provenance, namespace normalisation – that apply regardless of which
    * executor produced a quad.
    */
-  beforeStageWrite?: QuadTransform<{ dataset: Dataset }>;
+  beforeStageWrite?: QuadTransform<BeforeStageWriteContext>;
 }
 
 export interface PipelineOptions {
@@ -153,16 +166,18 @@ class FanOutWriter implements Writer {
 class TransformWriter implements Writer {
   constructor(
     private readonly inner: Writer,
-    private readonly transform: QuadTransform<{ dataset: Dataset }>,
+    private readonly transform: QuadTransform<BeforeStageWriteContext>,
+    private readonly stage: string,
   ) {}
 
   async write(dataset: Dataset, quads: AsyncIterable<Quad>): Promise<void> {
-    await this.inner.write(dataset, this.transform(quads, { dataset }));
+    await this.inner.write(
+      dataset,
+      this.transform(quads, { dataset, stage: this.stage }),
+    );
   }
-
-  async flush(dataset: Dataset): Promise<void> {
-    await this.inner.flush?.(dataset);
-  }
+  // No flush(): the Pipeline flushes the underlying user writer directly, once
+  // per dataset after all stages — a TransformWriter only wraps a single write.
 }
 
 export class Pipeline {
@@ -170,6 +185,7 @@ export class Pipeline {
   private readonly datasetSelector: DatasetSelector;
   private readonly stages: Stage[];
   private readonly writer: Writer;
+  private readonly beforeStageWrite?: QuadTransform<BeforeStageWriteContext>;
   private readonly distributionResolver: DistributionResolver;
   private readonly chaining?: PipelineOptions['chaining'];
   private readonly reporter?: ProgressReporter;
@@ -195,20 +211,21 @@ export class Pipeline {
     this.datasetSelector = options.datasetSelector;
     this.stages = options.stages;
 
-    let writer: Writer = Array.isArray(options.writers)
+    // The user writer is the post-merge target; the plugins' beforeStageWrite
+    // transforms wrap it per stage (see stageWriter) so each carries the stage
+    // identity it needs to mint stable, non-fusing IRIs.
+    this.writer = Array.isArray(options.writers)
       ? new FanOutWriter(options.writers)
       : options.writers;
 
     const transforms = options.plugins
       ?.map((p) => p.beforeStageWrite)
-      .filter((t): t is QuadTransform<{ dataset: Dataset }> => t !== undefined);
-    if (transforms?.length) {
-      const composed: QuadTransform<{ dataset: Dataset }> = (quads, context) =>
-        transforms.reduce((q, fn) => fn(q, context), quads);
-      writer = new TransformWriter(writer, composed);
-    }
-
-    this.writer = writer;
+      .filter(
+        (t): t is QuadTransform<BeforeStageWriteContext> => t !== undefined,
+      );
+    this.beforeStageWrite = transforms?.length
+      ? (quads, context) => transforms.reduce((q, fn) => fn(q, context), quads)
+      : undefined;
     this.distributionResolver =
       options.distributionResolver ?? new SparqlDistributionResolver();
     this.chaining = options.chaining;
@@ -344,7 +361,7 @@ export class Pipeline {
               dataset,
               resolved.distribution,
               stage,
-              this.writer,
+              this.stageWriter(stage.name),
               timeout,
             );
           }
@@ -413,6 +430,18 @@ export class Pipeline {
       yield stage;
       if (stage.stages.length > 0) yield* this.collectStages(stage.stages);
     }
+  }
+
+  /**
+   * The writer a stage's merged output is written through: the user writer
+   * wrapped with the plugins' {@link PipelinePlugin.beforeStageWrite}
+   * transforms, carrying this `stage`'s identity so a transform can mint stable
+   * per-`(dataset, stage)` IRIs rather than blank nodes.
+   */
+  private stageWriter(stage: string): Writer {
+    return this.beforeStageWrite
+      ? new TransformWriter(this.writer, this.beforeStageWrite, stage)
+      : this.writer;
   }
 
   /**
@@ -535,8 +564,12 @@ export class Pipeline {
         }
       }
 
-      // 3. Concatenate all output files → user writer.
-      await this.writer.write(dataset, this.readFiles(outputFiles));
+      // 3. Concatenate all output files → user writer, applying the plugins'
+      // beforeStageWrite transforms once for the chain under the parent stage.
+      await this.stageWriter(stage.name).write(
+        dataset,
+        this.readFiles(outputFiles),
+      );
     } finally {
       await stageOutputResolver.cleanup();
     }

--- a/packages/pipeline/src/plugin/provenance.ts
+++ b/packages/pipeline/src/plugin/provenance.ts
@@ -1,10 +1,10 @@
 import type { QuadTransform } from '../stage.js';
-import type { PipelinePlugin } from '../pipeline.js';
-import type { Dataset } from '@lde/dataset';
+import type { BeforeStageWriteContext, PipelinePlugin } from '../pipeline.js';
+import { hashSuffix, skolemIri } from '@lde/dataset';
 import type { Quad } from '@rdfjs/types';
 import { DataFactory } from 'n3';
 
-const { namedNode, literal, blankNode, quad } = DataFactory;
+const { namedNode, literal, quad } = DataFactory;
 
 const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
 const PROV_ENTITY = namedNode('http://www.w3.org/ns/prov#Entity');
@@ -19,10 +19,10 @@ const PROV_ENDED_AT_TIME = namedNode('http://www.w3.org/ns/prov#endedAtTime');
 const XSD_DATE_TIME = namedNode('http://www.w3.org/2001/XMLSchema#dateTime');
 
 /** QuadTransform that appends PROV-O provenance quads. */
-export const provenanceTransform: QuadTransform<{ dataset: Dataset }> = (
+export const provenanceTransform: QuadTransform<BeforeStageWriteContext> = (
   quads,
-  { dataset },
-) => appendProvenanceQuads(quads, dataset.iri.toString(), new Date());
+  { dataset, stage },
+) => appendProvenanceQuads(quads, dataset.iri.toString(), stage, new Date());
 
 /** Pipeline plugin that appends PROV-O provenance to every stage's output. */
 export function provenancePlugin(): PipelinePlugin {
@@ -35,6 +35,7 @@ export function provenancePlugin(): PipelinePlugin {
 async function* appendProvenanceQuads(
   quads: AsyncIterable<Quad>,
   iri: string,
+  stage: string,
   startedAt: Date,
 ): AsyncIterable<Quad> {
   for await (const q of quads) {
@@ -43,7 +44,16 @@ async function* appendProvenanceQuads(
 
   const endedAt = new Date();
   const subject = namedNode(iri);
-  const activity = blankNode();
+  // Skolemise the activity to a stable IRI keyed on (dataset, stage) instead of
+  // a blank node. Per-dataset outputs are merged into one graph (the DKG index
+  // cats every dataset's file together), where blank-node labels are not unique
+  // across documents and would fuse unrelated activities into one node — one
+  // prov:Activity wrongly wasGeneratedBy several datasets (see issue #474).
+  // The IRI also makes a re-run idempotent: same (dataset, stage) → same node.
+  // The `.well-known/prov#activity-<hash>` shape mirrors the linkset skolem.
+  const activity = namedNode(
+    skolemIri(`${iri}/.well-known/prov#activity`, hashSuffix(stage)),
+  );
 
   yield quad(subject, RDF_TYPE, PROV_ENTITY);
   yield quad(subject, PROV_WAS_GENERATED_BY, activity);

--- a/packages/pipeline/test/distribution/report.test.ts
+++ b/packages/pipeline/test/distribution/report.test.ts
@@ -177,7 +177,7 @@ describe('probeResultsToQuads', () => {
     expect(actions).toHaveLength(2);
   });
 
-  it('attaches import error to the correct action blank node', async () => {
+  it('attaches import error to the correct action node', async () => {
     const distribution = new Distribution(
       new URL('http://example.org/data.nt'),
       'application/n-triples',
@@ -200,7 +200,7 @@ describe('probeResultsToQuads', () => {
       ),
     );
 
-    // The import error should be on the same blank node as the action target
+    // The import error should be on the same action node as the action target
     const targets = store.getQuads(
       null,
       `${SCHEMA}target`,
@@ -236,6 +236,39 @@ describe('probeResultsToQuads', () => {
     // Should not emit void:dataDump since it's a failure.
     const dumps = store.getQuads(null, `${VOID}dataDump`, null, null);
     expect(dumps).toHaveLength(0);
+  });
+
+  it('mints stable, distinct action IRIs per URL, not blank nodes (issue #474)', async () => {
+    const results = [
+      new SparqlProbeResult(
+        'http://example.org/sparql',
+        sparqlResponse(),
+        0,
+        'application/sparql-results+json',
+      ),
+      new NetworkError('http://example.org/other', 'timeout', 0),
+    ];
+
+    const actionSubjects = async () => {
+      const store = await collect(
+        probeResultsToQuads(results, 'http://example.org/dataset'),
+      );
+      return store
+        .getQuads(null, `${RDF}type`, `${SCHEMA}Action`, null)
+        .map((q) => q.subject);
+    };
+
+    const subjects = await actionSubjects();
+    // Two URLs -> two distinct action nodes, each an IRI.
+    expect(subjects).toHaveLength(2);
+    expect(subjects.every((s) => s.termType === 'NamedNode')).toBe(true);
+    expect(new Set(subjects.map((s) => s.value)).size).toBe(2);
+
+    // Re-running yields the same IRIs (idempotent across runs).
+    const rerun = await actionSubjects();
+    expect(rerun.map((s) => s.value).sort()).toEqual(
+      subjects.map((s) => s.value).sort(),
+    );
   });
 
   it('yields nothing for empty probe results', async () => {

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -470,6 +470,34 @@ describe('Pipeline', () => {
       expect(stageOutputResolver.cleanup).toHaveBeenCalledTimes(1);
     });
 
+    it('reports a chained stage that returns NotSupported and skips the concat', async () => {
+      const stageOutputResolver = makeStageOutputResolver();
+      const child = makeStage('child');
+      const parent = makeStage(
+        'parent',
+        new NotSupported('No items selected'),
+        [child],
+      );
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [parent],
+        writers: writer,
+        distributionResolver: makeResolver(makeResolvedDistribution()),
+        chaining: {
+          stageOutputResolver,
+          outputDir: '/tmp/test',
+        },
+      });
+
+      // The chain throws internally; the pipeline catches it, so run resolves.
+      await pipeline.run();
+
+      // The concat to the user writer never runs, and resources are cleaned up.
+      expect(writer.write).not.toHaveBeenCalled();
+      expect(stageOutputResolver.cleanup).toHaveBeenCalledTimes(1);
+    });
+
     it('validates chaining is required for sub-stages', () => {
       const child = makeStage('child');
       const parent = makeStage('parent', undefined, [child]);
@@ -1091,6 +1119,33 @@ describe('Pipeline', () => {
 
       expect(cw.quads).toHaveLength(1);
       expect(cw.quads[0].subject.value).toBe('http://example.org/my-dataset');
+    });
+
+    it('passes the stage name to beforeStageWrite transform', async () => {
+      const seenStages: string[] = [];
+
+      const plugin: PipelinePlugin = {
+        name: 'stage-aware',
+        beforeStageWrite: async function* (quads, { stage }) {
+          seenStages.push(stage);
+          yield* quads;
+        },
+      };
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(makeDataset()),
+        stages: [
+          new Stage({ name: 'first', executors: realExecutor([]) }),
+          new Stage({ name: 'second', executors: realExecutor([]) }),
+        ],
+        writers: collectingWriter(),
+        plugins: [plugin],
+        distributionResolver: makeResolver(makeResolvedDistribution()),
+      });
+
+      await pipeline.run();
+
+      expect(seenStages).toEqual(['first', 'second']);
     });
   });
 

--- a/packages/pipeline/test/plugin/provenance.test.ts
+++ b/packages/pipeline/test/plugin/provenance.test.ts
@@ -45,7 +45,7 @@ describe('provenanceTransform', () => {
 
   it('adds prov:Entity type', async () => {
     const quads = await collect(
-      provenanceTransform(emptyStream(), { dataset }),
+      provenanceTransform(emptyStream(), { dataset, stage: 'describe' }),
     );
 
     const entityQuads = quads.filter(
@@ -59,7 +59,7 @@ describe('provenanceTransform', () => {
 
   it('adds prov:wasGeneratedBy linking to an activity', async () => {
     const quads = await collect(
-      provenanceTransform(emptyStream(), { dataset }),
+      provenanceTransform(emptyStream(), { dataset, stage: 'describe' }),
     );
 
     const generatedByQuads = quads.filter(
@@ -68,12 +68,12 @@ describe('provenanceTransform', () => {
         q.predicate.value === `${PROV}wasGeneratedBy`,
     );
     expect(generatedByQuads).toHaveLength(1);
-    expect(generatedByQuads[0].object.termType).toBe('BlankNode');
+    expect(generatedByQuads[0].object.termType).toBe('NamedNode');
   });
 
   it('adds prov:Activity type to the activity', async () => {
     const quads = await collect(
-      provenanceTransform(emptyStream(), { dataset }),
+      provenanceTransform(emptyStream(), { dataset, stage: 'describe' }),
     );
 
     const activityQuads = quads.filter(
@@ -81,12 +81,12 @@ describe('provenanceTransform', () => {
         q.predicate.value === RDF_TYPE && q.object.value === `${PROV}Activity`,
     );
     expect(activityQuads).toHaveLength(1);
-    expect(activityQuads[0].subject.termType).toBe('BlankNode');
+    expect(activityQuads[0].subject.termType).toBe('NamedNode');
   });
 
   it('adds prov:startedAtTime as xsd:dateTime', async () => {
     const quads = await collect(
-      provenanceTransform(emptyStream(), { dataset }),
+      provenanceTransform(emptyStream(), { dataset, stage: 'describe' }),
     );
 
     const startQuads = quads.filter(
@@ -106,7 +106,7 @@ describe('provenanceTransform', () => {
     // Advance time before consuming the stream (triggers endedAt).
     vi.setSystemTime(new Date('2024-01-15T10:05:00.000Z'));
     const quads = await collect(
-      provenanceTransform(emptyStream(), { dataset }),
+      provenanceTransform(emptyStream(), { dataset, stage: 'describe' }),
     );
 
     const endQuads = quads.filter(
@@ -129,7 +129,10 @@ describe('provenanceTransform', () => {
     );
 
     const quads = await collect(
-      provenanceTransform(quadStream([existing]), { dataset }),
+      provenanceTransform(quadStream([existing]), {
+        dataset,
+        stage: 'describe',
+      }),
     );
 
     const existingQuads = quads.filter(
@@ -138,6 +141,48 @@ describe('provenanceTransform', () => {
     expect(existingQuads).toHaveLength(1);
     // 1 existing + 5 provenance triples
     expect(quads).toHaveLength(6);
+  });
+
+  it('mints the activity as an IRI, not a blank node (issue #474)', async () => {
+    const quads = await collect(
+      provenanceTransform(emptyStream(), { dataset, stage: 'describe' }),
+    );
+
+    const activitySubject = quads.find(
+      (q) =>
+        q.predicate.value === RDF_TYPE && q.object.value === `${PROV}Activity`,
+    )!.subject;
+    expect(activitySubject.termType).toBe('NamedNode');
+  });
+
+  it('mints a stable activity IRI across runs (idempotent)', async () => {
+    const activityFor = async () =>
+      (
+        await collect(
+          provenanceTransform(emptyStream(), { dataset, stage: 'describe' }),
+        )
+      ).find(
+        (q) =>
+          q.predicate.value === RDF_TYPE &&
+          q.object.value === `${PROV}Activity`,
+      )!.subject.value;
+
+    expect(await activityFor()).toBe(await activityFor());
+  });
+
+  it('mints distinct activity IRIs per stage', async () => {
+    const activityFor = async (stage: string) =>
+      (
+        await collect(provenanceTransform(emptyStream(), { dataset, stage }))
+      ).find(
+        (q) =>
+          q.predicate.value === RDF_TYPE &&
+          q.object.value === `${PROV}Activity`,
+      )!.subject.value;
+
+    expect(await activityFor('describe')).not.toBe(
+      await activityFor('measure'),
+    );
   });
 });
 

--- a/packages/pipeline/test/plugin/schemaOrgNormalization.test.ts
+++ b/packages/pipeline/test/plugin/schemaOrgNormalization.test.ts
@@ -146,6 +146,7 @@ describe('schemaOrgNormalizationPlugin', () => {
     const quads = await collect(
       schemaOrgNormalizationPlugin().beforeStageWrite!(quadStream([input]), {
         dataset,
+        stage: 'describe',
       }),
     );
 
@@ -162,7 +163,7 @@ describe('schemaOrgNormalizationPlugin', () => {
     const quads = await collect(
       schemaOrgNormalizationPlugin({ reverse: true }).beforeStageWrite!(
         quadStream([input]),
-        { dataset },
+        { dataset, stage: 'describe' },
       ),
     );
 
@@ -179,7 +180,7 @@ describe('schemaOrgNormalizationPlugin', () => {
     const quads = await collect(
       schemaOrgNormalizationPlugin({ reverse: true }).beforeStageWrite!(
         quadStream([input]),
-        { dataset },
+        { dataset, stage: 'describe' },
       ),
     );
 

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 95.55,
-          lines: 95.17,
-          branches: 89.87,
-          statements: 94.64,
+          lines: 95.28,
+          branches: 90.12,
+          statements: 94.74,
         },
       },
     },


### PR DESCRIPTION
## Why

Each dataset’s graph in the pipeline is assembled from the output of several independent stages, and per-dataset graphs are in turn merged into one index downstream (the Dataset Knowledge Graph rebuilds its QLever index over cat-merged `.nq` files). Blank-node labels are **not** preserved across separately serialised documents, so when those documents are merged into one graph, two stages (or two datasets) that each emitted `_:b0` collapse into a single node — silently fusing unrelated data.

This surfaced as malformed RDF in the Dataset Knowledge Graph (see netwerk-digitaal-erfgoed/dataset-knowledge-graph#352): a single `void:Linkset` blank node ended up carrying several `void:objectsTarget` and `void:triples` values (two distinct linksets fused into one). The same mechanism fuses the pipeline’s minted PROV and report blank nodes across datasets in the cat-built index (ldelements/lde#474): one `prov:Activity` ends up `prov:wasGeneratedBy` several unrelated datasets.

## What

- **`@lde/dataset`**: add `skolemIri(base, ...suffixes)` and `hashSuffix(value)` — string utilities that mint a deterministic IRI for an otherwise-anonymous structural node (PROV activity/usage, DQV measurement, `void:Linkset`, `void:subset`, partitions) by extending a base IRI that is already unique within the dataset. IRIs are never relabelled, so distinct nodes stay distinct across stages and a re-run is idempotent. No new dependencies (string-in, string-out, like `assertSafeIri`).
- **`@lde/pipeline-void`**: `uriSpaceTransform` now mints each aggregated `void:Linkset` as a deterministic IRI (`<dataset>/.well-known/void#linkset-<hash>`, mirroring what `object-uri-space.rq` already produces) instead of a fresh blank node.
- **`@lde/pipeline`**: skolemise the remaining minted blank nodes (ldelements/lde#474):
  - `provenancePlugin` now mints the `prov:Activity` as `<dataset>/.well-known/prov#activity-<hash>`, keyed on `(dataset, stage)`, instead of a blank node. The stage identity is threaded into the `beforeStageWrite` plugin context (new `BeforeStageWriteContext`), and the plugin transforms wrap the user writer per stage rather than once at construction.
  - the distribution report mints each `schema:Action` as `<dataset>/.well-known/schema#action-<hash>`, keyed on `(dataset, URL)`, instead of a blank node.

## Tests

- New `skolem.test.ts` for the helper (determinism, no-collision).
- `uriSpaceTransform.test.ts`: asserts the linkset subject is a stable IRI and that distinct URI spaces get distinct, idempotent linkset IRIs.
- `provenance.test.ts` / `report.test.ts`: assert the activity/action subjects are `NamedNode`s, stable across runs, and distinct per `(dataset, stage)` / per URL.
- `pipeline.test.ts`: asserts the stage name is threaded into `beforeStageWrite`, plus a chained-stage `NotSupported` case.
- `nx affected -t lint typecheck test build` passes; coverage thresholds ratcheted up.

## Downstream

`@lde/dataset` and `@lde/pipeline` need a release so the dataset-knowledge-graph fix (which skolemises its PROV nodes via the same helper) can depend on it, and so the served graph stops fusing after a rebuild.

## Fixes

- Fixes ldelements/lde#474
- Refs netwerk-digitaal-erfgoed/dataset-knowledge-graph#352, netwerk-digitaal-erfgoed/dataset-knowledge-graph#354
</content>
