### PR TITLE
feat(pipeline): surface per-distribution RDF-validity verdicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40862,7 +40862,7 @@
     },
     "packages/dataset": {
       "name": "@lde/dataset",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -40870,10 +40870,10 @@
     },
     "packages/dataset-registry-client": {
       "name": "@lde/dataset-registry-client",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "@lde/dataset": "0.7.6",
+        "@lde/dataset": "0.7.7",
         "@traqula/generator-sparql-1-1": "^1.1.4",
         "@traqula/parser-sparql-1-1": "^1.1.4",
         "@traqula/rules-sparql-1-1": "^1.1.0",
@@ -40886,34 +40886,34 @@
     },
     "packages/distribution-downloader": {
       "name": "@lde/distribution-downloader",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
-        "@lde/dataset": "0.7.6",
+        "@lde/dataset": "0.7.7",
         "filenamify-url": "4.0.0",
         "tslib": "^2.3.0"
       }
     },
     "packages/distribution-health": {
       "name": "@lde/distribution-health",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "@lde/distribution-probe": "0.1.9",
-        "@lde/sparql-importer": "0.6.4",
+        "@lde/distribution-probe": "0.1.10",
+        "@lde/sparql-importer": "0.6.5",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@lde/dataset": "0.7.6"
+        "@lde/dataset": "0.7.7"
       }
     },
     "packages/distribution-monitor": {
       "name": "@lde/distribution-monitor",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
-        "@lde/dataset": "0.7.6",
-        "@lde/distribution-probe": "0.1.9",
+        "@lde/dataset": "0.7.7",
+        "@lde/distribution-probe": "0.1.10",
         "c12": "^3.3.4",
         "commander": "^15.0.0",
         "cron": "^4.1.0",
@@ -40940,10 +40940,10 @@
     },
     "packages/distribution-probe": {
       "name": "@lde/distribution-probe",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
-        "@lde/dataset": "0.7.6",
+        "@lde/dataset": "0.7.7",
         "rdf-parse": "^5.0.0",
         "tslib": "^2.3.0"
       }
@@ -42357,13 +42357,14 @@
     },
     "packages/pipeline": {
       "name": "@lde/pipeline",
-      "version": "0.30.13",
+      "version": "0.30.14",
       "license": "MIT",
       "dependencies": {
-        "@lde/dataset": "0.7.6",
-        "@lde/dataset-registry-client": "0.8.2",
-        "@lde/distribution-probe": "0.1.9",
-        "@lde/sparql-importer": "0.6.4",
+        "@lde/dataset": "0.7.7",
+        "@lde/dataset-registry-client": "0.8.3",
+        "@lde/distribution-health": "0.1.1",
+        "@lde/distribution-probe": "0.1.10",
+        "@lde/sparql-importer": "0.6.5",
         "@lde/sparql-server": "0.4.11",
         "@rdfjs/types": "^2.0.1",
         "@traqula/generator-sparql-1-1": "^1.1.4",
@@ -42380,7 +42381,7 @@
     },
     "packages/pipeline-console-reporter": {
       "name": "@lde/pipeline-console-reporter",
-      "version": "0.21.13",
+      "version": "0.21.14",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -42390,8 +42391,8 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@lde/dataset": "0.7.6",
-        "@lde/pipeline": "0.30.13"
+        "@lde/dataset": "0.7.7",
+        "@lde/pipeline": "0.30.14"
       }
     },
     "packages/pipeline-console-reporter/node_modules/ansi-regex": {
@@ -42571,7 +42572,7 @@
     },
     "packages/pipeline-shacl-sampler": {
       "name": "@lde/pipeline-shacl-sampler",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -42580,8 +42581,8 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@lde/dataset": "0.7.6",
-        "@lde/pipeline": "0.30.13"
+        "@lde/dataset": "0.7.7",
+        "@lde/pipeline": "0.30.14"
       }
     },
     "packages/pipeline-shacl-sampler/node_modules/n3": {
@@ -42599,7 +42600,7 @@
     },
     "packages/pipeline-shacl-validator": {
       "name": "@lde/pipeline-shacl-validator",
-      "version": "0.12.13",
+      "version": "0.12.14",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -42612,8 +42613,8 @@
         "n3": "^2.0.3"
       },
       "peerDependencies": {
-        "@lde/dataset": "0.7.6",
-        "@lde/pipeline": "0.30.13"
+        "@lde/dataset": "0.7.7",
+        "@lde/pipeline": "0.30.14"
       }
     },
     "packages/pipeline-shacl-validator/node_modules/n3": {
@@ -42632,7 +42633,7 @@
     },
     "packages/pipeline-void": {
       "name": "@lde/pipeline-void",
-      "version": "0.28.13",
+      "version": "0.28.14",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -42641,8 +42642,8 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@lde/dataset": "0.7.6",
-        "@lde/pipeline": "0.30.13"
+        "@lde/dataset": "0.7.7",
+        "@lde/pipeline": "0.30.14"
       }
     },
     "packages/pipeline-void/node_modules/n3": {
@@ -42699,11 +42700,11 @@
     },
     "packages/sparql-importer": {
       "name": "@lde/sparql-importer",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
-        "@lde/dataset": "0.7.6",
-        "@lde/distribution-downloader": "0.6.4",
+        "@lde/dataset": "0.7.7",
+        "@lde/distribution-downloader": "0.6.5",
         "@lde/task-runner": "0.2.11",
         "tslib": "^2.3.0"
       }
