### PR TITLE
feat(pipeline): add expectsOutput to fail a stage that yields no quads

### DIFF
--- a/packages/pipeline-void/src/stage.ts
+++ b/packages/pipeline-void/src/stage.ts
@@ -126,6 +126,7 @@ async function createVoidStage(
     perClass?: boolean;
     batchSize?: number;
     maxConcurrency?: number;
+    expectsOutput?: boolean;
   },
 ): Promise<Stage> {
   const query = await readQueryFile(resolve(queriesDir, filename));
@@ -140,6 +141,7 @@ async function createVoidStage(
     itemSelector: options?.perClass ? classSelector() : undefined,
     batchSize: options?.batchSize,
     maxConcurrency: options?.maxConcurrency,
+    expectsOutput: options?.expectsOutput,
   });
 }
 
@@ -187,26 +189,46 @@ export function classPartitions(options?: VoidStageOptions): Promise<Stage> {
   return createVoidStage(VOID_STAGE_NAMES.classPartitions, options);
 }
 
+// Scalar-aggregate counts: each query is a single COUNT with no GROUP BY/HAVING,
+// so it always returns exactly one row. Zero output therefore means the endpoint
+// truncated the response, so they set `expectsOutput` to fail (and trigger the
+// reactive dump fallback) rather than store a missing count.
+
 export function countObjectLiterals(
   options?: VoidStageOptions,
 ): Promise<Stage> {
-  return createVoidStage(VOID_STAGE_NAMES.objectLiterals, options);
+  return createVoidStage(VOID_STAGE_NAMES.objectLiterals, {
+    ...options,
+    expectsOutput: true,
+  });
 }
 
 export function countObjectUris(options?: VoidStageOptions): Promise<Stage> {
-  return createVoidStage(VOID_STAGE_NAMES.objectUris, options);
+  return createVoidStage(VOID_STAGE_NAMES.objectUris, {
+    ...options,
+    expectsOutput: true,
+  });
 }
 
 export function countProperties(options?: VoidStageOptions): Promise<Stage> {
-  return createVoidStage(VOID_STAGE_NAMES.properties, options);
+  return createVoidStage(VOID_STAGE_NAMES.properties, {
+    ...options,
+    expectsOutput: true,
+  });
 }
 
 export function countSubjects(options?: VoidStageOptions): Promise<Stage> {
-  return createVoidStage(VOID_STAGE_NAMES.subjects, options);
+  return createVoidStage(VOID_STAGE_NAMES.subjects, {
+    ...options,
+    expectsOutput: true,
+  });
 }
 
 export function countTriples(options?: VoidStageOptions): Promise<Stage> {
-  return createVoidStage(VOID_STAGE_NAMES.triples, options);
+  return createVoidStage(VOID_STAGE_NAMES.triples, {
+    ...options,
+    expectsOutput: true,
+  });
 }
 
 export function classPropertySubjects(
@@ -228,6 +250,9 @@ export function classPropertyObjects(
 }
 
 export function countDatatypes(options?: VoidStageOptions): Promise<Stage> {
+  // No expectsOutput: unlike the other counts, this query joins the scalar
+  // count with a `SELECT DISTINCT ?datatype` group, so a dataset with no
+  // literals yields zero rows — a legitimately empty result, not a truncation.
   return createVoidStage(VOID_STAGE_NAMES.datatypes, options);
 }
 

--- a/packages/pipeline-void/test/sparqlQueryAnalyzer.test.ts
+++ b/packages/pipeline-void/test/sparqlQueryAnalyzer.test.ts
@@ -1,4 +1,13 @@
-import { countTriples, countProperties, Stage } from '../src/index.js';
+import {
+  countTriples,
+  countProperties,
+  countSubjects,
+  countObjectLiterals,
+  countObjectUris,
+  countDatatypes,
+  classPartitions,
+  Stage,
+} from '../src/index.js';
 import { describe, it, expect } from 'vitest';
 
 describe('named stage functions', () => {
@@ -14,5 +23,27 @@ describe('named stage functions', () => {
 
     expect(stage).toBeInstanceOf(Stage);
     expect(stage.name).toBe('properties.rq');
+  });
+
+  it('marks scalar-aggregate counts as expectsOutput', async () => {
+    // Each is a single COUNT with no GROUP BY/HAVING, so an empty result can
+    // only mean a truncated endpoint response.
+    const counts = await Promise.all([
+      countTriples(),
+      countSubjects(),
+      countProperties(),
+      countObjectLiterals(),
+      countObjectUris(),
+    ]);
+    for (const stage of counts) {
+      expect(stage.expectsOutput).toBe(true);
+    }
+  });
+
+  it('leaves stages that may legitimately be empty unmarked', async () => {
+    // class-partition groups by class; datatypes joins a non-aggregate group —
+    // both can be validly empty, so neither expects output.
+    expect((await classPartitions()).expectsOutput).toBe(false);
+    expect((await countDatatypes()).expectsOutput).toBe(false);
   });
 });

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -86,6 +86,12 @@ new Stage({
 
 `maxConcurrency` (default: 10) limits the total number of concurrent SPARQL queries. Within each batch, all executors run in parallel; the number of concurrent batches is automatically reduced to `⌊maxConcurrency / executorCount⌋` so the total query pressure stays within the limit. For example, with `maxConcurrency: 10` and two executors per stage, up to 5 batches run concurrently (10 SPARQL queries total).
 
+#### Expecting output
+
+`expectsOutput` (default: `false`) marks a stage whose query must yield at least one quad. A supported stage that produces none is then treated as a hard failure rather than a legitimately empty result.
+
+Set it for scalar aggregates such as `SELECT (COUNT(*) AS ?n)`, which always return exactly one row — so zero output can only mean the endpoint truncated or aborted the response (e.g. a timeout surfaced as an empty `HTTP 200`). The failure flows through like any other hard stage failure, triggering the [reactive dump fallback](#distribution-resolver) when `strategy: 'sparqlWithImportFallback'` is configured. Leave it `false` for stages that may legitimately be empty, such as class or property partitions of a dataset that lacks that structure.
+
 ### Item Selector
 
 Selects resources from the distribution and fans out executor calls per batch of results. Implements the `ItemSelector` interface:

--- a/packages/pipeline/src/stage.ts
+++ b/packages/pipeline/src/stage.ts
@@ -215,13 +215,17 @@ export class Stage {
           );
         }
       }
-    } else {
+    } else if (this.expectsOutput) {
+      // Only thread the per-quad counter through when the count is actually
+      // needed; the default path stays a plain streaming write with no overhead.
       await writer.write(
         dataset,
         countQuads(mergeStreams(streams), (count) => {
           produced = count;
         }),
       );
+    } else {
+      await writer.write(dataset, mergeStreams(streams));
     }
 
     this.assertProduced(produced);
@@ -507,6 +511,10 @@ async function* mergeStreams(
  * Pass a quad stream through unchanged while counting it, reporting the total
  * via `onCount` once the stream is exhausted. Lets a streaming write enforce
  * {@link StageOptions.expectsOutput} without buffering.
+ *
+ * `onCount` fires only when the consumer drains the stream — which the pipeline
+ * writers do. A writer that stops early would leave the count short; callers
+ * relying on it for `expectsOutput` must consume the stream fully.
  */
 async function* countQuads(
   stream: AsyncIterable<Quad>,

--- a/packages/pipeline/src/stage.ts
+++ b/packages/pipeline/src/stage.ts
@@ -134,12 +134,13 @@ export interface SelectOptions {
 export class Stage {
   readonly name: string;
   readonly stages: readonly Stage[];
+  /** Whether an empty result is treated as a hard failure. @see {@link StageOptions.expectsOutput} */
+  readonly expectsOutput: boolean;
   private readonly executors: NormalizedExecutor[];
   private readonly itemSelector?: ItemSelector;
   private readonly batchSize: number;
   private readonly maxConcurrency: number;
   private readonly validation?: StageOptions['validation'];
-  private readonly expectsOutput: boolean;
 
   constructor(options: StageOptions) {
     this.name = options.name;

--- a/packages/pipeline/src/stage.ts
+++ b/packages/pipeline/src/stage.ts
@@ -89,6 +89,23 @@ export interface StageOptions {
   maxConcurrency?: number;
   /** Child stages that chain off this stage's output. */
   stages?: Stage[];
+  /**
+   * Treat a supported stage that produces no quads as a hard failure (throws),
+   * rather than a legitimately empty result.
+   *
+   * Set this for stages whose query must yield output — typically a scalar
+   * aggregate such as `SELECT (COUNT(*) AS ?n)`, which always returns exactly
+   * one row, so zero quads can only mean the endpoint truncated or aborted the
+   * response (e.g. a timeout surfaced as an empty `HTTP 200`). The resulting
+   * failure flows through the pipeline like any other hard stage failure,
+   * triggering the reactive dump fallback when one is configured.
+   *
+   * Leave it `false` (default) for stages that may legitimately be empty, such
+   * as class/property partitions of a dataset that lacks that structure.
+   *
+   * @default false
+   */
+  expectsOutput?: boolean;
   /** Optional validation of the combined quads produced by all executors per batch. */
   validation?: {
     validator: Validator;
@@ -122,6 +139,7 @@ export class Stage {
   private readonly batchSize: number;
   private readonly maxConcurrency: number;
   private readonly validation?: StageOptions['validation'];
+  private readonly expectsOutput: boolean;
 
   constructor(options: StageOptions) {
     this.name = options.name;
@@ -131,6 +149,7 @@ export class Stage {
     this.batchSize = options.batchSize ?? 10;
     this.maxConcurrency = options.maxConcurrency ?? 10;
     this.validation = options.validation;
+    this.expectsOutput = options.expectsOutput ?? false;
   }
 
   /** The validator for this stage, if configured. */
@@ -162,6 +181,10 @@ export class Stage {
       return streams;
     }
 
+    // Quads the executors produced (before any validation filtering); used to
+    // enforce `expectsOutput` below.
+    let produced = 0;
+
     if (this.validation) {
       const buffer: Quad[] = [];
       for (const stream of streams) {
@@ -169,6 +192,7 @@ export class Stage {
           buffer.push(quad);
         }
       }
+      produced = buffer.length;
       const onInvalid = this.validation.onInvalid ?? 'write';
       if (onInvalid === 'write') {
         await Promise.all([
@@ -192,7 +216,25 @@ export class Stage {
         }
       }
     } else {
-      await writer.write(dataset, mergeStreams(streams));
+      await writer.write(
+        dataset,
+        countQuads(mergeStreams(streams), (count) => {
+          produced = count;
+        }),
+      );
+    }
+
+    this.assertProduced(produced);
+  }
+
+  /**
+   * Throw when {@link StageOptions.expectsOutput} is set but the stage produced
+   * no quads — a supported-but-empty result that signals a truncated or aborted
+   * endpoint response rather than a legitimately empty one.
+   */
+  private assertProduced(produced: number): void {
+    if (this.expectsOutput && produced === 0) {
+      throw new Error(`Stage '${this.name}' expected output but produced none`);
     }
   }
 
@@ -352,6 +394,8 @@ export class Stage {
     if (!hasResults) {
       return new NotSupported('All executors returned NotSupported');
     }
+
+    this.assertProduced(quadsGenerated);
   }
 
   /**
@@ -457,6 +501,23 @@ async function* mergeStreams(
   for (const stream of streams) {
     yield* stream;
   }
+}
+
+/**
+ * Pass a quad stream through unchanged while counting it, reporting the total
+ * via `onCount` once the stream is exhausted. Lets a streaming write enforce
+ * {@link StageOptions.expectsOutput} without buffering.
+ */
+async function* countQuads(
+  stream: AsyncIterable<Quad>,
+  onCount: (count: number) => void,
+): AsyncIterable<Quad> {
+  let count = 0;
+  for await (const quad of stream) {
+    count++;
+    yield quad;
+  }
+  onCount(count);
 }
 
 /** Selects items (as variable bindings) for executors to process. Pagination is an implementation detail. */

--- a/packages/pipeline/test/pipeline.test.ts
+++ b/packages/pipeline/test/pipeline.test.ts
@@ -1462,6 +1462,60 @@ describe('Pipeline', () => {
         expect.objectContaining({ sourceFingerprint: dumpFingerprint }),
       );
     });
+
+    it('recovers via the dump when an expectsOutput stage is empty on the endpoint', async () => {
+      // End-to-end: a real stage whose query yields nothing on the endpoint
+      // (a truncated COUNT) but has data in the dump. expectsOutput turns the
+      // empty endpoint result into a hard failure that triggers the fallback.
+      const tripleQuad = DataFactory.quad(
+        DataFactory.namedNode('http://example.org/s'),
+        DataFactory.namedNode('http://example.org/p'),
+        DataFactory.namedNode('http://example.org/o'),
+      );
+      const executor = {
+        execute: async (_dataset: Dataset, distribution: Distribution) =>
+          distribution === endpointDistribution
+            ? // endpoint truncated: no rows
+              (async function* (): AsyncIterable<Quad> {
+                yield* [];
+              })()
+            : (async function* () {
+                yield tripleQuad;
+              })(),
+      };
+      const stage = new Stage({
+        name: 'triples-count',
+        executors: executor,
+        expectsOutput: true,
+      });
+
+      // A real writer that consumes the stream (the mock writer would not, so
+      // the produced-quad count would never advance).
+      const collected: Quad[] = [];
+      const consumingWriter: Writer = {
+        write: async (_dataset, quads) => {
+          for await (const quad of quads) collected.push(quad);
+        },
+        flush: vi.fn().mockResolvedValue(undefined),
+        reset: vi.fn(async () => {
+          collected.length = 0;
+        }),
+      };
+      const resolver = makeFallbackResolver();
+
+      const pipeline = new Pipeline({
+        datasetSelector: makeDatasetSelector(dataset),
+        stages: [stage],
+        writers: consumingWriter,
+        distributionResolver: resolver,
+      });
+
+      await pipeline.run();
+
+      expect(resolver.resolveFallback).toHaveBeenCalledTimes(1);
+      // Final stored output is the dump's, not the empty endpoint result.
+      expect(collected).toEqual([tripleQuad]);
+    });
   });
 
   describe('plugins', () => {

--- a/packages/pipeline/test/stage.test.ts
+++ b/packages/pipeline/test/stage.test.ts
@@ -1005,4 +1005,74 @@ describe('Stage', () => {
       expect(writer.quads.filter((q) => q.equals(q1))).toHaveLength(2);
     });
   });
+
+  describe('expectsOutput', () => {
+    it('throws when a supported stage produces no quads', async () => {
+      // A scalar aggregate (e.g. COUNT) always returns a row; zero output means
+      // the endpoint truncated the response — a hard failure, not an empty result.
+      const stage = new Stage({
+        name: 'triples-count',
+        executors: mockExecutor([]),
+        expectsOutput: true,
+      });
+
+      const writer = collectingWriter();
+      await expect(stage.run(dataset, distribution, writer)).rejects.toThrow(
+        /triples-count/,
+      );
+    });
+
+    it('does not throw when the stage produces quads', async () => {
+      const stage = new Stage({
+        name: 'triples-count',
+        executors: mockExecutor([q1]),
+        expectsOutput: true,
+      });
+
+      const writer = collectingWriter();
+      const result = await stage.run(dataset, distribution, writer);
+      expect(result).not.toBeInstanceOf(NotSupported);
+      expect(writer.quads).toEqual([q1]);
+    });
+
+    it('tolerates an empty result by default', async () => {
+      const stage = new Stage({
+        name: 'class-partition',
+        executors: mockExecutor([]),
+      });
+
+      const writer = collectingWriter();
+      const result = await stage.run(dataset, distribution, writer);
+      expect(result).not.toBeInstanceOf(NotSupported);
+      expect(writer.quads).toEqual([]);
+    });
+
+    it('returns NotSupported (not a failure) when the executor is unsupported', async () => {
+      // expectsOutput concerns a supported-but-empty response; an unsupported
+      // executor is a skip, never a hard failure.
+      const stage = new Stage({
+        name: 'triples-count',
+        executors: notSupportedExecutor(),
+        expectsOutput: true,
+      });
+
+      const writer = collectingWriter();
+      const result = await stage.run(dataset, distribution, writer);
+      expect(result).toBeInstanceOf(NotSupported);
+    });
+
+    it('throws for an item-selected stage that produces no quads', async () => {
+      const stage = new Stage({
+        name: 'per-class-count',
+        itemSelector: mockItemSelector([{ class: namedNode('http://x') }]),
+        executors: mockExecutor([]),
+        expectsOutput: true,
+      });
+
+      const writer = collectingWriter();
+      await expect(stage.run(dataset, distribution, writer)).rejects.toThrow(
+        /per-class-count/,
+      );
+    });
+  });
 });

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 96.27,
-          lines: 95.72,
-          branches: 90.92,
-          statements: 95.11,
+          functions: 96.33,
+          lines: 95.78,
+          branches: 91.02,
+          statements: 95.17,
         },
       },
     },

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 96.33,
-          lines: 95.78,
-          branches: 91.02,
-          statements: 95.17,
+          lines: 95.79,
+          branches: 91.06,
+          statements: 95.18,
         },
       },
     },


