### PR TITLE
fix(pipeline-shacl-validator): skolemise validation report blank nodes

### DIFF
--- a/packages/pipeline-shacl-validator/README.md
+++ b/packages/pipeline-shacl-validator/README.md
@@ -70,6 +70,20 @@ detail. Configure at least one writer in production pipelines.
 The bundled `FileWriter` and `SparqlUpdateWriter` already implement the
 `Writer` contract; bring your own for custom destinations.
 
+##### Blank-node-free reports
+
+shacl-engine emits the `sh:ValidationReport`, every `sh:ValidationResult` and
+any anonymous `sh:sourceShape` as blank nodes. Before writing, `ShaclValidator`
+rewrites each one to a dataset-scoped IRI of the form
+`<dataset>/.well-known/shacl#<batch>-<label>`. This keeps a file-based served
+store (e.g. the Dataset Knowledge Graph) from fusing one dataset's results into
+another's when it `cat`s every per-dataset n-quads file into a single index –
+blank-node labels are only document-scoped and recur across files (see
+[ldelements/lde#478](https://github.com/ldelements/lde/issues/478)). The
+dataset IRI rules out fusion across datasets; `<batch>`, a hash of the report's
+quads, rules out fusion across the separate `validate()` batches that land in
+one dataset's validation graph.
+
 #### Filesystem collisions with `FileWriter`
 
 `FileWriter` derives its filename from `dataset.iri` only. If the pipeline's

--- a/packages/pipeline-shacl-validator/src/shacl-validator.ts
+++ b/packages/pipeline-shacl-validator/src/shacl-validator.ts
@@ -12,6 +12,7 @@ import ShaclEngine from 'shacl-engine/Validator.js';
 // @ts-expect-error -- rdf-ext has no type declarations.
 import rdf from 'rdf-ext';
 import { rdfDereferencer } from 'rdf-dereference';
+import { skolemizeReport } from './skolemize-report.js';
 
 /** Options for {@link ShaclValidator}. */
 export interface ShaclValidatorOptions {
@@ -81,7 +82,15 @@ export class ShaclValidator implements Validator {
     this.accumulators.set(key, acc);
 
     if (violations > 0 && this.reportWriters.length > 0) {
-      const reportQuads: Quad[] = [...report.dataset];
+      // Skolemise the report's blank nodes to dataset-scoped IRIs before writing.
+      // shacl-engine emits the report and every result as blank nodes, whose
+      // labels are not unique across the per-dataset n-quads files a file-based
+      // store cats into one index — fusing one dataset's violations into
+      // another's (see ldelements/lde#478).
+      const reportQuads = skolemizeReport(
+        report.dataset,
+        dataset.iri.toString(),
+      );
       for (const writer of this.reportWriters) {
         await writer.write(dataset, asyncIterableOf(reportQuads));
       }

--- a/packages/pipeline-shacl-validator/src/skolemize-report.ts
+++ b/packages/pipeline-shacl-validator/src/skolemize-report.ts
@@ -1,0 +1,73 @@
+import type { Quad, Term } from '@rdfjs/types';
+import { hashSuffix, skolemIri } from '@lde/dataset';
+// @ts-expect-error -- rdf-ext has no type declarations.
+import rdf from 'rdf-ext';
+
+/**
+ * Rewrite every blank node in a shacl-engine validation report to a
+ * deterministic, dataset-scoped IRI, leaving the report otherwise unchanged.
+ *
+ * shacl-engine emits the `sh:ValidationReport`, every `sh:ValidationResult` and
+ * any anonymous `sh:sourceShape`/`sh:value`/`sh:detail` as blank nodes. When a
+ * file-based served store such as the Dataset Knowledge Graph concatenates every
+ * per-dataset n-quads file into one index (`qlever index` over the `cat` of all
+ * files), document-scoped blank-node labels recur across files and fuse one
+ * dataset's results into another's — a cross-graph traversal can then reach a
+ * foreign dataset's violations (see ldelements/lde#478 and #474, and
+ * netwerk-digitaal-erfgoed/dataset-knowledge-graph#352).
+ *
+ * Each blank node becomes `<dataset>/.well-known/shacl#<batch>-<label>`. The
+ * dataset IRI rules out fusion across datasets; `<batch>`, a hash of this
+ * report's quads, rules out fusion across the separate `validate()` batches that
+ * land in one dataset's validation graph — their labels both restart at `b1`,
+ * but a batch carrying different violations hashes differently. Two batches with
+ * byte-identical reports collapse onto the same IRIs, which is correct: they are
+ * the same violations.
+ *
+ * @param quads - The report quads (`report.dataset`), possibly with blank nodes.
+ * @param datasetIri - The dataset the report is about; scopes every minted IRI.
+ * @returns The same quads with every blank node replaced by a skolem IRI.
+ */
+export function skolemizeReport(
+  quads: Iterable<Quad>,
+  datasetIri: string,
+): Quad[] {
+  const reportQuads = [...quads];
+  // Fold the per-batch hash into the base, then let skolemIri append `-<label>`,
+  // matching the skolems minted for provenance and distribution reports (#474).
+  const base = `${datasetIri}/.well-known/shacl#${hashSuffix(fingerprint(reportQuads))}`;
+  const skolemize = (term: Term): Term =>
+    term.termType === 'BlankNode'
+      ? rdf.namedNode(skolemIri(base, term.value))
+      : term;
+  return reportQuads.map((quad) =>
+    rdf.quad(
+      skolemize(quad.subject),
+      quad.predicate,
+      skolemize(quad.object),
+      skolemize(quad.graph),
+    ),
+  );
+}
+
+/** A deterministic string identifying a report, for use as a per-batch IRI segment. */
+function fingerprint(quads: Quad[]): string {
+  return quads
+    .map(
+      (quad) =>
+        `${termKey(quad.subject)} ${quad.predicate.value} ${termKey(quad.object)}`,
+    )
+    .sort()
+    .join('\n');
+}
+
+function termKey(term: Term): string {
+  switch (term.termType) {
+    case 'BlankNode':
+      return `_:${term.value}`;
+    case 'Literal':
+      return `"${term.value}"^^<${term.datatype.value}>@${term.language}`;
+    default:
+      return `<${term.value}>`;
+  }
+}

--- a/packages/pipeline-shacl-validator/test/fixtures/invalid-two.ttl
+++ b/packages/pipeline-shacl-validator/test/fixtures/invalid-two.ttl
@@ -1,0 +1,4 @@
+@prefix ex: <http://example.org/> .
+
+ex:bob a ex:Person .
+ex:carol a ex:Person .

--- a/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
+++ b/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
@@ -6,8 +6,25 @@ import { tmpdir } from 'node:os';
 import { Parser } from 'n3';
 import type { Quad } from '@rdfjs/types';
 import { Dataset } from '@lde/dataset';
-import { FileWriter, type Writer } from '@lde/pipeline';
+import { FileWriter, assertNoBlankNodes, type Writer } from '@lde/pipeline';
 import { ShaclValidator } from '../src/shacl-validator.js';
+
+const SH_RESULT = 'http://www.w3.org/ns/shacl#result';
+
+async function reportQuadsFor(
+  filename: string,
+  forDataset: Dataset = dataset,
+): Promise<Quad[]> {
+  let received: Quad[] = [];
+  const writer: Writer = {
+    write: async (_dataset, quads) => {
+      received = await collectQuads(quads);
+    },
+  };
+  const validator = new ShaclValidator({ shapesFile, reportWriters: [writer] });
+  await validator.validate(parseFixture(filename), forDataset);
+  return received;
+}
 
 const shapesFile = join(__dirname, 'fixtures', 'shapes.ttl');
 
@@ -128,6 +145,55 @@ describe('ShaclValidator', () => {
         q.predicate.value.startsWith('http://www.w3.org/ns/shacl#'),
       ),
     ).toBe(true);
+  });
+
+  it('skolemises report blank nodes to dataset-scoped IRIs', async () => {
+    // shacl-engine emits the report and every result as blank nodes, which fuse
+    // across datasets in a file-based store's cat-built index (ldelements/lde#478).
+    const received = await reportQuadsFor('invalid.ttl');
+
+    expect(received.length).toBeGreaterThan(0);
+    assertNoBlankNodes(received);
+    const base = 'http://example.org/dataset/.well-known/shacl#';
+    expect(
+      received.every(
+        (quad) =>
+          (quad.subject.termType === 'NamedNode'
+            ? quad.subject.value.startsWith(base)
+            : true) &&
+          (quad.object.termType === 'NamedNode' &&
+          quad.object.value.includes('/.well-known/shacl#')
+            ? quad.object.value.startsWith(base)
+            : true),
+      ),
+    ).toBe(true);
+  });
+
+  it('keys result IRIs on the dataset, so they do not fuse across datasets', async () => {
+    const other = new Dataset({
+      iri: new URL('http://example.org/other'),
+      distributions: [],
+    });
+    const resultsOf = (quads: Quad[]) =>
+      quads
+        .filter((quad) => quad.predicate.value === SH_RESULT)
+        .map((quad) => quad.object.value);
+
+    const here = resultsOf(await reportQuadsFor('invalid.ttl'));
+    const there = resultsOf(await reportQuadsFor('invalid.ttl', other));
+
+    expect(here.length).toBeGreaterThan(0);
+    expect(there.length).toBeGreaterThan(0);
+    expect(here.some((result) => there.includes(result))).toBe(false);
+  });
+
+  it('gives each violation a distinct result IRI within one report', async () => {
+    const results = (await reportQuadsFor('invalid-two.ttl'))
+      .filter((quad) => quad.predicate.value === SH_RESULT)
+      .map((quad) => quad.object.value);
+
+    expect(results).toHaveLength(2);
+    expect(new Set(results).size).toBe(2);
   });
 
   it('flushes each writer when report() is called', async () => {

--- a/packages/pipeline-shacl-validator/test/skolemize-report.test.ts
+++ b/packages/pipeline-shacl-validator/test/skolemize-report.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { DataFactory } from 'n3';
+import type { Quad } from '@rdfjs/types';
+import { skolemizeReport } from '../src/skolemize-report.js';
+
+const { namedNode, blankNode, literal, quad } = DataFactory;
+
+const DATASET = 'http://example.org/ds';
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const sh = (local: string) => namedNode(`http://www.w3.org/ns/shacl#${local}`);
+
+// A minimal report — two batches restart their blank labels at the same `b1`/`b2`,
+// just as shacl-engine does across separate validate() calls.
+function reportAbout(focusNode: string): Quad[] {
+  const report = blankNode('b1');
+  const result = blankNode('b2');
+  return [
+    quad(report, RDF_TYPE, sh('ValidationReport')),
+    quad(report, sh('result'), result),
+    quad(result, RDF_TYPE, sh('ValidationResult')),
+    quad(result, sh('focusNode'), namedNode(focusNode)),
+    quad(result, sh('resultMessage'), literal('missing name')),
+  ];
+}
+
+const resultIri = (quads: Quad[]) =>
+  quads.find((quad) => quad.predicate.value === sh('result').value)?.object
+    .value;
+
+describe('skolemizeReport', () => {
+  it('replaces every blank node with a dataset-scoped IRI', () => {
+    const out = skolemizeReport(reportAbout('http://example.org/bob'), DATASET);
+
+    const noBlankNodes = out.every((quad) =>
+      [quad.subject, quad.object, quad.graph].every(
+        (term) => term.termType !== 'BlankNode',
+      ),
+    );
+    expect(noBlankNodes).toBe(true);
+    expect(resultIri(out)).toMatch(
+      new RegExp(`^${DATASET}/\\.well-known/shacl#[0-9a-f]+-`),
+    );
+  });
+
+  it('is a pure function of the report (same input → same IRIs)', () => {
+    const first = skolemizeReport(
+      reportAbout('http://example.org/bob'),
+      DATASET,
+    );
+    const second = skolemizeReport(
+      reportAbout('http://example.org/bob'),
+      DATASET,
+    );
+
+    expect(resultIri(first)).toBe(resultIri(second));
+  });
+
+  it('does not fuse batches that reuse blank labels for different violations', () => {
+    const bob = skolemizeReport(reportAbout('http://example.org/bob'), DATASET);
+    const carol = skolemizeReport(
+      reportAbout('http://example.org/carol'),
+      DATASET,
+    );
+
+    // Both reports label their result `b2`; the per-batch hash keeps the minted
+    // IRIs distinct so they cannot collapse in a shared validation graph.
+    expect(resultIri(bob)).not.toBe(resultIri(carol));
+  });
+
+  it('scopes IRIs by dataset so results do not collide across datasets', () => {
+    const here = skolemizeReport(
+      reportAbout('http://example.org/bob'),
+      DATASET,
+    );
+    const there = skolemizeReport(
+      reportAbout('http://example.org/bob'),
+      'http://example.org/other',
+    );
+
+    expect(resultIri(here)).not.toBe(resultIri(there));
+  });
+});


### PR DESCRIPTION
Fix #478

## Problem

`pipeline-shacl-validator` wrote the shacl-engine report graph verbatim, so the `sh:ValidationReport`, every `sh:ValidationResult`, and the anonymous `sh:sourceShape` reached the writers as **blank nodes**. A file-based served store such as the Dataset Knowledge Graph rebuilds its index by concatenating every per-dataset n-quads file and parsing it as one document (`qlever index` over the `cat` of all files). The indexer never sees file boundaries, so document-scoped blank-node labels recur across files and **fuse** report/result nodes across datasets – a cross-graph or default-graph traversal could then pull a foreign dataset's violations (same mechanism as #474 / #352).

## Fix

Before the report reaches any writer, `skolemizeReport(quads, datasetIri)` rewrites every blank node to a dataset-scoped IRI:

```
<dataset>/.well-known/shacl#<batch>-<label>
```

- the **dataset IRI** rules out fusion across datasets;
- **`<batch>`**, a hash of the report's quads, rules out fusion across the separate `validate()` batches that land in one dataset's validation graph – their blank labels both restart at `b1`, but a batch carrying different violations hashes differently.

This mirrors the `skolemIri` / `hashSuffix` skolemisation already used for provenance and distribution reports (#471, #474), but stays deliberately simple: no recursion, no shapes-graph coupling, no per-node content hashing. The opaque report/result IRIs are queried structurally (via `sh:result` / `sh:focusNode`), never by value, and the DKG rebuilds its index wholesale each run – so cross-run IRI stability buys nothing and is not pursued.

## Acceptance criteria

- ✅ Report output contains no blank nodes (IRIs only) – asserted with `assertNoBlankNodes` (#477).
- ✅ Result IRIs are keyed on the dataset, so the cross-graph shared-result query returns 0 after a rebuild.
- ✅ Regression tests assert blank-node-free output, plus cross-dataset and cross-batch non-fusion and within-report distinctness.

The README documents the new blank-node-free output.
