### PR TITLE
docs: warn to build before manually publishing a new package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,13 +134,19 @@ For releasing the new package’s first version, see [Releasing a new package](#
 One-time bootstrap for a new package (do this once it has been merged to main):
 
 1. **Publish the first version manually.** From a maintainer’s machine:
+
    ```sh
    npm login --auth-type=web   # opens a browser tab; handles 2FA
    npm whoami                  # verify the publisher account
+   npx nx build <name>         # populate dist/ — see warning below
    cd packages/<name>
    npm publish --access public --provenance
    ```
+
    The package is created on npm at the version in its `package.json`.
+
+   > **Build first, or you ship an empty package.** Package manifests use `"files": ["dist"]`, so `npm publish` packs only `package.json` and `README.md` unless `dist/` exists on disk. CI releases get `dist/` for free via `release.version.preVersionCommand` (`nx run-many -t build`) in `nx.json`, but this manual bootstrap is the one publish path that bypasses it — always run `npx nx build <name>` immediately before `npm publish`.
+
 2. **Add a Trusted Publisher to the now-existing package.** On npmjs.com, open the new package → ‘Settings’ → ‘Trusted Publishers’ → ‘Add trusted publisher’. Fill in:
    - Publisher: GitHub Actions
    - Organization or user: `ldelements`


### PR DESCRIPTION
## What

Adds a warning to the **Releasing a new package** bootstrap in `AGENTS.md`: build the package before the one-time manual `npm publish`, or you ship a tarball with only `package.json` and `README.md`.

## Why

Package manifests use `"files": ["dist"]`, so `npm publish` packs `dist/` only if it already exists on disk. CI releases get `dist/` for free via `release.version.preVersionCommand` (`nx run-many -t build`), but the manual first-publish bootstrap is the one path that bypasses it. This is the failure mode behind `@lde/distribution-health@0.1.1` shipping empty (#479).

The change adds an `npx nx build <name>` step to the bootstrap snippet plus a callout explaining the cause.
