### PR TITLE
docs(readme): fix the Linked Open Limburg link

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ graph TD
 
 <a href="https://dc4eu.nl"><img src="https://dc4eu.nl/wp-content/uploads/2022/01/logo.png" width="20" valign="middle"></a>&ensp;<a href="https://dc4eu.nl">DC4EU</a> — Dutch Collections for Europe, the accredited national aggregator connecting Dutch heritage institutions with Europeana
 
-<a href="https://www.linkedopenlimburg.nl">Linked Open Limburg</a> — Coöperatie Erfgoed Limburg’s regional heritage programme, built on LDE’s pipeline components
+<a href="https://hklimburg.nl/nieuws/linked-open-limburg">Linked Open Limburg</a> — Coöperatie Erfgoed Limburg’s regional heritage programme, built on LDE’s pipeline components
 
 ## Comparison
 


### PR DESCRIPTION
The linkedopenlimburg.nl domain does not resolve; link the programme page at Huis voor de Kunsten Limburg instead.