@@ -42721,12 +42722,12 @@
     },
     "packages/sparql-qlever": {
       "name": "@lde/sparql-qlever",
-      "version": "0.14.8",
+      "version": "0.14.9",
       "license": "MIT",
       "dependencies": {
-        "@lde/dataset": "0.7.6",
-        "@lde/distribution-downloader": "0.6.4",
-        "@lde/sparql-importer": "0.6.4",
+        "@lde/dataset": "0.7.7",
+        "@lde/distribution-downloader": "0.6.5",
+        "@lde/sparql-importer": "0.6.5",
         "@lde/sparql-server": "0.4.11",
         "@lde/task-runner": "0.2.11",
         "@lde/task-runner-docker": "0.2.13",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@lde/dataset": "0.7.7",
     "@lde/dataset-registry-client": "0.8.3",
+    "@lde/distribution-health": "0.1.1",
     "@lde/distribution-probe": "0.1.10",
     "@lde/sparql-importer": "0.6.5",
     "@lde/sparql-server": "0.4.11",

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -22,6 +22,11 @@ import {
   SparqlProbeResult,
   type ProbeResultType,
 } from '@lde/distribution-probe';
+import { ImportSuccessful } from '@lde/sparql-importer';
+import {
+  importOutcomeToVerdict,
+  probeResultToVerdict,
+} from '@lde/distribution-health';
 import { NotSupported } from './sparql/executor.js';
 import type { StageOutputResolver } from './stageOutputResolver.js';
 import type {
@@ -267,6 +272,16 @@ export class Pipeline {
           this.reporter?.distributionProbed?.(
             mapProbeResult(distribution, result),
           );
+          // Shallow validity: the probe parse-validates small RDF bodies as a
+          // by-product. Surface that verdict per distribution, judged against
+          // the distribution's own observed fingerprint.
+          const verdict = probeResultToVerdict(
+            result,
+            sourceFingerprint(distribution, result),
+          );
+          if (verdict) {
+            this.reporter?.distributionValidated?.(distribution, verdict);
+          }
         },
       });
     } catch (error) {
@@ -328,6 +343,16 @@ export class Pipeline {
     }
 
     if (resolved instanceof NoDistributionAvailable) {
+      // A failed import is a deep RDF-validity verdict on the distribution
+      // attempted. Surface it per distribution even though the dataset produces
+      // no summary, so an invalid distribution is recorded rather than silently
+      // dropped.
+      if (resolved.importFailed) {
+        this.reporter?.distributionValidated?.(
+          resolved.importFailed.distribution,
+          importOutcomeToVerdict(resolved.importFailed, fingerprint),
+        );
+      }
       // Record the failure so a dataset whose source is unchanged is not
       // re-imported every run; it is retried at the next fingerprint change or
       // version rotation.
@@ -343,6 +368,23 @@ export class Pipeline {
       resolved.importDuration,
       resolved.tripleCount,
     );
+
+    // A completed data-dump import is a deep validity verdict on the imported
+    // distribution (valid, or empty when it yielded no triples). Native SPARQL
+    // endpoints are not imported, so they carry no deep verdict.
+    if (resolved.importedFrom) {
+      this.reporter?.distributionValidated?.(
+        resolved.importedFrom,
+        importOutcomeToVerdict(
+          new ImportSuccessful(
+            resolved.importedFrom,
+            undefined,
+            resolved.tripleCount,
+          ),
+          fingerprint,
+        ),
+      );
+    }
 
     const timeout: TimeoutPolicy = this.timeoutFactory();
     const unsubscribe = timeout.subscribe?.({
@@ -595,6 +637,7 @@ function mapProbeResult(
   distribution: Distribution,
   result: ProbeResultType,
 ): DistributionAnalysisResult {
+  const fingerprint = sourceFingerprint(distribution, result);
   if (result instanceof NetworkError) {
     return {
       distribution,
@@ -602,6 +645,7 @@ function mapProbeResult(
       available: false,
       error: result.message,
       warnings: [],
+      fingerprint,
     };
   }
   return {
@@ -614,5 +658,6 @@ function mapProbeResult(
     statusCode: result.statusCode,
     error: result.failureReason ?? undefined,
     warnings: result.warnings,
+    fingerprint,
   };
 }

--- a/packages/pipeline/src/progressReporter.ts
+++ b/packages/pipeline/src/progressReporter.ts
@@ -1,4 +1,5 @@
 import type { Dataset, Distribution } from '@lde/dataset';
+import type { ValidityVerdict } from '@lde/distribution-health';
 import type { ValidationReport } from './validator.js';
 import type { TimeoutTransitionEvent } from './sparql/timeoutPolicy.js';
 
@@ -9,6 +10,14 @@ export interface DistributionAnalysisResult {
   statusCode?: number;
   error?: string;
   warnings: string[];
+  /**
+   * The source-change fingerprint observed for this distribution, or `null`
+   * when none could be established (e.g. a live SPARQL endpoint). The shared
+   * key against which a validity verdict's `validatedFingerprint` is matched,
+   * so a consumer can record it on the reachability rail. Always populated by
+   * the pipeline; optional so consumers constructing the result need not set it.
+   */
+  fingerprint?: string | null;
 }
 
 export interface ProgressReporter {
@@ -21,6 +30,16 @@ export interface ProgressReporter {
   importStarted?(): void;
   /** Called when importing a distribution fails. */
   importFailed?(distribution: Distribution, error: string): void;
+  /**
+   * Called with the RDF-validity verdict for a distribution the pipeline
+   * attempted, whether valid or invalid, and even when the dataset is
+   * otherwise skipped (no summary produced). The verdict is a plain
+   * TypeScript value; consumers decide how (and whether) to record it as RDF.
+   */
+  distributionValidated?(
+    distribution: Distribution,
+    verdict: ValidityVerdict,
+  ): void;
   distributionSelected?(
     dataset: Dataset,
     distribution: Distribution,

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -3,6 +3,7 @@ import { Pipeline, type PipelinePlugin } from '../src/pipeline.js';
 import { Dataset, Distribution } from '@lde/dataset';
 import { Stage } from '../src/stage.js';
 import { NotSupported } from '../src/sparql/executor.js';
+import { ImportFailed } from '@lde/sparql-importer';
 import {
   ResolvedDistribution,
   NoDistributionAvailable,
@@ -92,6 +93,8 @@ function makeReporter(): RequiredReporter {
       vi.fn<NonNullable<ProgressReporter['distributionProbed']>>(),
     importStarted: vi.fn<NonNullable<ProgressReporter['importStarted']>>(),
     importFailed: vi.fn<NonNullable<ProgressReporter['importFailed']>>(),
+    distributionValidated:
+      vi.fn<NonNullable<ProgressReporter['distributionValidated']>>(),
     distributionSelected:
       vi.fn<NonNullable<ProgressReporter['distributionSelected']>>(),
     stageStart: vi.fn<NonNullable<ProgressReporter['stageStart']>>(),
@@ -702,6 +705,7 @@ describe('Pipeline', () => {
         available: true,
         statusCode: 200,
         warnings: [],
+        fingerprint: sourceFingerprint(sparqlDist, sparqlResult),
       });
       expect(reporter.distributionProbed).toHaveBeenCalledWith({
         distribution: dataDumpDist,
@@ -709,6 +713,7 @@ describe('Pipeline', () => {
         available: false,
         statusCode: 404,
         warnings: [],
+        fingerprint: sourceFingerprint(dataDumpDist, dataDumpResult),
       });
       expect(reporter.distributionProbed).toHaveBeenCalledWith({
         distribution: downDist,
@@ -716,6 +721,7 @@ describe('Pipeline', () => {
         available: false,
         error: 'Connection refused',
         warnings: [],
+        fingerprint: sourceFingerprint(downDist, networkError),
       });
     });
 
@@ -831,6 +837,7 @@ describe('Pipeline', () => {
         available: false,
         error: 'Connection refused',
         warnings: [],
+        fingerprint: sourceFingerprint(downDist, networkError),
       });
       expect(reporter.distributionSelected).not.toHaveBeenCalled();
     });
@@ -1524,6 +1531,166 @@ describe('Pipeline', () => {
         expect.objectContaining({
           sourceFingerprint: currentFingerprint,
           status: 'failed',
+        }),
+      );
+    });
+
+    it('surfaces an invalid deep validity verdict when a distribution fails to import', async () => {
+      const resolver = makeDumpResolver(
+        new NoDistributionAvailable(
+          dataset,
+          'Import failed',
+          [dumpProbe],
+          new ImportFailed(
+            dumpDistribution,
+            'QName not allowed for property: rdf:Description',
+          ),
+        ),
+      );
+      const reporter = makeReporter();
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [makeStage('stage1')],
+        writers: writer,
+        distributionResolver: resolver,
+        reporter,
+        pipelineVersion: 'v1',
+      });
+
+      await pipeline.run();
+
+      expect(reporter.distributionValidated).toHaveBeenCalledWith(
+        dumpDistribution,
+        {
+          valid: false,
+          reason: 'parse-error',
+          message: 'QName not allowed for property: rdf:Description',
+          validatedFingerprint: currentFingerprint,
+          depth: 'deep',
+        },
+      );
+    });
+
+    it('surfaces a valid deep verdict when a distribution imports successfully', async () => {
+      const resolver = makeDumpResolver(); // default: imports dumpDistribution, 100 triples
+      const reporter = makeReporter();
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [makeStage('stage1')],
+        writers: writer,
+        distributionResolver: resolver,
+        reporter,
+        pipelineVersion: 'v1',
+      });
+
+      await pipeline.run();
+
+      expect(reporter.distributionValidated).toHaveBeenCalledWith(
+        dumpDistribution,
+        {
+          valid: true,
+          validatedFingerprint: currentFingerprint,
+          depth: 'deep',
+        },
+      );
+    });
+
+    it('surfaces an empty deep verdict when an import yields no triples', async () => {
+      const resolver = makeDumpResolver(
+        new ResolvedDistribution(
+          sparqlDistribution,
+          [dumpProbe],
+          dumpDistribution,
+          1,
+          0,
+        ),
+      );
+      const reporter = makeReporter();
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [makeStage('stage1')],
+        writers: writer,
+        distributionResolver: resolver,
+        reporter,
+        pipelineVersion: 'v1',
+      });
+
+      await pipeline.run();
+
+      expect(reporter.distributionValidated).toHaveBeenCalledWith(
+        dumpDistribution,
+        {
+          valid: false,
+          reason: 'empty',
+          validatedFingerprint: currentFingerprint,
+          depth: 'deep',
+        },
+      );
+    });
+
+    it('surfaces a shallow verdict from a probe that detected invalid RDF', async () => {
+      const ttl = new Distribution(
+        new URL('http://example.org/probe.ttl'),
+        'text/turtle',
+      );
+      const probeResult = new DataDumpProbeResult(
+        'http://example.org/probe.ttl',
+        new Response('', {
+          status: 200,
+          headers: { 'Content-Type': 'text/turtle', 'Content-Length': '500' },
+        }),
+        0,
+        'Unexpected "." on line 3.',
+      );
+      const reporter = makeReporter();
+      const resolver = makeResolver(makeResolvedDistribution(), [
+        { distribution: ttl, result: probeResult },
+      ]);
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [makeStage('stage1')],
+        writers: writer,
+        distributionResolver: resolver,
+        reporter,
+        pipelineVersion: 'v1',
+      });
+
+      await pipeline.run();
+
+      expect(reporter.distributionValidated).toHaveBeenCalledWith(ttl, {
+        valid: false,
+        reason: 'parse-error',
+        message: 'Unexpected "." on line 3.',
+        validatedFingerprint: sourceFingerprint(ttl, probeResult),
+        depth: 'shallow',
+      });
+    });
+
+    it('records the observed fingerprint on the reachability result', async () => {
+      const reporter = makeReporter();
+      const resolver = makeResolver(makeResolvedDistribution(), [
+        { distribution: dumpDistribution, result: dumpProbe },
+      ]);
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [makeStage('stage1')],
+        writers: writer,
+        distributionResolver: resolver,
+        reporter,
+        pipelineVersion: 'v1',
+      });
+
+      await pipeline.run();
+
+      expect(reporter.distributionProbed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          distribution: dumpDistribution,
+          fingerprint: currentFingerprint,
         }),
       );
     });

