### PR TITLE
feat(pipeline): blank-node guard + regression assertions for cat-built indexes

### DIFF
--- a/packages/pipeline-void/test/uriSpaceTransform.test.ts
+++ b/packages/pipeline-void/test/uriSpaceTransform.test.ts
@@ -1,6 +1,6 @@
 import { withUriSpaces } from '../src/index.js';
 import { Dataset, Distribution } from '@lde/dataset';
-import type { ExecutorContext } from '@lde/pipeline';
+import { assertNoBlankNodes, type ExecutorContext } from '@lde/pipeline';
 import { describe, it, expect } from 'vitest';
 import { DataFactory } from 'n3';
 import type { Quad } from '@rdfjs/types';
@@ -191,6 +191,15 @@ describe('withUriSpaces', () => {
         (q) => q.predicate.equals(voidTriples) && q.object.value === '42',
       ),
     ).toBeDefined();
+  });
+
+  it('emits no blank nodes (they fuse across datasets in a cat-built index, #352)', async () => {
+    const input = linksetQuads(
+      'http://example.com/.well-known/void#linkset-1',
+      'http://vocab.getty.edu/aat/',
+      42,
+    );
+    assertNoBlankNodes(await collect(transform(quadStream(input), context)));
   });
 
   it('mints distinct, deterministic linkset IRIs per URI space (issue #352)', async () => {

--- a/packages/pipeline/src/guard/blankNodes.ts
+++ b/packages/pipeline/src/guard/blankNodes.ts
@@ -1,0 +1,76 @@
+import type { Quad } from '@rdfjs/types';
+import type { QuadTransform } from '../stage.js';
+
+/**
+ * Why this guard exists.
+ *
+ * A file-based served store (e.g. the Dataset Knowledge Graph) rebuilds its
+ * index by concatenating every per-dataset n-quads file and parsing the
+ * concatenation as ONE RDF document (`qlever index` over
+ * `find … -exec cat {} +`). Blank-node labels are only document-scoped, and the
+ * pipeline emits deterministic labels (n3 `DataFactory.blankNode()` → `n3-N`,
+ * the counter resets per dataset/run), so the same label recurs across files and
+ * the indexer fuses those nodes into one — merging unrelated provenance,
+ * measurements and linksets across datasets and runs. Named nodes never fuse.
+ *
+ * The invariant for any quads the pipeline writes into such a store is therefore:
+ * NO blank nodes. Mint stable (skolem) IRIs instead — see `skolemIri` in
+ * `@lde/dataset`. These helpers make that invariant testable and enforceable.
+ *
+ * See ldelements/lde#474 and netwerk-digitaal-erfgoed/dataset-knowledge-graph#352.
+ */
+
+/**
+ * The distinct blank-node labels appearing in subject, object, or graph position
+ * across `quads`. Empty when the quads are blank-node-free.
+ */
+export function blankNodes(quads: Iterable<Quad>): string[] {
+  const offenders = new Set<string>();
+  for (const quad of quads) {
+    for (const term of [quad.subject, quad.object, quad.graph]) {
+      if (term.termType === 'BlankNode') {
+        offenders.add(term.value);
+      }
+    }
+  }
+  return [...offenders];
+}
+
+/**
+ * Throw if any quad carries a blank node. Use in producer tests to lock in the
+ * no-blank-nodes invariant (see module docs).
+ */
+export function assertNoBlankNodes(quads: Iterable<Quad>): void {
+  const offenders = blankNodes(quads);
+  if (offenders.length > 0) {
+    throw new Error(
+      `Output contains ${offenders.length} blank node(s), which fuse across ` +
+        `datasets when a file-based store cat-indexes per-dataset files. ` +
+        `Mint skolem IRIs instead (see skolemIri in @lde/dataset; ldelements/lde#474). ` +
+        `First: ${offenders.slice(0, 10).join(', ')}`,
+    );
+  }
+}
+
+/**
+ * A {@link QuadTransform} that passes quads through unchanged but throws on the
+ * first blank node it sees. Insert it just before the writer to turn the
+ * no-blank-nodes invariant into a hard pipeline failure (e.g. in a CI/staging
+ * run) rather than a per-test opt-in.
+ */
+export function failOnBlankNodes<Context>(): QuadTransform<Context> {
+  return async function* (quads) {
+    for await (const quad of quads) {
+      for (const term of [quad.subject, quad.object, quad.graph]) {
+        if (term.termType === 'BlankNode') {
+          throw new Error(
+            `Blank node reached the writer (${term.value}); it would fuse ` +
+              `across datasets in a cat-built index. Mint a skolem IRI instead ` +
+              `(ldelements/lde#474): ${quad.subject.value} ${quad.predicate.value} …`,
+          );
+        }
+      }
+      yield quad;
+    }
+  };
+}

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -6,6 +6,7 @@ export * from './progressReporter.js';
 export * from './selector.js';
 export * from './stage.js';
 export * from './stageOutputResolver.js';
+export * from './guard/blankNodes.js';
 export * from './sparql/index.js';
 export * from './distribution/index.js';
 export * from './provenance/index.js';

--- a/packages/pipeline/test/distribution/report.test.ts
+++ b/packages/pipeline/test/distribution/report.test.ts
@@ -8,6 +8,7 @@ import {
   SparqlProbeResult,
   DataDumpProbeResult,
 } from '../../src/distribution/index.js';
+import { assertNoBlankNodes } from '../../src/index.js';
 
 const SCHEMA = 'https://schema.org/';
 const VOID = 'http://rdfs.org/ns/void#';
@@ -44,6 +45,16 @@ describe('probeResultsToQuads', () => {
     const errors = store.getQuads(null, `${SCHEMA}error`, null, null);
     expect(errors).toHaveLength(1);
     expect(errors[0].object.value).toBe('ECONNREFUSED');
+  });
+
+  it('emits no blank nodes (they fuse across datasets in a cat-built index, #474)', async () => {
+    const results = [
+      new NetworkError('http://example.org/sparql', 'ECONNREFUSED', 0),
+    ];
+    const store = await collect(
+      probeResultsToQuads(results, 'http://example.org/dataset'),
+    );
+    assertNoBlankNodes(store.getQuads(null, null, null, null));
   });
 
   it('yields schema:error with status URI for HTTP error', async () => {

--- a/packages/pipeline/test/guard/blankNodes.test.ts
+++ b/packages/pipeline/test/guard/blankNodes.test.ts
@@ -1,0 +1,83 @@
+import {
+  assertNoBlankNodes,
+  blankNodes,
+  failOnBlankNodes,
+} from '../../src/index.js';
+import { describe, it, expect } from 'vitest';
+import { DataFactory } from 'n3';
+import type { Quad } from '@rdfjs/types';
+
+const { namedNode, literal, quad, blankNode, defaultGraph } = DataFactory;
+
+const s = namedNode('http://example.org/dataset');
+const p = namedNode('http://www.w3.org/ns/prov#wasGeneratedBy');
+
+const clean: Quad[] = [
+  quad(s, namedNode('http://rdfs.org/ns/void#triples'), literal('42')),
+  quad(s, p, namedNode('http://example.org/dataset#activity-abc')),
+];
+
+async function* stream(quads: Quad[]): AsyncIterable<Quad> {
+  yield* quads;
+}
+
+async function drain(quads: AsyncIterable<Quad>): Promise<Quad[]> {
+  const out: Quad[] = [];
+  for await (const q of quads) out.push(q);
+  return out;
+}
+
+describe('blankNodes', () => {
+  it('returns nothing for blank-node-free quads', () => {
+    expect(blankNodes(clean)).toEqual([]);
+  });
+
+  it('reports blank nodes in subject, object, and graph position', () => {
+    const quads = [
+      quad(blankNode('inSubject'), p, s),
+      quad(s, p, blankNode('inObject')),
+      quad(s, p, s, blankNode('inGraph')),
+    ];
+    expect(new Set(blankNodes(quads))).toEqual(
+      new Set(['inSubject', 'inObject', 'inGraph']),
+    );
+  });
+
+  it('deduplicates repeated labels', () => {
+    const a = blankNode('a');
+    expect(blankNodes([quad(a, p, s), quad(s, p, a)])).toEqual(['a']);
+  });
+});
+
+describe('assertNoBlankNodes', () => {
+  it('does not throw for blank-node-free quads', () => {
+    expect(() => assertNoBlankNodes(clean)).not.toThrow();
+  });
+
+  it('throws, naming the offending label, when a blank node is present', () => {
+    expect(() => assertNoBlankNodes([quad(s, p, blankNode('n3-50'))])).toThrow(
+      /n3-50/,
+    );
+  });
+});
+
+describe('failOnBlankNodes', () => {
+  it('passes blank-node-free quads through unchanged', async () => {
+    const out = await drain(failOnBlankNodes()(stream(clean), {}));
+    expect(out).toEqual(clean);
+  });
+
+  it('throws on the first blank node reaching the writer', async () => {
+    const quads = [clean[0], quad(s, p, blankNode('n3-7')), clean[1]];
+    await expect(drain(failOnBlankNodes()(stream(quads), {}))).rejects.toThrow(
+      /n3-7/,
+    );
+  });
+
+  it('ignores the default graph (not a blank node)', async () => {
+    const out = await drain(
+      failOnBlankNodes()(stream([quad(s, p, s, defaultGraph())]), {}),
+    );
+    expect(out).toHaveLength(1);
+  });
+});

--- a/packages/pipeline/test/plugin/provenance.test.ts
+++ b/packages/pipeline/test/plugin/provenance.test.ts
@@ -1,4 +1,8 @@
-import { provenanceTransform, provenancePlugin } from '../../src/index.js';
+import {
+  assertNoBlankNodes,
+  provenanceTransform,
+  provenancePlugin,
+} from '../../src/index.js';
 import { Dataset } from '@lde/dataset';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DataFactory } from 'n3';
@@ -153,6 +157,22 @@ describe('provenanceTransform', () => {
         q.predicate.value === RDF_TYPE && q.object.value === `${PROV}Activity`,
     )!.subject;
     expect(activitySubject.termType).toBe('NamedNode');
+  });
+
+  it('emits no blank nodes (they fuse across datasets in a cat-built index, #474)', async () => {
+    const existing = quad(
+      namedNode(dataset.iri.toString()),
+      namedNode('http://rdfs.org/ns/void#triples'),
+      literal('100'),
+    );
+    assertNoBlankNodes(
+      await collect(
+        provenanceTransform(quadStream([existing]), {
+          dataset,
+          stage: 'describe',
+        }),
+      ),
+    );
   });
 
   it('mints a stable activity IRI across runs (idempotent)', async () => {

--- a/packages/pipeline/test/provenance/fileLoadedSparqlProvenanceStore.test.ts
+++ b/packages/pipeline/test/provenance/fileLoadedSparqlProvenanceStore.test.ts
@@ -18,6 +18,7 @@ import {
   teardownSparqlEndpoint,
 } from '@lde/local-sparql-endpoint';
 import { FileLoadedSparqlProvenanceStore } from '../../src/provenance/fileLoadedSparqlProvenanceStore.js';
+import { assertNoBlankNodes } from '../../src/index.js';
 
 const PORT = 3004;
 const QUERY_ENDPOINT = `http://localhost:${PORT}/sparql`;
@@ -73,6 +74,9 @@ describe('FileLoadedSparqlProvenanceStore', () => {
       });
 
       const quads = await readQuads(outputDir);
+
+      // No blank nodes: they fuse across datasets in a cat-built index (#474).
+      assertNoBlankNodes(quads);
 
       // Every quad lands in the pipeline provenance graph, keyed by dataset URI.
       expect(quads.length).toBeGreaterThan(0);

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 95.55,
-          lines: 95.28,
-          branches: 90.12,
-          statements: 94.74,
+          functions: 95.65,
+          lines: 95.36,
+          branches: 90.23,
+          statements: 94.83,
         },
       },
     },


### PR DESCRIPTION
## Why

A file-based served store (the Dataset Knowledge Graph) rebuilds its index by concatenating every per-dataset n-quads file and parsing the concatenation as **one** RDF document (`qlever index` over `find … -exec cat {} +`). Blank-node labels are only document-scoped, and the pipeline emits **deterministic** labels (n3 `DataFactory.blankNode()` → `n3-N`, the counter resets per dataset/run), so the same label recurs across files and the indexer **fuses** those nodes — merging unrelated provenance/measurements/linksets across datasets and runs. Named nodes never fuse.

The invariant for anything written into such a store is therefore: **no blank nodes** (mint skolem IRIs instead). This PR makes that invariant testable and enforceable.

## What

- **`@lde/pipeline`** exports a small guard:
  - `blankNodes(quads)` — the distinct blank-node labels in subject/object/graph position.
  - `assertNoBlankNodes(quads)` — throws (naming offenders) for use in producer tests.
  - `failOnBlankNodes()` — a `QuadTransform` that passes quads through but throws on the first blank node, so it can sit before the writer and fail a CI/staging run.
- **Regression assertions** wired into the structural producers whose output lands in the cat-built index, all passing:
  - `provenanceTransform`, the distribution `report` (`probeResultsToQuads`), `FileLoadedSparqlProvenanceStore` (`@lde/pipeline`)
  - `uriSpaceTransform` linkset (`@lde/pipeline-void`)

## Out of scope

- **SHACL validation reports** (`@lde/pipeline-shacl-validator`) still emit blank nodes (`sh:ValidationResult`/`sh:ValidationReport` via `rdf-validate-shacl`) — the remaining offender, tracked in #474. Not asserted here (it would fail).
- The **SHACL sampler** emits sampled publisher RDF where blank nodes are legitimate; exempt.
- `fastify-rdf` hydra error bodies are HTTP responses, never indexed; exempt.

## Tests

`@lde/pipeline` (322 tests) and `@lde/pipeline-void` (32 tests): typecheck, lint, and test all green; the guard module is 100% covered.

Refs #474, netwerk-digitaal-erfgoed/dataset-knowledge-graph#352.
