### PR TITLE
feat(distribution-probe): add onProgress callback to probeMany

### DIFF
--- a/packages/distribution-probe/src/probe.ts
+++ b/packages/distribution-probe/src/probe.ts
@@ -76,6 +76,15 @@ export interface ProbeManyOptions extends ProbeOptions {
    * other hosts proceed, so this never idles the global pool. Default 4.
    */
   perHostConcurrency?: number;
+  /**
+   * Called once after each probe settles, with the number of probes completed so
+   * far and the total to run (`distributions.length`). Lets a caller drive a
+   * determinate progress indicator while a large batch runs. Fires `total` times,
+   * ending at `(total, total)`; the order reflects completion, not input order.
+   * Never called for an empty batch. A throwing callback rejects the batch, so
+   * keep it cheap and side-effect-only.
+   */
+  onProgress?: (completed: number, total: number) => void;
 }
 
 const DEFAULT_SPARQL_QUERY = 'SELECT * { ?s ?p ?o } LIMIT 1';
@@ -346,12 +355,23 @@ export async function probeMany(
     (distribution) =>
       distribution.accessUrl.host || distribution.accessUrl.href,
   );
+  // Report progress as each probe settles. mapHostLimited resolves results in
+  // input order, but tasks complete out of order, so count completions here
+  // rather than rely on result position. The total is the batch size.
+  const onProgress = options?.onProgress;
+  const total = distributions.length;
+  let completed = 0;
   return mapHostLimited(
     distributions,
     hostKeys,
     globalLimit,
     perHostLimit,
-    (distribution) => probe(distribution, options),
+    async (distribution) => {
+      const result = await probe(distribution, options);
+      completed += 1;
+      onProgress?.(completed, total);
+      return result;
+    },
   );
 }
 

--- a/packages/distribution-probe/test/probe.test.ts
+++ b/packages/distribution-probe/test/probe.test.ts
@@ -1911,6 +1911,36 @@ describe('probeMany', () => {
     expect(await probeMany([])).toEqual([]);
   });
 
+  it('reports progress once per probe, ending at (total, total)', async () => {
+    vi.mocked(fetch).mockImplementation(async () => okResponse());
+
+    const distributions = [
+      dataDump('host-a.example', 0),
+      dataDump('host-b.example', 0),
+      dataDump('host-c.example', 0),
+    ];
+
+    const calls: Array<[number, number]> = [];
+    const results = await probeMany(distributions, {
+      onProgress: (completed, total) => calls.push([completed, total]),
+    });
+
+    expect(results).toHaveLength(3);
+    // One call per probe; completed increments monotonically as tasks settle and
+    // the total stays the batch size, so the sequence ends at (total, total).
+    expect(calls).toEqual([
+      [1, 3],
+      [2, 3],
+      [3, 3],
+    ]);
+  });
+
+  it('does not call onProgress for an empty batch', async () => {
+    const onProgress = vi.fn();
+    await probeMany([], { onProgress });
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
   it('falls back to the default budget for a non-positive or non-integer limit', async () => {
     vi.mocked(fetch).mockImplementation(async () => okResponse());
 

--- a/packages/distribution-probe/vite.config.ts
+++ b/packages/distribution-probe/vite.config.ts
@@ -14,7 +14,7 @@ export default mergeConfig(
           lines: 100,
           functions: 100,
           branches: 96.72,
-          statements: 99.63,
+          statements: 99.64,
         },
       },
     },


### PR DESCRIPTION
## What

`probeMany` gains an optional `onProgress(completed, total)` callback, fired once after each probe settles and ending at `(total, total)`.

## Why

It lets a caller drive a **determinate** progress indicator while a large batch runs — the total (distinct probe targets) is known up front, and each settle is a tick. The motivating consumer is the **NDE Dataset Register**: validating a catalogue with many distributions on one host can take a while (especially with the per-host concurrency cap throttling the burst), and today the UI just hangs. This is the foundation for a progress bar there.

## How

- New `onProgress?: (completed, total) => void` on `ProbeManyOptions`.
- `probeMany` wraps the per-probe task so the callback fires after each `probe()` resolves, counting completions (not result position, since results resolve in input order but tasks settle out of order). The generic `mapHostLimited` scheduler is untouched.

## Notes

- Order reflects completion, not input order; fires `total` times; never called for an empty batch.
- A throwing callback rejects the batch (documented), so it is meant to be cheap and side-effect-only.
- Additive, optional — non-breaking.

## Tests

Added: `onProgress` ticks once per probe ending at `(total, total)`; not called for an empty batch. Full `@lde/distribution-probe` suite green (91 tests), typecheck clean.