--- a/packages/pipeline/tsconfig.lib.json
+++ b/packages/pipeline/tsconfig.lib.json
@@ -19,6 +19,9 @@
       "path": "../sparql-importer/tsconfig.lib.json"
     },
     {
+      "path": "../distribution-health/tsconfig.lib.json"
+    },
+    {
       "path": "../distribution-probe/tsconfig.lib.json"
     },
     {

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 95.65,
-          lines: 95.36,
-          branches: 90.23,
-          statements: 94.83,
+          lines: 95.4,
+          branches: 90.74,
+          statements: 94.87,
         },
       },
     },


### PR DESCRIPTION
Closes #469. Part of the distribution-health feature: netwerk-digitaal-erfgoed/dataset-register#2103.

## What

Wires `@lde/distribution-health` into `@lde/pipeline` so every distribution the pipeline touches gets an RDF-**validity** verdict, surfaced as a plain TypeScript value through a new reporter callback. The pipeline emits **no RDF and coins no vocabulary** — consumers map the verdict to their own RDF (the “RDF emission & vocabulary boundary” decision in #2103).

New surface:

```ts
ProgressReporter.distributionValidated?(distribution: Distribution, verdict: ValidityVerdict): void
```

## Behaviour

- **Deep verdict** from the import outcome:
  - import **failure** → `parse-error`, surfaced **even when the dataset is then skipped** (the previously-silent drop that motivated #2103);
  - import **success** → `valid`, or `empty` when it yielded no triples.
  - Guarded on an actual data-dump import, so native SPARQL endpoints (not imported) carry no deep verdict.
- **Shallow verdict** from the probe's existing body validation, per probed distribution that yields a validity signal.
- Each verdict carries the distribution's **observed source fingerprint**; the fingerprint is also added to the reachability result (`DistributionAnalysisResult.fingerprint`) so it is the **shared key** across the reachability and validity rails.

## Tests

311 pipeline tests pass (5 new, behaviour-asserted through the reporter): deep invalid / valid / empty, shallow invalid, and the reachability fingerprint. Lint + typecheck clean.

## Notes

- The success path reconstructs an `ImportSuccessful` to feed the shared mapper. A possible later cleanup is to compute the verdict where the real import outcomes live (`importResolver`) and thread the fingerprint in; left as-is for now since it's localised.
- Vocabulary/RDF stays out of LDE entirely (returns TS); the `def.nde.nl` mapping lands in the consumers (epic tasks 4 & 5).
