### PR TITLE
fix(distribution-probe): accept empty and non-n-triples SPARQL CONSTRUCT answers

### DIFF
--- a/packages/distribution-probe/README.md
+++ b/packages/distribution-probe/README.md
@@ -17,10 +17,10 @@ const result = await probe(distribution);
 
 ### SPARQL endpoints
 
-Sends `POST` with `SELECT * { ?s ?p ?o } LIMIT 1` and `Accept: application/sparql-results+json`, then:
+Sends `POST` with the configured query (default `SELECT * { ?s ?p ?o } LIMIT 1`). The query type is detected (`ASK` / `SELECT` / `CONSTRUCT` / `DESCRIBE`) and drives both the `Accept` header and how the response is validated:
 
-- **Content-Type is enforced.** The response Content-Type must start with `application/sparql-results+json`; anything else fails the probe (`isSuccess() === false`). This rules out HTML error pages served with `200 OK`.
-- The JSON body must parse and contain a `results` object. Empty bodies, invalid JSON, and missing `results` all fail the probe with a `failureReason`.
+- **`ASK` / `SELECT`** request `application/sparql-results+json`, with `application/sparql-results+xml` as a lower-priority fallback. The response Content-Type must be one of those — anything else fails the probe (`isSuccess() === false`), which rules out HTML error pages served with `200 OK`. The body must parse and contain a results document (a `results` object for `SELECT`, a `boolean` for `ASK`); empty bodies, invalid JSON/XML, and missing results all fail with a `failureReason`.
+- **`CONSTRUCT` / `DESCRIBE`** request the common RDF serializations (`text/turtle`, `application/n-triples`, `application/rdf+xml`, `application/ld+json`, `application/n-quads`, `application/trig`) and accept any of them. A `2xx` RDF response confirms availability, and **an empty graph is a valid answer** — so an empty body does not fail the probe (unlike a data dump, which must be non-empty). The body is not parse-validated.
 
 ### Data dumps
 

