### PR TITLE
fix: relax workspace dependency pins to caret (versionPrefix) to fix downstream dual-package hazard

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -74,6 +74,7 @@
       "preVersionCommand": "npx nx run-many -t build",
       "conventionalCommits": true,
       "updateDependents": "auto",
+      "versionPrefix": "^",
       "fallbackCurrentVersionResolver": "disk",
       "adjustSemverBumpsForZeroMajorVersion": true,
       "versionActionsOptions": {

--- a/packages/distribution-health/package.json
+++ b/packages/distribution-health/package.json
@@ -24,11 +24,11 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@lde/distribution-probe": "0.2.2",
-    "@lde/sparql-importer": "0.6.5",
+    "@lde/distribution-probe": "^0.2.2",
+    "@lde/sparql-importer": "^0.6.5",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@lde/dataset": "0.7.7"
+    "@lde/dataset": "^0.7.7"
   }
 }

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -24,12 +24,12 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@lde/dataset": "0.7.7",
-    "@lde/dataset-registry-client": "0.8.4",
-    "@lde/distribution-health": "0.2.2",
-    "@lde/distribution-probe": "0.2.2",
-    "@lde/sparql-importer": "0.6.5",
-    "@lde/sparql-server": "0.4.11",
+    "@lde/dataset": "^0.7.7",
+    "@lde/dataset-registry-client": "^0.8.4",
+    "@lde/distribution-health": "^0.2.2",
+    "@lde/distribution-probe": "^0.2.2",
+    "@lde/sparql-importer": "^0.6.5",
+    "@lde/sparql-server": "^0.4.11",
     "@rdfjs/namespace": "^2.0.1",
     "@rdfjs/types": "^2.0.1",
     "@tpluscode/rdf-ns-builders": "^5.0.0",


### PR DESCRIPTION
## What

- Set `release.version.versionPrefix: "^"` so nx writes **caret** ranges (e.g. `^0.2.2`) when `updateDependents` rewrites a dependent package, instead of exact pins.
- Relax the existing exact `@lde/*` pins in `distribution-health` and `pipeline` to caret.

## Why

Exact pins on workspace dependencies force any downstream consumer that wants a **newer** version of a workspace package into **two copies** of it. That's a dual-package hazard: `@lde/distribution-health`'s `probeResultToVerdict()` does an `instanceof ProbeResultType` that silently fails across the two `@lde/distribution-probe` copies, so the validity rail breaks.

This actually bit the Dataset Register: bumping `@lde/distribution-probe` to `0.2.2` (for the new `onProgress`, #527) while `distribution-health`/`pipeline` still pinned `0.2.1` exact produced a split tree and broke its distribution-validity behaviour.

The only documented reason for exact pins was that **`^0.0.0` aborts `nx release version`** (ef41eee, #496) — a `0.0.0` bootstrap problem. Since new packages now start from `0.1.0` (#510), that never occurs. Verified on **nx 23**: a `^0.2.2` workspace ref runs `nx release version` cleanly (no abort).

## Effect

- Downstream consumers can dedupe `@lde/*` packages to a single version — no more dual-package hazard.
- With caret ranges, a patch bump of a workspace dep no longer forces a cascade re-release of every dependent (the patch is already in range), reducing release churn.
- `versionPrefix: "^"` converts the remaining exact pins across other packages to caret automatically on their next release.

## Note

The `fix(distribution-health)` / `fix(pipeline)` commits trigger a republish of those two with the caret pins, which is what unblocks the Dataset Register.
