### PR TITLE
feat(search): pin @lde/text-normalization to an exact version

### DIFF
--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -25,7 +25,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@lde/text-normalization": "^0.0.0",
+    "@lde/text-normalization": "0.0.0",
     "@rdfjs/types": "^2.0.1",
     "@tpluscode/rdf-ns-builders": "^5.0.0",
     "jsonld": "^9.0.0",


### PR DESCRIPTION
## What

Pin `@lde/search`'s intra-repo dependency on `@lde/text-normalization` to an exact version (`0.0.0`) instead of the caret range `^0.0.0`, matching every other intra-repo dependency in the monorepo (e.g. `@lde/dataset-registry-client` → `@lde/dataset` `"0.7.7"`).

## Why

`nx release version` aborts on the caret range. With `preserveMatchingDependencyRanges` enabled, once `@lde/text-normalization` bumps, the new version falls outside `^0.0.0`, so nx refuses to rewrite it and the release crashes:

```
"preserveMatchingDependencyRanges" is enabled … the new version is outside the current range
for "@lde/text-normalization" in packages/search/package.json. Please update the range before releasing.
```

An exact pin lets nx rewrite the range to the new version on release, exactly as it already does for every other intra-repo dependency. This unblocks releasing the new `@lde/search*` packages.
