### PR TITLE
fix(distribution-monitor): reconcile schema via pushSchema diff, not full DDL each boot

### DIFF
--- a/packages/distribution-monitor/src/store.ts
+++ b/packages/distribution-monitor/src/store.ts
@@ -18,51 +18,60 @@ export class PostgresObservationStore implements ObservationStore {
   }
 
   /**
-   * Create a new store and initialize the database schema.
+   * Create a new store and reconcile the database schema with {@link schema}.
    *
-   * Uses drizzle-kit's generateMigration to create schema from code.
-   * This approach works around a bug in pushSchema where the execute()
-   * return format doesn't match what drizzle-kit expects.
-   * See: https://github.com/drizzle-team/drizzle-orm/issues/5293
+   * Uses drizzle-kit's `pushSchema` to diff the declared schema against the live
+   * database and apply only the difference, so an already-provisioned database
+   * issues no DDL — no needless, lock-taking index re-creation on every start.
+   *
+   * drizzle-kit's push adapter expects `execute()` to return `{ rows }`, but
+   * drizzle-orm's postgres-js driver resolves to a bare array, so the database
+   * is wrapped to re-shape the result. See
+   * https://github.com/drizzle-team/drizzle-orm/issues/5293.
    */
   static async create(
     connectionString: string,
   ): Promise<PostgresObservationStore> {
     const store = new PostgresObservationStore(connectionString);
-    const { generateDrizzleJson, generateMigration } =
-      await import('drizzle-kit/api-postgres');
+    const { pushSchema } = await import('drizzle-kit/api-postgres');
 
-    // Generate migration from empty state to our schema
-    const empty = await generateDrizzleJson({});
-    const target = await generateDrizzleJson(schema, empty.id);
-    const migration = await generateMigration(empty, target);
+    // #5293 shim: drizzle-kit reads `.rows` off the execute() result, which the
+    // postgres-js driver returns as a bare array. Wrap it back into `{ rows }`.
+    const pushAdapter = {
+      execute: async (query: Parameters<PostgresJsDatabase['execute']>[0]) => ({
+        rows: await store.db.execute(query),
+      }),
+    } as unknown as PostgresJsDatabase;
 
-    // Execute each statement, ignoring "already exists" errors for idempotency
-    for (const statement of migration) {
-      try {
-        await store.db.execute(sql.raw(statement));
-      } catch (error) {
-        // Check both direct error and cause for "already exists"
-        const isAlreadyExists = (e: unknown): boolean => {
-          if (!(e instanceof Error)) return false;
-          if (e.message.includes('already exists')) return true;
-          if ('cause' in e) return isAlreadyExists(e.cause);
-          return false;
-        };
-        if (!isAlreadyExists(error)) {
-          throw error;
-        }
-      }
-    }
+    const { sqlStatements } = await pushSchema(schema, pushAdapter);
 
-    // Create unique index on materialized view for CONCURRENTLY refresh
-    try {
-      await store.db.execute(
-        sql`CREATE UNIQUE INDEX latest_observations_monitor_idx ON latest_observations (monitor)`,
+    // `pushSchema` is state-based, so a removed or retyped column diffs to a
+    // destructive statement. Refuse to drop data-bearing objects automatically —
+    // that needs a deliberate migration, not an app-start side effect. Dropping
+    // an index is a safe rebuild and stays allowed.
+    const destructive = sqlStatements.find((statement) =>
+      /\bDROP\s+(TABLE|MATERIALIZED\s+VIEW)\b|\bDROP\s+COLUMN\b/i.test(
+        statement,
+      ),
+    );
+    if (destructive) {
+      throw new Error(
+        `Refusing to apply a data-loss schema change automatically: ${destructive}`,
       );
-    } catch {
-      // Index may already exist
     }
+
+    for (const statement of sqlStatements) {
+      await store.db.execute(sql.raw(statement));
+    }
+
+    // The unique index on the materialized view is required for
+    // REFRESH ... CONCURRENTLY but is not modelled by drizzle's
+    // `pgMaterializedView`, so `pushSchema` never emits it. Create it
+    // idempotently — `IF NOT EXISTS` matches by name and skips (no rebuild) when
+    // it already exists.
+    await store.db.execute(
+      sql`CREATE UNIQUE INDEX IF NOT EXISTS latest_observations_monitor_idx ON latest_observations (monitor)`,
+    );
 
     return store;
   }

--- a/packages/distribution-monitor/test/store.test.ts
+++ b/packages/distribution-monitor/test/store.test.ts
@@ -80,13 +80,20 @@ describe('PostgresObservationStore', () => {
       expect(latest.get('monitor-b')?.success).toBe(true);
     });
 
-    it('handles schema re-initialization on existing database', async () => {
-      // Close and recreate store to test idempotent schema push
+    it('reconciles an existing database idempotently, without data loss', async () => {
+      // Re-create the store against the already-provisioned database. The
+      // declarative push must diff to an empty change set, so previously stored
+      // observations survive (a destructive re-create would drop them).
       await store.close();
       store = await PostgresObservationStore.create(
         container.getConnectionUri(),
       );
       expect(store).toBeDefined();
+
+      await store.refreshLatestObservationsView();
+      const latest = await store.getLatest();
+      expect(latest.get('monitor-a')?.success).toBe(false);
+      expect(latest.get('monitor-b')?.success).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Why

`PostgresObservationStore.create()` regenerated the full schema from an empty state on **every** startup and fired every `CREATE`, swallowing `already exists` for idempotency. That re-attempted lock-taking DDL — notably `CREATE UNIQUE INDEX` on the `latest_observations` materialized view — against an already-provisioned database on every boot.

In production this contributed to a multi-hour startup stall: when those locks were contended (a rolling deploy), the `CREATE INDEX` waited indefinitely (no `lock_timeout`), and the service couldn’t come up until the lock cleared.

## What

Switch `create()` to drizzle-kit’s **`pushSchema`**, which diffs the declared schema against the **live** database and applies only the delta:

- An already-provisioned database yields **zero statements** → no needless, lock-taking index re-creation on startup.
- Real schema changes still apply automatically on boot — no separate migration step — so schema evolution comes for free.

Details:

- **#5293 shim.** drizzle-kit’s push adapter reads `.rows` off `execute()`, but drizzle-orm’s postgres-js driver resolves to a bare array. The instance is wrapped to re-shape the result back into `{ rows }`. See drizzle-team/drizzle-orm#5293.
- **Materialized-view unique index.** Not modelled by drizzle’s `pgMaterializedView`, so `pushSchema` never emits it. It stays a guarded `CREATE UNIQUE INDEX IF NOT EXISTS` — matches by name, so it skips (no rebuild) when present.
- **Data-loss guard.** `pushSchema` is state-based, so a removed/retyped column would diff to a destructive statement. `create()` refuses to auto-apply `DROP TABLE`/`MATERIALIZED VIEW`/`COLUMN` — those need a deliberate migration, not an app-start side effect. Index drops/rebuilds stay allowed.

## Tests

The integration test (testcontainers) is strengthened to prove re-initialisation is idempotent **and non-destructive**: after a second `create()` against the provisioned database, previously stored observations survive (a destructive re-create would drop them). Full `store.test.ts` suite: 5/5 pass against real Postgres; the log shows the index reporting `already exists, skipping` (no rebuild) on re-init.

## Downstream

Once released, bump `@lde/distribution-monitor` in `network-of-terms-status`.
