### PR TITLE
fix(release): unblock the search release version bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42882,7 +42882,7 @@
     },
     "packages/search": {
       "name": "@lde/search",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@lde/text-normalization": "^0.1.1",
@@ -42914,19 +42914,6 @@
         "tslib": "^2.3.0"
       }
     },
-    "packages/search-api-graphql/node_modules/@lde/search": {
-      "version": "0.2.2",
-      "resolved": "http://localhost:4873/@lde/search/-/search-0.2.2.tgz",
-      "integrity": "sha512-tnDY2AGGMonv43/rR7twaaWUIKHs2xplZZ5r6qIJMKu/1WO1KsNJ1diV8/6hWTsIRmJ7h5McXb1R7EU+gRJ6wg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lde/text-normalization": "^0.1.1",
-        "@rdfjs/types": "^2.0.1",
-        "@tpluscode/rdf-ns-builders": "^5.0.0",
-        "jsonld": "^9.0.0",
-        "tslib": "^2.3.0"
-      }
-    },
     "packages/search-typesense": {
       "name": "@lde/search-typesense",
       "version": "0.1.1",
@@ -42939,19 +42926,6 @@
       },
       "devDependencies": {
         "testcontainers": "^12.0.3"
-      }
-    },
-    "packages/search-typesense/node_modules/@lde/search": {
-      "version": "0.2.2",
-      "resolved": "http://localhost:4873/@lde/search/-/search-0.2.2.tgz",
-      "integrity": "sha512-tnDY2AGGMonv43/rR7twaaWUIKHs2xplZZ5r6qIJMKu/1WO1KsNJ1diV8/6hWTsIRmJ7h5McXb1R7EU+gRJ6wg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lde/text-normalization": "^0.1.1",
-        "@rdfjs/types": "^2.0.1",
-        "@tpluscode/rdf-ns-builders": "^5.0.0",
-        "jsonld": "^9.0.0",
-        "tslib": "^2.3.0"
       }
     },
     "packages/search/node_modules/n3": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42906,11 +42906,24 @@
     },
     "packages/search-api-graphql": {
       "name": "@lde/search-api-graphql",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.1.2",
+        "@lde/search": "^0.2.0",
         "graphql": "^15.8.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "packages/search-api-graphql/node_modules/@lde/search": {
+      "version": "0.2.2",
+      "resolved": "http://localhost:4873/@lde/search/-/search-0.2.2.tgz",
+      "integrity": "sha512-tnDY2AGGMonv43/rR7twaaWUIKHs2xplZZ5r6qIJMKu/1WO1KsNJ1diV8/6hWTsIRmJ7h5McXb1R7EU+gRJ6wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lde/text-normalization": "^0.1.1",
+        "@rdfjs/types": "^2.0.1",
+        "@tpluscode/rdf-ns-builders": "^5.0.0",
+        "jsonld": "^9.0.0",
         "tslib": "^2.3.0"
       }
     },
@@ -42919,13 +42932,26 @@
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.1.2",
+        "@lde/search": "^0.2.0",
         "@lde/text-normalization": "^0.1.1",
         "tslib": "^2.3.0",
         "typesense": "^3.0.6"
       },
       "devDependencies": {
         "testcontainers": "^12.0.3"
+      }
+    },
+    "packages/search-typesense/node_modules/@lde/search": {
+      "version": "0.2.2",
+      "resolved": "http://localhost:4873/@lde/search/-/search-0.2.2.tgz",
+      "integrity": "sha512-tnDY2AGGMonv43/rR7twaaWUIKHs2xplZZ5r6qIJMKu/1WO1KsNJ1diV8/6hWTsIRmJ7h5McXb1R7EU+gRJ6wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lde/text-normalization": "^0.1.1",
+        "@rdfjs/types": "^2.0.1",
+        "@tpluscode/rdf-ns-builders": "^5.0.0",
+        "jsonld": "^9.0.0",
+        "tslib": "^2.3.0"
       }
     },
     "packages/search/node_modules/n3": {

--- a/packages/search-api-graphql/package.json
+++ b/packages/search-api-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lde/search-api-graphql",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Engine- and domain-agnostic GraphQL surface for @lde/search: builds an executable GraphQLSchema from a whole SearchSchema at runtime (no codegen) — one root query field per SearchType — served by generic resolvers over any SearchEngine. You supply the schema and per-type typeNames; it names neither your domain nor your engine.",
   "repository": {
     "url": "git+https://github.com/ldelements/lde.git",
@@ -25,7 +25,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@lde/search": "^0.1.2",
+    "@lde/search": "^0.2.0",
     "graphql": "^15.8.0",
     "tslib": "^2.3.0"
   }

--- a/packages/search-typesense/package.json
+++ b/packages/search-typesense/package.json
@@ -25,7 +25,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@lde/search": "^0.1.2",
+    "@lde/search": "^0.2.0",
     "@lde/text-normalization": "^0.1.1",
     "tslib": "^2.3.0",
     "typesense": "^3.0.6"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lde/search",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Engine- and domain-agnostic core for RDF-backed search: a unified declarative field model (SearchField/SearchType/SearchSchema), a neutral query IR, the SearchEngine port with logical result types, and a streaming CONSTRUCT-to-document projection. Bakes in no engine, protocol, or domain.",
   "repository": {
     "url": "git+https://github.com/ldelements/lde.git",


### PR DESCRIPTION
## What

Unblocks the Release run that failed after #529 merged
([release run](https://github.com/ldelements/lde/actions/runs/28750286340)):

- **Widen the `@lde/search` dependency ranges to `^0.2.0`** in
  `@lde/search-typesense` and `@lde/search-api-graphql`. The breaking search
  rework bumps `@lde/search` 0.1.x → 0.2.0, and nx release’s
  `preserveMatchingDependencyRanges` refuses to write a new version outside the
  declared range.
- **Start `@lde/search-api-graphql` from 0.0.0**, so the breaking introduction
  commits land its *first* release at 0.1.0 (per the new-package convention)
  instead of overshooting to 0.2.0.
- Refresh `package-lock.json` accordingly.

After this merges, the release should publish `@lde/search` 0.2.0 and
`@lde/search-typesense` 0.2.0 via OIDC. The `@lde/search-api-graphql` 0.1.0
publish step is expected to fail until the one-time manual bootstrap (a new
package cannot be created by the Trusted Publisher; see AGENTS.md ‘Releasing a
new package’).

https://claude.ai/code/session_01PDZBfA1bj35oc7Yqn1pc2n
