### PR TITLE
feat(pipeline): accept multiple progress reporters

### DIFF
--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -276,6 +276,21 @@ Writes generated quads to a destination:
 - `SparqlUpdateWriter` — writes to a SPARQL endpoint via UPDATE queries
 - `FileWriter` — writes to local files
 
+### Reporter
+
+A `ProgressReporter` observes the run, receiving lifecycle events such as `pipelineStart`, `stageComplete`, `datasetValidated` and `pipelineComplete`. Every method is optional, so a reporter implements only the events it cares about.
+
+Pass a single reporter, or an array to have several observe the same run — for example a console reporter alongside one that collects validation verdicts:
+
+```typescript
+new Pipeline({
+  // …
+  reporter: [new ConsoleReporter(), verdictCollector],
+});
+```
+
+Each reporter receives every event, in array order; a reporter that does not implement a given event is skipped for it.
+
 ### Provenance store
 
 A `ProvenanceStore` gives the pipeline a small per-dataset memory, so a future run can skip datasets that are genuinely unchanged. It is purely a storage seam: the framework owns the skip decision (see [`sourceFingerprint`](#source-change-fingerprint) and `shouldReprocess`), the store owns only how each record is persisted.

--- a/packages/pipeline/src/combineReporters.ts
+++ b/packages/pipeline/src/combineReporters.ts
@@ -1,0 +1,70 @@
+import type { ProgressReporter } from './progressReporter.js';
+
+/** A {@link ProgressReporter} lifecycle method name. */
+type ReporterMethod = keyof ProgressReporter;
+
+/** The arguments of a {@link ProgressReporter} method, with its optionality stripped. */
+type ReporterArguments<Method extends ReporterMethod> = Parameters<
+  NonNullable<ProgressReporter[Method]>
+>;
+
+/**
+ * Combine several {@link ProgressReporter}s into one that forwards every
+ * lifecycle call to each child that implements it. Lets a single run be
+ * observed by more than one reporter – e.g. a console reporter alongside a
+ * verdict-collecting one.
+ *
+ * Each method is dispatched to the children in array order; a child that does
+ * not implement a given (optional) method is skipped for that call.
+ *
+ * Internal to the package: not re-exported from `index.ts`. {@link Pipeline}
+ * uses it to normalise a `reporter` array into the single reporter its call
+ * sites expect, so the broader API need not grow a new public symbol.
+ */
+export function combineReporters(
+  reporters: readonly ProgressReporter[],
+): ProgressReporter {
+  const forward = <Method extends ReporterMethod>(
+    method: Method,
+    ...args: ReporterArguments<Method>
+  ): void => {
+    for (const reporter of reporters) {
+      // Cast to the concrete signature for `method`: indexing by a generic key
+      // yields a union of method types TS won't call directly, even though the
+      // arguments are correlated.
+      const handler = reporter[method] as
+        | ((...handlerArgs: ReporterArguments<Method>) => void)
+        | undefined;
+      // Every method is optional; notify only the children that implement it.
+      handler?.(...args);
+    }
+  };
+
+  // Listing every method explicitly (rather than a Proxy) keeps the forwarding
+  // type-safe: typing the result as `Required<ProgressReporter>` forces a new
+  // entry here whenever the interface grows, so a forgotten method fails to
+  // compile instead of silently going unforwarded.
+  const combined: Required<ProgressReporter> = {
+    pipelineStart: (...args) => forward('pipelineStart', ...args),
+    datasetsSelected: (...args) => forward('datasetsSelected', ...args),
+    datasetStart: (...args) => forward('datasetStart', ...args),
+    distributionProbed: (...args) => forward('distributionProbed', ...args),
+    importStarted: (...args) => forward('importStarted', ...args),
+    importFailed: (...args) => forward('importFailed', ...args),
+    distributionValidated: (...args) =>
+      forward('distributionValidated', ...args),
+    distributionSelected: (...args) => forward('distributionSelected', ...args),
+    stageStart: (...args) => forward('stageStart', ...args),
+    stageProgress: (...args) => forward('stageProgress', ...args),
+    stageComplete: (...args) => forward('stageComplete', ...args),
+    stageFailed: (...args) => forward('stageFailed', ...args),
+    stageSkipped: (...args) => forward('stageSkipped', ...args),
+    datasetValidated: (...args) => forward('datasetValidated', ...args),
+    datasetComplete: (...args) => forward('datasetComplete', ...args),
+    datasetSkipped: (...args) => forward('datasetSkipped', ...args),
+    pipelineComplete: (...args) => forward('pipelineComplete', ...args),
+    timeoutTightened: (...args) => forward('timeoutTightened', ...args),
+    timeoutRelaxed: (...args) => forward('timeoutRelaxed', ...args),
+  };
+  return combined;
+}

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -33,6 +33,7 @@ import type {
   DistributionAnalysisResult,
   ProgressReporter,
 } from './progressReporter.js';
+import { combineReporters } from './combineReporters.js';
 import type { Validator } from './validator.js';
 import {
   ConstantTimeoutPolicy,
@@ -75,7 +76,13 @@ export interface PipelineOptions {
     stageOutputResolver: StageOutputResolver;
     outputDir: string;
   };
-  reporter?: ProgressReporter;
+  /**
+   * Observer(s) notified of pipeline lifecycle events. Pass an array to have
+   * several reporters observe the same run – e.g. a console reporter alongside
+   * a verdict-collecting one; every reporter receives each event in array
+   * order. A single reporter may be passed directly.
+   */
+  reporter?: ProgressReporter | readonly ProgressReporter[];
   /**
    * Optional per-dataset processing memory. When set, the pipeline skips a
    * dataset whose source-change fingerprint and {@link pipelineVersion} both
@@ -234,7 +241,11 @@ export class Pipeline {
     this.distributionResolver =
       options.distributionResolver ?? new SparqlDistributionResolver();
     this.chaining = options.chaining;
-    this.reporter = options.reporter;
+    // `Array.isArray` narrows the array branch but not the readonly-array out of
+    // the else branch, so cast the single-reporter case explicitly.
+    this.reporter = Array.isArray(options.reporter)
+      ? combineReporters(options.reporter)
+      : (options.reporter as ProgressReporter | undefined);
     this.timeoutFactory =
       options.timeout ?? (() => new ConstantTimeoutPolicy(300_000));
     this.provenanceStore = options.provenanceStore;

--- a/packages/pipeline/test/combineReporters.test.ts
+++ b/packages/pipeline/test/combineReporters.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Dataset } from '@lde/dataset';
+import { combineReporters } from '../src/combineReporters.js';
+import type { ProgressReporter } from '../src/progressReporter.js';
+
+function makeDataset(iri = 'http://example.org/dataset'): Dataset {
+  return new Dataset({ iri: new URL(iri), distributions: [] });
+}
+
+/**
+ * Every {@link ProgressReporter} method. Kept here so the forward-to-all test
+ * exercises each forwarder; a method added to the interface that is missed here
+ * leaves its forwarder uncovered, which the coverage threshold flags.
+ */
+const REPORTER_METHODS = [
+  'pipelineStart',
+  'datasetsSelected',
+  'datasetStart',
+  'distributionProbed',
+  'importStarted',
+  'importFailed',
+  'distributionValidated',
+  'distributionSelected',
+  'stageStart',
+  'stageProgress',
+  'stageComplete',
+  'stageFailed',
+  'stageSkipped',
+  'datasetValidated',
+  'datasetComplete',
+  'datasetSkipped',
+  'pipelineComplete',
+  'timeoutTightened',
+  'timeoutRelaxed',
+] as const satisfies readonly (keyof ProgressReporter)[];
+
+type FullReporter = ProgressReporter &
+  Record<(typeof REPORTER_METHODS)[number], ReturnType<typeof vi.fn>>;
+
+function makeReporter(): FullReporter {
+  return Object.fromEntries(
+    REPORTER_METHODS.map((method) => [method, vi.fn()]),
+  ) as unknown as FullReporter;
+}
+
+describe('combineReporters', () => {
+  it('forwards every method to each child', () => {
+    const first = makeReporter();
+    const second = makeReporter();
+    const combined = combineReporters([first, second]);
+
+    for (const method of REPORTER_METHODS) {
+      (combined[method] as () => void)();
+    }
+
+    for (const reporter of [first, second]) {
+      for (const method of REPORTER_METHODS) {
+        expect(reporter[method]).toHaveBeenCalledTimes(1);
+      }
+    }
+  });
+
+  it('skips children that do not implement the called method', () => {
+    const withMethod = { datasetStart: vi.fn() } satisfies ProgressReporter;
+    const withoutMethod = { pipelineStart: vi.fn() } satisfies ProgressReporter;
+    const dataset = makeDataset();
+
+    // Must not throw even though `withoutMethod` has no `datasetStart`.
+    combineReporters([withMethod, withoutMethod]).datasetStart?.(dataset);
+
+    expect(withMethod.datasetStart).toHaveBeenCalledWith(dataset);
+    expect(withoutMethod.pipelineStart).not.toHaveBeenCalled();
+  });
+
+  it('passes every argument through unchanged', () => {
+    const reporter = { datasetsSelected: vi.fn() } satisfies ProgressReporter;
+
+    combineReporters([reporter]).datasetsSelected?.(42, 1234);
+
+    expect(reporter.datasetsSelected).toHaveBeenCalledWith(42, 1234);
+  });
+
+  it('dispatches to children in array order', () => {
+    const order: number[] = [];
+    const first = {
+      pipelineStart: vi.fn(() => order.push(1)),
+    } satisfies ProgressReporter;
+    const second = {
+      pipelineStart: vi.fn(() => order.push(2)),
+    } satisfies ProgressReporter;
+
+    combineReporters([first, second]).pipelineStart?.('run');
+
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('is a no-op for an empty array of reporters', () => {
+    expect(() => combineReporters([]).pipelineStart?.('run')).not.toThrow();
+  });
+});

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -637,6 +637,28 @@ describe('Pipeline', () => {
       await expect(pipeline.run()).resolves.toBeUndefined();
     });
 
+    it('notifies every reporter when passed an array', async () => {
+      const first = makeReporter();
+      const second = makeReporter();
+
+      const pipeline = new Pipeline({
+        name: 'my-pipeline',
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [makeStage('stage1')],
+        writers: writer,
+        distributionResolver: makeResolver(makeResolvedDistribution()),
+        reporter: [first, second],
+      });
+
+      await pipeline.run();
+
+      for (const reporter of [first, second]) {
+        expect(reporter.pipelineStart).toHaveBeenCalledWith('my-pipeline');
+        expect(reporter.stageStart).toHaveBeenCalledWith('stage1');
+        expect(reporter.pipelineComplete).toHaveBeenCalledTimes(1);
+      }
+    });
+
     it('distributionProbed called once per distribution with correct result', async () => {
       const reporter = makeReporter();
 

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 95.65,
-          lines: 95.4,
-          branches: 90.74,
-          statements: 94.87,
+          functions: 96.09,
+          lines: 95.53,
+          branches: 90.78,
+          statements: 95.01,
         },
       },
     },


### PR DESCRIPTION
## What

Let `@lde/pipeline`’s `Pipeline` accept **more than one `ProgressReporter`**, so a single run can be observed by several reporters – for example a console reporter alongside one that collects validation verdicts.

## How

- Widen the `reporter` option from `ProgressReporter` to `ProgressReporter | readonly ProgressReporter[]`. A single reporter may still be passed directly; pass an array to fan out.
- Normalise an array into one private composite (`combineReporters`) that forwards every lifecycle method to each child that implements it. `this.reporter` stays a single `ProgressReporter`, so the ~25 `this.reporter?.x?.(...)` call sites in `pipeline.ts` are untouched.
- The composite is **internal** – not re-exported from `index.ts`, so the public API gains no new symbol. An array meaning “notify all of them” is a self-evident convention that needs no new vocabulary; if a second use site for the composite ever appears outside the pipeline, it can be promoted to an exported `combineReporters` then.
- Forwarding is explicit and type-safe: each method is listed and the result is typed as `Required<ProgressReporter>`, so a method added to the interface fails to compile until it is forwarded. No Proxy needed – LDE owns the interface.

## Notes

This replaces a Proxy-based stop-gap fan-out currently living downstream in the dataset-knowledge-graph repo; that consumer will drop its local copy and pass `reporter: [new ConsoleReporter(), collector]` once this is released.

## Tests

- Unit tests for the composite: forward-to-all, skip-unimplemented, argument pass-through, dispatch order, empty-array no-op.
- A pipeline-level test that an array of reporters both observe a run.
