### PR TITLE
feat(distribution-monitor): set lock and statement timeouts on the DB connection

### DIFF
--- a/packages/distribution-monitor/src/store.ts
+++ b/packages/distribution-monitor/src/store.ts
@@ -8,13 +8,32 @@ const { observations, latestObservations, refreshLatestObservationsViewSql } =
   schema;
 
 /**
+ * Per-session Postgres timeouts applied to every pooled connection. A statement
+ * that cannot acquire its lock within `lock_timeout` — most importantly the
+ * periodic `REFRESH MATERIALIZED VIEW CONCURRENTLY`, and the boot-time index
+ * check — fails fast and is retried on the next cycle, rather than hanging
+ * indefinitely on a contended lock (which once stalled startup for hours).
+ * `statement_timeout` is a generous backstop against a single runaway query.
+ */
+const LOCK_TIMEOUT_MS = 30_000;
+const STATEMENT_TIMEOUT_MS = 60_000;
+
+/**
  * PostgreSQL implementation of the ObservationStore interface.
  */
 export class PostgresObservationStore implements ObservationStore {
   private db: PostgresJsDatabase;
 
   private constructor(connectionString: string) {
-    this.db = drizzle(connectionString);
+    this.db = drizzle({
+      connection: {
+        url: connectionString,
+        connection: {
+          lock_timeout: LOCK_TIMEOUT_MS,
+          statement_timeout: STATEMENT_TIMEOUT_MS,
+        },
+      },
+    });
   }
 
   /**

--- a/packages/distribution-monitor/test/store.test.ts
+++ b/packages/distribution-monitor/test/store.test.ts
@@ -3,6 +3,8 @@ import {
   PostgreSqlContainer,
   StartedPostgreSqlContainer,
 } from '@testcontainers/postgresql';
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { PostgresObservationStore } from '../src/store.js';
 
 describe('PostgresObservationStore', () => {
@@ -28,6 +30,15 @@ describe('PostgresObservationStore', () => {
 
     it('initializes schema on first run', () => {
       expect(store).toBeDefined();
+    });
+
+    it('applies lock and statement timeouts to its connection', async () => {
+      // Read the GUCs back off the store's own pooled connection.
+      const db = (store as unknown as { db: PostgresJsDatabase }).db;
+      const [lock] = await db.execute(sql`SHOW lock_timeout`);
+      const [statement] = await db.execute(sql`SHOW statement_timeout`);
+      expect(lock.lock_timeout).toBe('30s');
+      expect(statement.statement_timeout).toBe('1min');
     });
 
     it('stores and retrieves observations', async () => {


### PR DESCRIPTION
## Why

A blocked Postgres statement had no time bound. In production the periodic `REFRESH MATERIALIZED VIEW CONCURRENTLY latest_observations` waited on a contended lock and hung for hours; with `RUN_ON_START` enabled at the time, the boot-time `CREATE INDEX` did the same. Without `lock_timeout`/`statement_timeout`, those waits are unbounded.

## What

Apply two session GUCs to **every** pooled connection (via postgres-js's `connection` option, so they’re sent in each connection’s startup packet):

- `lock_timeout = 30s` — a statement that cannot acquire its lock fails fast instead of waiting indefinitely. Well under the default 5-minute poll interval, so a contended refresh simply errors and is retried on the next cycle (data is stale for one interval, not hung).
- `statement_timeout = 60s` — a generous backstop against a single runaway query.

This is defence in depth alongside the two other changes: the `pushSchema` rework removed the per-boot DDL, and `RUN_ON_START=false` took the initial check off the startup path — but the recurring cron refresh is unaffected by those, and this guard bounds it.

## Tests

Adds an integration test (testcontainers) asserting the store’s own connection reports `lock_timeout = 30s` and `statement_timeout = 1min` via `SHOW`. Full `store.test.ts` suite: 6/6 pass.
