### PR TITLE
build: commit the verdaccio local-registry config

### DIFF
--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -1,0 +1,29 @@
+# Local registry for testing publishable packages (nx local-registry / @nx/js:verdaccio).
+# Storage is overridden by the target option (tmp/local-registry/storage).
+storage: ../tmp/local-registry/storage
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    maxage: 60m
+
+packages:
+  # @lde/* falls through to this rule: locally-published packages (the four we
+  # publish here) are served from local storage and shadow npmjs; any @lde package
+  # not published locally (DR also uses @lde/dataset, @lde/pipeline, …) proxies npmjs.
+  '@*/*':
+    access: $all
+    publish: $all
+    unpublish: $all
+    proxy: npmjs
+  '**':
+    access: $all
+    publish: $all
+    unpublish: $all
+    proxy: npmjs
+
+# Allow republishing the same version during local iteration.
+publish:
+  allow_offline: true
+
+log: { type: stdout, format: pretty, level: warn }


### PR DESCRIPTION
## What

Commits `.verdaccio/config.yml`, which the root `package.json`’s `local-registry` target (`@nx/js:verdaccio`) has referenced all along. Without the file in the repo, `npx nx local-registry` only works on the machine that originally generated it.

The registry’s mutable storage stays out of the repo (`tmp/local-registry/storage`, covered by the existing `tmp` ignore).