### PR TITLE
fix(pipeline): preserve reporter `this` when forwarding to combined reporters

### DIFF
--- a/packages/pipeline/src/combineReporters.ts
+++ b/packages/pipeline/src/combineReporters.ts
@@ -36,7 +36,10 @@ export function combineReporters(
         | ((...handlerArgs: ReporterArguments<Method>) => void)
         | undefined;
       // Every method is optional; notify only the children that implement it.
-      handler?.(...args);
+      // Invoke through `call` so a class-based reporter keeps its `this`: a bare
+      // `handler?.(...)` would drop the receiver and break methods that touch
+      // instance state (e.g. ConsoleReporter’s spinner).
+      handler?.call(reporter, ...args);
     }
   };
 

--- a/packages/pipeline/test/combineReporters.test.ts
+++ b/packages/pipeline/test/combineReporters.test.ts
@@ -97,4 +97,21 @@ describe('combineReporters', () => {
   it('is a no-op for an empty array of reporters', () => {
     expect(() => combineReporters([]).pipelineStart?.('run')).not.toThrow();
   });
+
+  it('preserves a class-based reporter’s `this` receiver', () => {
+    // A plain-object reporter never exercises `this`; a class method that reads
+    // instance state does, and regressed when forwarding dropped the receiver.
+    class CountingReporter implements ProgressReporter {
+      calls = 0;
+      pipelineStart(): void {
+        this.calls += 1;
+      }
+    }
+    const reporter = new CountingReporter();
+
+    expect(() =>
+      combineReporters([reporter]).pipelineStart?.('run'),
+    ).not.toThrow();
+    expect(reporter.calls).toBe(1);
+  });
 });


### PR DESCRIPTION
## What

`combineReporters` forwarded each lifecycle call as a bare `handler?.(...args)`, calling the method **unbound**. Class-based reporters that touch instance state then crash on the first call:

```
TypeError: Cannot read properties of undefined (reading ‘startSpinner’)
    at pipelineStart (…/@lde/pipeline-console-reporter/dist/consoleReporter.js:37:14)
    at forward (…/@lde/pipeline/dist/combineReporters.js:22:22)
    at Pipeline.run (…/@lde/pipeline/dist/pipeline.js:129:39)
```

`ConsoleReporter.pipelineStart` calls `this.startSpinner(...)`, but `this` was `undefined`.

## Fix

Invoke through `handler.call(reporter, ...args)` so the receiver is preserved. Plain-object reporters (the only kind the existing tests used) were unaffected, which is why this slipped through – added a class-based reporter regression test that fails before the fix.

## Impact

This broke any consumer passing a class-based reporter through the combined path. It took down the dataset-knowledge-graph cron job, which registers `[new ConsoleReporter(), …]` and crashes at startup before selecting any datasets.

## Verification

- `npx nx test @lde/pipeline` – green, `combineReporters.ts` at 100% coverage
- `npx nx build @lde/pipeline` – green