--- a/packages/distribution-probe/src/probe.ts
+++ b/packages/distribution-probe/src/probe.ts
@@ -91,7 +91,22 @@ abstract class ProbeResult {
 
 const SPARQL_RESULTS_JSON = 'application/sparql-results+json';
 const SPARQL_RESULTS_XML = 'application/sparql-results+xml';
-const SPARQL_RDF_RESULTS = 'application/n-triples';
+
+/**
+ * RDF serializations a CONSTRUCT or DESCRIBE query may be answered with, in
+ * preference order. The endpoint chooses the serialization, so availability must
+ * not hinge on a single one: accepting only n-triples flagged healthy endpoints
+ * that answer in Turtle (a common default) as unavailable, and made endpoints
+ * that cannot emit n-triples reject the probe with HTTP 406.
+ */
+const SPARQL_RDF_RESULTS = [
+  'text/turtle',
+  'application/n-triples',
+  'application/rdf+xml',
+  'application/ld+json',
+  'application/n-quads',
+  'application/trig',
+];
 
 /**
  * Result of probing a SPARQL endpoint.
@@ -316,7 +331,7 @@ function acceptableContentTypes(queryType: SparqlQueryType): string[] {
   if (queryType === 'ASK' || queryType === 'SELECT') {
     return [SPARQL_RESULTS_JSON, SPARQL_RESULTS_XML];
   }
-  return [SPARQL_RDF_RESULTS];
+  return [...SPARQL_RDF_RESULTS];
 }
 
 /**
@@ -385,15 +400,19 @@ async function validateSparqlResponse(
   queryType: SparqlQueryType,
   contentType: string,
 ): Promise<string | null> {
+  if (queryType === 'CONSTRUCT' || queryType === 'DESCRIBE') {
+    // A CONSTRUCT/DESCRIBE answer is RDF, and an empty graph is a valid answer –
+    // e.g. an availability probe whose query happens to match nothing – so the
+    // 200 response alone confirms the endpoint is up. Deep parse validation is
+    // the data-dump path’s job. Only data dumps must be non-empty (see
+    // validateBody); a SPARQL result may be empty.
+    await response.body?.cancel();
+    return null;
+  }
+
   const body = await response.text();
   if (body.length === 0) {
     return 'SPARQL endpoint returned an empty response';
-  }
-
-  if (queryType === 'CONSTRUCT' || queryType === 'DESCRIBE') {
-    // Body should be RDF; a non-empty response is sufficient to confirm the
-    // endpoint answered. Deep parse validation is the data-dump path’s job.
-    return null;
   }
 
   return contentType.startsWith(SPARQL_RESULTS_XML)

--- a/packages/distribution-probe/test/probe.test.ts
+++ b/packages/distribution-probe/test/probe.test.ts
@@ -1282,6 +1282,76 @@ describe('probe', () => {
       expect((result as SparqlProbeResult).isSuccess()).toBe(true);
     });
 
+    it('accepts an empty graph as a successful CONSTRUCT answer', async () => {
+      // A CONSTRUCT availability probe whose query matches nothing returns a
+      // 200 with an empty body; the endpoint is up, so this must not fail.
+      vi.mocked(fetch).mockResolvedValue(
+        new Response('', {
+          status: 200,
+          headers: { 'Content-Type': 'application/n-triples' },
+        }),
+      );
+
+      const distribution = Distribution.sparql(
+        new URL('http://example.org/sparql'),
+      );
+
+      const result = await probe(distribution, {
+        sparqlQuery: 'CONSTRUCT WHERE { ?s ?p ?o } LIMIT 1',
+      });
+
+      const sparqlResult = result as SparqlProbeResult;
+      expect(sparqlResult.isSuccess()).toBe(true);
+      expect(sparqlResult.failureReason).toBeNull();
+    });
+
+    it('accepts a CONSTRUCT answer serialized as Turtle', async () => {
+      // The endpoint chooses the RDF serialization; Turtle is a common default
+      // and must be accepted, not only n-triples.
+      vi.mocked(fetch).mockResolvedValue(
+        new Response('<http://s> <http://p> <http://o> .', {
+          status: 200,
+          headers: { 'Content-Type': 'text/turtle' },
+        }),
+      );
+
+      const distribution = Distribution.sparql(
+        new URL('http://example.org/sparql'),
+      );
+
+      const result = await probe(distribution, {
+        sparqlQuery: 'CONSTRUCT WHERE { ?s ?p ?o } LIMIT 1',
+      });
+
+      const sparqlResult = result as SparqlProbeResult;
+      expect(sparqlResult.isSuccess()).toBe(true);
+      expect(sparqlResult.failureReason).toBeNull();
+    });
+
+    it('offers several RDF serializations in the CONSTRUCT Accept header', async () => {
+      let capturedHeaders: Headers | undefined;
+      vi.mocked(fetch).mockImplementation(async (_input, init) => {
+        capturedHeaders = new Headers(init?.headers);
+        return new Response('<http://s> <http://p> <http://o> .', {
+          status: 200,
+          headers: { 'Content-Type': 'text/turtle' },
+        });
+      });
+
+      const distribution = Distribution.sparql(
+        new URL('http://example.org/sparql'),
+      );
+
+      await probe(distribution, {
+        sparqlQuery: 'CONSTRUCT WHERE { ?s ?p ?o } LIMIT 1',
+      });
+
+      const accept = capturedHeaders?.get('Accept');
+      expect(accept).toContain('text/turtle');
+      expect(accept).toContain('application/n-triples');
+      expect(accept).toContain('application/rdf+xml');
+    });
+
     it('ignores # comments when detecting query type', async () => {
       let capturedHeaders: Headers | undefined;
       vi.mocked(fetch).mockImplementation(async (_input, init) => {

--- a/packages/distribution-probe/vite.config.ts
+++ b/packages/distribution-probe/vite.config.ts
@@ -14,7 +14,7 @@ export default mergeConfig(
           lines: 100,
           functions: 100,
           branches: 95.23,
-          statements: 99.41,
+          statements: 99.42,
         },
       },
     },


### PR DESCRIPTION
## Why

A SPARQL availability probe runs the source’s own `CONSTRUCT` query, but the probe judged the response too strictly and flagged healthy endpoints as down. Reproduced against the Network of Terms catalog (56 SPARQL sources): 26 healthy sources were falsely reported unavailable —

- **20×** `SPARQL endpoint returned an empty response` — the probe query (`CONSTRUCT … "test" LIMIT 1`) legitimately matches nothing, so the endpoint returns a `200` with an empty graph.
- **2×** `HTTP 200 OK` — the endpoint answered the `CONSTRUCT` with `text/turtle`, which didn’t match the n-triples-only accept list.
- **4×** `HTTP 406` — the endpoint cannot emit n-triples and rejected the request.

## What

1. **Accept an empty graph as a successful `CONSTRUCT`/`DESCRIBE` answer.** An empty graph is a valid answer, so the `200` alone confirms availability. The non-empty requirement stays for `ASK`/`SELECT` (which must return a results document) and for **data dumps** (`validateBody` still fails an empty body — only SPARQL may be empty).
2. **Offer and accept the common RDF serializations for `CONSTRUCT`/`DESCRIBE`** (`text/turtle`, `application/n-triples`, `application/rdf+xml`, `application/ld+json`, `application/n-quads`, `application/trig`) instead of n-triples only. This removes both the Turtle false-negatives and the `406`s.

## Tests

Added coverage for an empty `CONSTRUCT` graph, a Turtle-serialized `CONSTRUCT` answer, and the broadened `Accept` header. Full suite: 69/69 pass, 100% line coverage.

## Downstream

Once released, bump `@lde/distribution-monitor` and then `network-of-terms-status` to pick this up.
