### PR TITLE
fix(distribution-health): republish to include missing dist build output

### DIFF
--- a/packages/distribution-health/README.md
+++ b/packages/distribution-health/README.md
@@ -32,3 +32,6 @@ into a SKOS failure scheme (`<scheme>#${reason}`) with no lookup table.
 
 The normative usability rule and the rejected alternatives are recorded in the
 PRD: netwerk-digitaal-erfgoed/dataset-register#2103.
+
+<!-- 0.1.1 was published to npm without its dist/; this republishes the package with the build output. -->
+


### PR DESCRIPTION
## Problem

`@lde/distribution-health@0.1.1` was published to npm containing **only** `package.json` and `README.md` – its `dist/` was missing:

```
package/package.json
package/README.md
```

Its `main`/`exports` point at `./dist/index.js`. `@lde/pipeline@0.30.16` pins `@lde/distribution-health@0.1.1` exactly (it is the only published version), so anything depending on the pipeline fails at runtime:

```
Error: Cannot find module '.../node_modules/@lde/distribution-health/dist/index.js'
  imported from .../node_modules/@lde/pipeline/dist/pipeline.js
```

This is red-flagging Dependabot bumps downstream, e.g. netwerk-digitaal-erfgoed/dataset-knowledge-graph#359.

## Fix

The package source is fine – a normal `nx build` + `npm pack` produces the correct 11-file tarball; only the published `0.1.1` artefact is broken. This is a minimal patch bump so `nx release` rebuilds and republishes `@lde/distribution-health@0.1.2` with its `dist/`, and `updateDependents: auto` re-pins and republishes `@lde/pipeline` and the `pipeline-*` packages against it.

Downstream Dependabot PRs then pick up working packages.
