### PR TITLE
docs: add ADRs for the search API core query model and GraphQL surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ The `@nx/js:library` generator’s output diverges from the conventions in this 
    - `name` → `@lde/<new-name>`
    - `description` — write something useful
    - `repository.directory` → `packages/<new-name>`
-   - `version` → `0.0.0` from the get-go (do NOT keep the sibling’s version). nx release bumps from there via conventional commits, so the introducing `feat:` commit lands the first release at `0.1.0`; any higher starting version overshoots it. This must be in place before the PR merges — see [Releasing a new package](#releasing-a-new-package).
+   - `version` → `0.1.0` from the get-go (do NOT keep the sibling’s version). nx release bumps from there via conventional commits, so the introducing `feat:` commit lands the first release at `0.1.0`; any higher starting version overshoots it. This must be in place before the PR merges — see [Releasing a new package](#releasing-a-new-package).
    - `dependencies` and `peerDependencies` — replace with what the new package actually needs
 4. **Replace the source.** Empty out `src/` and `test/`, write the new code.
 5. **Update `tsconfig.lib.json` `references`** to match the new package’s actual `@lde/*` peers.
@@ -128,8 +128,6 @@ For releasing the new package’s first version, see [Releasing a new package](#
 #### Releasing a new package
 
 `.github/workflows/release.yml` publishes existing packages on every push to main, but the CI workflow alone cannot bring up a brand-new `@lde/<name>` package: npm’s Trusted Publisher configuration can only be added to a package that already exists on the registry. The first version has to be published manually by a maintainer; CI takes over from the second version onwards.
-
-The package’s `version` must already be `0.0.0` before the PR merges (set in [Creating New Packages](#creating-new-packages) step 3) so the introducing `feat:` commit publishes `0.1.0`.
 
 One-time bootstrap for a new package (do this once it has been merged to main):
 

--- a/docs/decisions/0003-search-api-core-query-model.md
+++ b/docs/decisions/0003-search-api-core-query-model.md
@@ -1,0 +1,253 @@
+# 3. Search API core query model
+
+Date: 2026-06-25
+
+## Status
+
+Proposed
+
+Reconciles against the NDE stack platform docs
+(`netwerk-digitaal-erfgoed/docs` → `docs/stack/layers/platform.md`), which are themselves
+a **draft under discussion**, so several decisions below are deliberate deviations from
+the current draft, to be reconciled back into it.
+
+## Context
+
+The Dataset Register is moving its browser search off direct Typesense queries onto a
+search API, API-first and GraphQL-first (REST deferred). We want the API configured from a
+declarative source so the GraphQL surface, a later REST surface, and the index cannot drift
+from each other, and so a deployment can swap search engines without consumers noticing.
+
+That requires an engine- and protocol-neutral **core** that both API surfaces and any
+engine adapter sit on. The platform draft frames this as Ports & Adapters with a framed
+JSON-LD intermediate representation, generated from SHACL + a `search:` annotation
+vocabulary. We adopt that direction but scope it to what a v1 keyword search needs, and
+diverge on a few concrete points where the draft does not fit DR’s catalog-search case.
+
+## Decision
+
+### Package family
+
+Two tiers: `search-*` is backend you compose; `search-api-*` is the surface you publish.
+
+| Tier        | Package                   | Responsibility                                                                                                          |
+| ----------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| backend     | `@lde/search`             | field model · `SearchQuery` · filter semantics · adapter port                                                           |
+| backend     | `@lde/search-typesense`   | engine adapter: collection schema · query/filter compiler · `search()`                                                  |
+| API surface | `@lde/search-api-graphql` | field model + `SearchQuery` → GraphQL schema (runtime configuration; see [ADR 4](./0004-search-api-graphql-surface.md)) |
+| API surface | `@lde/search-api-rest`    | OpenAPI + route handlers (later, thin over the core)                                                                    |
+
+This deviates from the draft’s function-mapping table (`@lde/graphql-server`,
+`@lde/rest-server`, no core row); the draft should adopt the `@lde/search*` family.
+
+### Contract frozen, storage swappable
+
+The **API contract** (the SDL shape consumers couple to) is breaking to change and must be
+right in v1. The **IR / stored document** (framed JSON-LD vs a flat engine doc) lives
+behind the adapter and is swappable with no consumer impact. Nothing engine-specific
+(companion fields, `int32`, the engine query language) and nothing RDF-specific
+(`@context`, `@id`, IRI-keyed predicates) leaks past the adapter port.
+
+### Field model
+
+The engine-neutral description of a queryable field – the runtime form of one SHACL
+NodeShape + its `search:` annotations:
+
+```ts
+type FieldKind =
+  | 'text'
+  | 'keyword'
+  | 'integer'
+  | 'number'
+  | 'boolean'
+  | 'date'
+  | 'reference';
+
+interface SearchField {
+  readonly name: string; // logical API name
+  readonly kind: FieldKind;
+  readonly array?: boolean;
+  readonly localized?: boolean;
+  readonly output?: boolean; // appears in the schema output type
+  readonly searchable?: { weight: number }; // free-text inclusion + weight
+  readonly filterable?: boolean; // usable in `where`
+  readonly facetable?: boolean;
+  readonly sortable?: boolean;
+  readonly nestedStrategy?: 'labelOnly' | 'idOnly' | 'inline'; // for `reference`
+  readonly group?: { readonly name: string; readonly prefix: string }; // deployment delta
+}
+
+interface SearchSchema {
+  readonly fields: readonly SearchField[];
+}
+```
+
+Maps onto SHACL + `search:` (`kind`←`sh:datatype`, `array`←`sh:maxCount`,
+`localized`←`sh:languageIn`, `facetable`←`search:facetable`, `sortable`←`search:sortable`,
+`nestedStrategy`←`sh:node`/`sh:class` + `search:nestedStrategy`) so an eventual generator
+emits it unchanged. The `group` companion (coarse grouped facets, e.g. `format_group`) and
+the `status_rank` tie-break sort are **deployment-specific deltas**, never in `@lde/search`.
+`relevance` is _not_ a delta: every full-text engine ranks by match score, so it is a
+generic reserved sort the adapter understands.
+
+### `SearchQuery` – the neutral query IR
+
+Both surfaces parse input into this; the adapter consumes this. It is the shared compiler
+target that keeps GraphQL and REST from drifting.
+
+```ts
+interface SearchQuery {
+  readonly text?: string; // undefined/'' = browse
+  readonly where: readonly Filter[]; // AND across fields
+  readonly orderBy: readonly Sort[];
+  readonly limit: number; // numbered pagination
+  readonly offset: number;
+  readonly facets: readonly string[];
+  readonly locale: string; // from Accept-Language; selects per-locale fields
+}
+
+type Filter =
+  | { readonly field: string; readonly in: readonly string[] } // keyword membership, OR within field
+  | {
+      readonly field: string;
+      readonly range: { min?: number | string; max?: number | string };
+    }
+  | { readonly field: string; readonly is: boolean };
+
+interface Sort {
+  readonly field: string;
+  readonly direction: 'asc' | 'desc';
+}
+```
+
+`locale` drives query-side field selection only; output language ordering is a surface
+concern. Deployment defaults (e.g. status=valid, default sort) are consumer policy applied
+when building the query, not baked into the core.
+
+Sorting has two tiers. A field’s `sortable` flag marks it **publicly selectable** in the
+surface’s `orderBy`, alongside the generic `relevance` – so a user can sort by `relevance`
+(the sane default when there is a query) or by any sortable field (title, date, size). The
+adapter can _additionally_ sort by any indexed field a deployment’s `queryDefaults`
+references – e.g. DR’s `status_rank` tie-break – which is never exposed as a public sort
+option.
+
+The public `orderBy` is a **single** primary sort; the surface composes it with the server
+tie-break(s) into this internal `Sort[]`. A client-supplied array can be added
+later, but it is backward-compatible only for inline-literal clients (list input coercion);
+variable-based clients (`$o: DatasetOrderBy`) break, so a future array is a deliberate change.
+
+### Filter semantics
+
+| `kind`                        | `where`                          | facet         | sort            |
+| ----------------------------- | -------------------------------- | ------------- | --------------- |
+| `text`                        | – (feeds `text`)                 | –             | yes (localized) |
+| `keyword` / `reference`       | `in` (exact membership)          | yes           | –               |
+| `integer` / `number` / `date` | `range { min?, max? }` inclusive | range buckets | yes             |
+| `boolean`                     | `is`                             | yes           | –               |
+
+**Inclusive bounds only** – `min`/`max`, no `gt`/`gte`/`lt`/`lte`: self-documenting,
+matches Typesense’s native inclusive range, covers every DR case, additively reversible.
+Grouped facets need no special shape – `group:`-prefixed tokens travel as ordinary `in`
+strings and the adapter splits/unions them.
+
+### Adapter port and result
+
+```ts
+interface SearchAdapter {
+  search(query: SearchQuery, schema: SearchSchema): Promise<SearchResult>;
+}
+
+interface SearchResult {
+  readonly hits: readonly { id: string; document: SearchDocument }[];
+  readonly total: number;
+  readonly facets: Readonly<
+    Record<string, readonly { value: string; count: number }[]>
+  >;
+}
+
+type SearchDocument = Record<string, SearchValue>;
+type SearchValue =
+  | string
+  | number
+  | boolean
+  | readonly string[]
+  | LocalizedValue
+  | Reference
+  | readonly Reference[];
+type LocalizedValue = Readonly<Record<string, readonly string[]>>; // language map; `und` = @none
+interface Reference {
+  readonly id: string;
+  readonly label?: LocalizedValue;
+}
+```
+
+The adapter owns all engine specifics (companion-field expansion, `query_by`/weights, the
+filter compiler, `sort_by`, folding, `facet_by`) and returns only logical documents.
+
+`Reference` here is the generic _internal_ carrier; the GraphQL surface maps it to named
+per-shape types (e.g. `Organization`, `Term`) with `label` exposed as `name`
+(see [ADR 4](./0004-search-api-graphql-surface.md)).
+
+### Localized representation: map in the IR, best-first list at the surface
+
+- **IR / adapter-return:** JSON-LD language map (`@container: @language`), `@set` arrays,
+  `und` for untagged. Matches schema-profile #171 (language maps are more usable as a data
+  model) and the platform draft’s envelope.
+- **GraphQL surface:** a single **best-first** `Accept-Language`-ordered list
+  (`[LanguageString!]!`, see [ADR 4](./0004-search-api-graphql-surface.md)). `[0]` is the
+  value to display; **`[0].language` is the language actually served** – the per-field
+  equivalent of HTTP `Content-Language`, so a client detects a fallback
+  (`[0].language !== requested`) and sets the right `lang`. `language` is nullable for
+  untagged (`@none`) values; the rest of the list is the available-languages set (switcher /
+  discovery).
+
+Preference is driven **solely by the `Accept-Language` header** – any HTTP client sends it
+(not just browsers), one mechanism across GraphQL and REST. No per-field or root `language`
+argument (deferred): a parallel arg would duplicate the header and need precedence rules.
+
+Chosen over a `{nl,en}` map (silently yields `undefined` for a missing language, no defined
+fallback order) and over a separate resolved scalar (the value must be a `LanguageString` to
+carry its language anyway, so the scalar saved only the `[0]` index – not worth a second
+field plus a deviation from the draft / Network-of-Terms list shape). Grounded in measured
+data and all three substrates:
+
+- **A (descriptions, measured):** bilingual `nl`/`en`, ~86% Dutch-only → an English user gets
+  a tagged Dutch fallback ~86% of the time; the `Content-Language` tag is load-bearing. Zero
+  untagged in the valid set.
+- **B (objects):** untagged proper names (Person/Place) → the nullable `language` earns its keep.
+- **C (terminology):** labels in many languages → long ordered lists.
+
+**Deferred (note only):** filtering by _metadata-language availability_ (e.g. records that
+have an English title) is distinct from content `dct:language` (already filterable) and from
+preference; expressible as a facetable dimension (languages-present-in-a-localized-field),
+not enabled for DR v1, more relevant for B/C.
+
+### Other reconciled decisions
+
+- **Numbered pagination** (`offset`/`limit`, presented as page/per-page), not Relay
+  cursors. DR is a page-numbered faceted browser with totals; Typesense is natively
+  page/per-page; the ~2,500-doc corpus never paginates deep enough for offset cost to bite;
+  and the blue/green alias swap removes the mutation-drift that motivates cursors.
+- **Sidecar canonical labels**, not inline `labelOnly` as default. Facets need one
+  canonical label per entity; the draft’s own two-source model puts canonical labels in a
+  separate collection, which is what DR’s `labels` collection is. `nestedStrategy` is
+  carried as metadata but inline `labelOnly` is not the default.
+- **Logical typed result document** at the query seam; framed JSON-LD kept index-side. The
+  draft treats framed JSON-LD as the universal IR; we scope it to the index/projection
+  artifact (its payoff – vector/LDES/UI sinks – is object-search’s, not catalog-search’s),
+  gated on the generic framing packages existing rather than on DR.
+
+## Consequences
+
+- One declarative source drives GraphQL, later REST, and the index; they cannot drift.
+- The engine is a swappable adapter; the contract outlives engine choices.
+- Adopted from the draft unchanged: the Stable API Contract discipline, `nestedStrategy` as
+  a concept, the surface `LanguageString` list, folding at the adapter boundary + query
+  side via `@lde/text-normalization`, SDL-in-projection vs filter-compiler-in-adapter.
+- Deviations to reconcile into the platform draft: numbered pagination; sidecar labels;
+  logical result doc (framed JSON-LD scoped to index-side); `min`/`max` filter ranges; the
+  `@lde/search*` naming and a core package row.
+- Deferred: REST surface; framed-JSON-LD materialised view (nested storage, index-time
+  label inlining, detail-page-on-index, terms-collection split); semantic/hybrid (vector)
+  search; unifying the projection `FieldSpec` (RDF→doc) with this `SearchField`
+  (query/output) into one field declaration.

--- a/docs/decisions/0004-search-api-graphql-surface.md
+++ b/docs/decisions/0004-search-api-graphql-surface.md
@@ -1,0 +1,301 @@
+# 4. Search API GraphQL surface
+
+Date: 2026-06-25
+
+## Status
+
+Proposed
+
+Builds on [ADR 3 (Search API core query model)](./0003-search-api-core-query-model.md).
+
+## Context
+
+Given the engine-neutral core of [ADR 3](./0003-search-api-core-query-model.md), the first
+API surface is GraphQL. The platform draft requires the surface to be derived from the same
+source as the index, never hand-written, so it cannot drift. It must also be framework-free:
+resolvers are standard `graphql-js`, not tied to Fastify/Mercurius, so any GraphQL server
+can host the schema (DR mounts it inline; a Fastify wrapper is deferred and, if ever built,
+is a separate package).
+
+## Decision
+
+### Runtime configuration, not code generation
+
+The platform draft frames this as _generating_ the surface – emitting GraphQL SDL **and**
+resolvers as artifacts. We deviate: nothing is emitted or committed. The schema is
+**constructed at runtime from the field-model configuration** (`buildSearchSchema(config)`),
+once at startup, and the resolvers are **generic functions inside the package** attached to
+that schema. A better name for the draft’s “generation” step, at least for this surface, is
+**runtime configuration**.
+
+This matters because the resolvers are inherently generic – there is essentially one root
+resolver that maps args to a `SearchQuery`, calls the adapter, and maps the result back;
+the field model only parameterises data. Codegen would emit N near-identical resolver stubs
+that all delegate to the same logic, plus a build step and staleness risk, for no benefit.
+
+**No SDL artifact.** A live GraphQL API serves its own schema via introspection, so clients
+need no committed `.graphql` file. The field-model diff is the reviewable change. A
+`printSchema()` helper exists only as an **optional** CI snapshot test for catching
+accidental breaking changes to the frozen contract – not a shipped artifact.
+
+> Deviation from the stack draft: the draft’s “generate SDL + resolvers” becomes
+> _construct the schema at runtime from configuration; resolvers are generic and in-package;
+> SDL is served live via introspection, not emitted._ For the reconciliation list.
+
+### The schema-building function
+
+```ts
+function buildSearchSchema(
+  schema: SearchSchema,
+  options: {
+    typeName: string; // 'Dataset' – drives all derived type names
+    queryField?: string; // root field; default lowercased plural of typeName
+    queryDefaults?: (q: SearchQuery, ctx: SearchContext) => SearchQuery; // consumer policy
+    languageOrder?: (
+      available: readonly string[],
+      accept: readonly string[],
+    ) => readonly string[];
+    extendTypeDefs?: string; // merged before build (compose-before-build)
+    extendResolvers?: Record<string, unknown>;
+  },
+): GraphQLSchema; // executable schema: types + generic resolvers attached
+
+// also exported for manual composition / non-default servers:
+function buildSearchTypeDefsAndResolvers(
+  schema,
+  options,
+): { typeDefs: string; resolvers: object };
+// optional CI helper only:
+function printSearchSchema(schema, options): string; // SDL, for a snapshot/breaking-change test
+```
+
+`buildSearchSchema` is the standalone, framework-agnostic artifact (depends only on
+`graphql` + `@graphql-tools/schema`). Deep customisation passes `extendTypeDefs`/
+`extendResolvers` (merged before `makeExecutableSchema`, since Mercurius registers once) or
+composes the exported typeDefs/resolvers by hand.
+
+### Construction rules (field model → schema)
+
+Type names derive from `typeName`; shared types (`LanguageString`, `Facet`, `FacetBucket`,
+`SortDirection`, `StringFilter`, `IntRange`, `FloatRange`, `DateRange`) are emitted once.
+GraphQL field names are the field model `name` verbatim (declare camelCase).
+
+- **Output type** – one field per `output` field: `text`+`localized` → `[LanguageString!]!` (best-first; `[0].language` = served language, the per-field `Content-Language`);
+  `keyword` array → `[String!]!`, scalar → `String`; `integer` → `Int`; `number` → `Float`;
+  `date` → `String` (ISO 8601); `boolean` → `Boolean!` (absent = false); `reference` →
+  see below. Nullability from `array` / required / optional; `id` is `String!`.
+- **Reference types** – a `reference` field is typed by the **referenced shape**
+  (`sh:class`/`sh:node`), emitted once and reused by every field referencing the same shape.
+  Its fields follow `nestedStrategy`:
+
+  | `nestedStrategy`         | GraphQL                                                     |
+  | ------------------------ | ----------------------------------------------------------- |
+  | `idOnly`                 | `String` (the IRI)                                          |
+  | `labelOnly` (v1 default) | named type `{ id: String!, name: [LanguageString!]! }`      |
+  | `inline` (later)         | the named type plus the referenced shape’s projected fields |
+
+  So DR emits `publisher: Organization` (the `foaf:Agent` shape) and
+  `terminologySource: [Term!]!`; a shape’s type is emitted once and reused by any field that
+  references it. Named, not a generic GraphQL `Reference`: going `labelOnly → inline` then
+  only _adds_ fields (non-breaking), whereas generic→named later would break the contract.
+
+- **`where` input** – one field per `filterable` field: `keyword`/`reference` →
+  `StringFilter { in: [String!] }`; `integer` → `IntRange { min, max }`; `number` →
+  `FloatRange`; `date` → `DateRange { min, max }` (Strings); `boolean` → `Boolean` (the
+  `is` value); `text` is excluded (it goes through the `query` arg).
+- **`orderBy`** – `RELEVANCE` (the sane default when a `query` is present) plus every
+  `sortable` field, as an enum, in a single `{ field, direction }` input. Only
+  publicly-selectable sorts appear here; the resolver expands the client’s one choice into
+  the internal `Sort[]`, appending deployment tie-breaks like DR’s `status_rank` via
+  `queryDefaults` (never exposed). Single for now because a user picks one dimension.
+  Promoting it to a list later is backward-compatible only for inline-literal clients (list
+  input coercion wraps a single value); **variable-based clients break** (`$o: DatasetOrderBy`
+  is rejected where `[DatasetOrderBy!]` is expected), so a future array is a deliberate,
+  potentially breaking change – not a free one.
+- **Facets** – an enum of every `facetable` field; requested per query, returned with counts.
+
+### Resulting schema (DR example, abridged)
+
+```graphql
+type LanguageString {
+  language: String
+  value: String!
+} # language null = untagged (@none)
+type Organization {
+  id: String!
+  name: [LanguageString!]!
+} # labelOnly; gains fields if inline
+type Term {
+  id: String!
+  name: [LanguageString!]!
+}
+
+type Dataset {
+  id: String!
+  title: [LanguageString!]!
+  description: [LanguageString!]!
+  publisher: Organization
+  terminologySource: [Term!]!
+  format: [String!]!
+  class: [String!]!
+  size: Int
+  datePosted: String
+  status: String
+  iiif: Boolean!
+  # … keyword, language, iiifManifestCount, ndeSchemaAp, linkedData, terms, persistentUris
+}
+
+input StringFilter {
+  in: [String!]
+}
+input IntRange {
+  min: Int
+  max: Int
+}
+input DateRange {
+  min: String
+  max: String
+}
+
+input DatasetWhere {
+  publisher: StringFilter
+  format: StringFilter
+  class: StringFilter
+  status: StringFilter
+  size: IntRange
+  datePosted: DateRange
+  iiif: Boolean
+  # … keyword, language, terminologySource, catalog, ndeSchemaAp, linkedData, terms, persistentUris
+}
+
+enum DatasetSortField {
+  RELEVANCE
+  TITLE
+  DATE_POSTED
+  SIZE
+}
+enum SortDirection {
+  ASC
+  DESC
+}
+input DatasetOrderBy {
+  field: DatasetSortField!
+  direction: SortDirection! = DESC
+}
+
+enum DatasetFacetField {
+  PUBLISHER
+  KEYWORD
+  LANGUAGE
+  FORMAT
+  CLASS
+  TERMINOLOGY_SOURCE
+  STATUS
+  IIIF
+  NDE_SCHEMA_AP
+  LINKED_DATA
+  TERMS
+  PERSISTENT_URIS
+}
+type FacetBucket {
+  value: String!
+  count: Int!
+}
+type Facet {
+  field: DatasetFacetField!
+  buckets: [FacetBucket!]!
+}
+
+type DatasetSearchResult {
+  items: [Dataset!]!
+  total: Int!
+  page: Int!
+  perPage: Int!
+  facets: [Facet!]!
+}
+
+type Query {
+  datasets(
+    query: String
+    where: DatasetWhere
+    orderBy: DatasetOrderBy
+    page: Int = 1
+    perPage: Int = 20
+    facets: [DatasetFacetField!]
+  ): DatasetSearchResult!
+}
+```
+
+Numbered pagination (`page`/`perPage` + `total`), per
+[ADR 3](./0003-search-api-core-query-model.md) – no Relay connection. The reference types
+(`Organization`, `Term`) carry `id + name` (labelOnly) from DR’s sidecar labels collection,
+resolved by the adapter. `publisher` is single (`dct:publisher` `maxCount 1`); `creator` is
+search-only – its name feeds full-text `query` but it has no output field of its own,
+mirroring the current card. `catalog` is filter-only, so it appears in `where` but not as an
+output field.
+
+### Resolver behaviour
+
+The single, generic root resolver (shipped in the package, not emitted):
+
+1. **Args → `SearchQuery`** (pure): `query`→`text`; `where`→`Filter[]`; `orderBy`→`Sort[]`
+   (`RELEVANCE`→reserved `relevance`); `page`/`perPage`→`offset`/`limit`; `facets`→logical
+   names; `locale`←`context.acceptLanguage[0]`.
+2. **Apply `options.queryDefaults`** – the generic resolver bakes no deployment defaults;
+   DR injects its policy here: default `status:=valid`; default sort `relevance` when a
+   `query` is present else `title`; and the `status_rank` tie-break appended to either.
+3. **`context.adapter.search(query, schema)` → `SearchResult`.**
+4. **`SearchResult` → output** – scalars pass through; a `LocalizedValue` map →
+   `[LanguageString]` ordered by `options.languageOrder(available, acceptLanguage)`;
+   reference values likewise; facets keyed logical→enum. GraphQL field selection prunes.
+
+Default `languageOrder`: Accept-Language entries first, then remaining tagged languages,
+then untagged (`und`) last – so `[0]` is always the best available value.
+
+### Lifecycle and performance
+
+- **Built once at startup.** The consumer calls `buildSearchSchema` during boot and hands
+  the single `GraphQLSchema` to its server; the field model is static per deployment, so it
+  is never rebuilt per request.
+- **Held and reused.** That one schema serves every request (Mercurius additionally
+  caches/compiles it).
+- **Zero per-request penalty vs codegen.** A runtime-constructed schema is the same
+  `GraphQLSchema` object codegen would have produced; the only added cost is the one-time
+  build, sub-millisecond to low-single-digit-ms for a schema this size.
+- **Hot path is the engine, not GraphQL.** Per-request cost is dominated by the Typesense
+  round-trip; parse/validate/resolve of a small query is sub-millisecond.
+- **Introspection serves the contract.** Cheap (a query against the built schema, cached by
+  clients). Leave it on, or disable in production and use `printSearchSchema` for tooling.
+
+### Context contract
+
+```ts
+interface SearchContext {
+  adapter: SearchAdapter; // any engine
+  acceptLanguage: readonly string[]; // parsed, ordered; drives locale + output ordering
+}
+```
+
+Each transport populates it per request; no framework type appears in the package.
+
+## Consequences
+
+- The GraphQL surface is configured at runtime from the
+  [ADR 3](./0003-search-api-core-query-model.md) field model, so it cannot drift from the
+  index or a later REST surface, and works under any GraphQL server.
+- **Frozen (public contract):** `LanguageString`, the named reference types (`Organization`,
+  `Term`, …), output types, `where` operators, `orderBy` enums, numbered-pagination args,
+  facet types. Breaking to change – right in v1.
+- **Internal:** args→`SearchQuery` mapping, language ordering, how the adapter computes
+  facets, the `SearchDocument` shape.
+- **Deviations to reconcile into the platform draft:**
+  - “generate SDL + resolvers” → _runtime configuration_ (construct at startup from config;
+    generic in-package resolvers; SDL served via introspection, not emitted as an artifact).
+  - Named reference types per shape (`Organization`, `Term`) rather than the draft’s uniform
+    `labelOnly` `{ @id, @type, name }` reference shape – chosen for ergonomics and
+    additive `inline` growth.
+- Deferred: a `dataset(id)` single-resource query (detail-page-on-index direction; DR detail
+  stays on SPARQL); cross-collection `@reference` joins beyond inline labels; cursor
+  pagination; a `Date` scalar (kept ISO `String`); transport-layer persisted queries / cost
+  limits; a root or per-field language argument (Accept-Language is the sole preference
+  mechanism); metadata-language-availability filtering (a facetable dimension, not v1).


### PR DESCRIPTION
Adds two Architecture Decision Records proposing the search API design (the `@lde/search*` package family), as the Dataset Register moves to API-first, GraphQL-first search.

## 0003 – Search API core query model

The engine- and protocol-neutral core (`@lde/search`): the field model, the neutral `SearchQuery` IR, filter semantics, the adapter port, the localized representation (best-first `LanguageString` lists, with per-field `Content-Language` via the first entry), numbered pagination, sidecar canonical labels, and the contract-frozen / storage-swappable principle.

## 0004 – Search API GraphQL surface

`@lde/search-api-graphql`: a runtime-configured executable schema (no code generation, no SDL artifact, served via introspection), the field-model to schema construction rules, named per-shape reference types, a single primary `orderBy` with server-side tie-breaks, resolver behaviour, and lifecycle/performance.

Both ADRs are Status: Proposed and record deliberate deviations from the draft NDE stack platform docs, to be reconciled there separately.