### PR DESCRIPTION
## Summary

Follow-up to #514 (reactive dump fallback): adds the **incoherent-empty detection** deferred there, as a generic opt-in stage option, **and arms it in `@lde/pipeline-void`** so the RAZU silent-empty case is actually caught.

`@lde/pipeline` is generic and has no VoID semantics, so it cannot run the cross-stage coherence check #445 sketched (`triples = 0` while `classPartition` is non-empty). But there is a sound, generic per-stage invariant it *can* enforce: a scalar aggregate such as `SELECT (COUNT(*) AS ?n)` (no `GROUP BY`, no `HAVING`) always returns exactly one row, so **zero output can only mean the endpoint truncated or aborted the response** (a timeout surfaced as an empty `HTTP 200` — the RAZU `https://data.razu.nl/id/dataset/kranten` case).

## Changes

**`@lde/pipeline`**
- Adds `StageOptions.expectsOutput` (default `false`). A *supported* stage marked `expectsOutput` that produces **zero quads** now throws — an ordinary hard stage failure, so it flows through the existing `runStages` → reactive dump fallback (`strategy: 'sparqlWithImportFallback'`) with no extra wiring.
- Quads are counted through the streaming write path **only when `expectsOutput` is set** (the default path stays a plain streaming write, no overhead); works for global and item-selected stages.
- `NotSupported` (unsupported executor) is still a skip, never a failure.
- `Stage.expectsOutput` is exposed as a public readonly for introspection.

**`@lde/pipeline-void`**
- Marks the five scalar-aggregate counts — `triples`, `distinctSubjects`, `properties`, `distinctLiterals`, `distinctIRIReferenceObjects` — with `expectsOutput: true`.
- Deliberately leaves `countDatatypes` (joins a non-aggregate `SELECT DISTINCT ?datatype`, so empty is legal) and the `GROUP BY` partition stages unmarked.

## Why per-stage, declared (not inferred)

The pipeline only sees a CONSTRUCT query string and can’t reliably tell a scalar aggregate (must be non-empty) from a grouped one (may be empty) by AST inspection — and VoID specifics live in the consumer. Declaring the expectation per stage keeps the pipeline generic while letting `@lde/pipeline-void` opt the precise stages in. This is a narrow, additive output expectation, not a required/optional stage split.

## Follow-up

To close the RAZU half of netwerk-digitaal-erfgoed/dataset-knowledge-graph#133, DKG bumps to the versions carrying this PR (it already opted into `sparqlWithImportFallback` in dataset-knowledge-graph#390).

Relates to #445.
