### PR TITLE
feat(search)!: batch facet searches into a single multi_search

### DIFF
--- a/docs/decisions/0003-search-api-core-query-model.md
+++ b/docs/decisions/0003-search-api-core-query-model.md
@@ -233,6 +233,12 @@ interface SearchEngine<
     searchType: T,
     query: SearchQuery,
   ): Promise<SearchResult<FacetFieldsOf<T>, OutputFieldsOf<T>>>;
+  // Amended by ADR 5: the batch entry point for facet-only queries
+  // (one multi_search round-trip; per-query outcomes).
+  searchFacets<T extends Types[number]>(
+    searchType: T,
+    queries: readonly SearchQuery[],
+  ): Promise<readonly FacetsOutcome<FacetFieldsOf<T>>[]>;
 }
 
 interface SearchResult<

--- a/docs/decisions/0005-batch-facet-queries-through-the-engine-port.md
+++ b/docs/decisions/0005-batch-facet-queries-through-the-engine-port.md
@@ -15,7 +15,7 @@ refines the faceting described in
 The keyed facets object of ADR 4 resolves each selected facet with its own
 `where`-filter removed (skip-own-filter). Implemented as one `engine.search`
 call per selected facet, a typical listing page fanned out into 1 listing
-search + N facet searches — ~4–5× the engine round-trips of the pre-migration
+search + N facet searches – ~4–5× the engine round-trips of the pre-migration
 direct-Typesense path, which computed the whole sidebar in a single
 `multi_search`. Skip-own-filter only _changes_ the result for a facet whose
 own field is actively filtered; for every other facet the dedicated query is
@@ -28,15 +28,15 @@ identical except for its `facet_by`.
 `SearchEngine` gains `searchFacets(searchType, queries)`: a batch of
 facet-only queries answered in one engine round-trip where the engine
 supports one (Typesense: a single `multi_search`). Engines answer every
-query facet-only — as if `limit: 0` and without ordering, whatever the query
-carries — so hits are never transferred. The port contract (schema binding,
+query facet-only – as if `limit: 0` and without ordering, whatever the query
+carries – so hits are never transferred. The port contract (schema binding,
 per-query structural validation) holds for every query in the batch.
 
 ### Per-query outcomes, not a whole-batch rejection
 
 `searchFacets` returns one `FacetsOutcome` per query, positionally aligned:
 `{ facets }` or `{ error }` (an `allSettled`-style union). A failure of one
-query — e.g. one failed `multi_search` entry — is reported in place and never
+query – e.g. one failed `multi_search` entry – is reported in place and never
 discards its siblings’ facets; the promise rejects only for batch-level
 failures (foreign type, invalid query, the transport itself). This preserves
 the per-facet degradation granularity the per-facet resolvers had: the
@@ -48,7 +48,7 @@ reports each via `onFacetError`.
 The GraphQL surface owns skip-own-filter (a surface policy per ADR 4), so it
 also owns the grouping: selected facet fields are collected per request
 (a DataLoader batches the same-tick sibling resolvers) and grouped by their
-**effective `where`** — facets whose own field is unfiltered share one query,
+**effective `where`** – facets whose own field is unfiltered share one query,
 so the unfiltered browse collapses to a single facet query; each own-filtered
 facet gets its own variant. The adapter owns the engine specifics: one
 `multi_search`, one bundled reference-label lookup (or the in-memory label

--- a/docs/decisions/0005-batch-facet-queries-through-the-engine-port.md
+++ b/docs/decisions/0005-batch-facet-queries-through-the-engine-port.md
@@ -1,0 +1,68 @@
+# 5. Batch facet queries through the engine port
+
+Date: 2026-07-06
+
+## Status
+
+Proposed
+
+Amends [ADR 3 (Search API core query model)](./0003-search-api-core-query-model.md);
+refines the faceting described in
+[ADR 4 (Search API GraphQL surface)](./0004-search-api-graphql-surface.md).
+
+## Context
+
+The keyed facets object of ADR 4 resolves each selected facet with its own
+`where`-filter removed (skip-own-filter). Implemented as one `engine.search`
+call per selected facet, a typical listing page fanned out into 1 listing
+search + N facet searches — ~4–5× the engine round-trips of the pre-migration
+direct-Typesense path, which computed the whole sidebar in a single
+`multi_search`. Skip-own-filter only _changes_ the result for a facet whose
+own field is actively filtered; for every other facet the dedicated query is
+identical except for its `facet_by`.
+
+## Decision
+
+### A batch entry point on the engine port
+
+`SearchEngine` gains `searchFacets(searchType, queries)`: a batch of
+facet-only queries answered in one engine round-trip where the engine
+supports one (Typesense: a single `multi_search`). Engines answer every
+query facet-only — as if `limit: 0` and without ordering, whatever the query
+carries — so hits are never transferred. The port contract (schema binding,
+per-query structural validation) holds for every query in the batch.
+
+### Per-query outcomes, not a whole-batch rejection
+
+`searchFacets` returns one `FacetsOutcome` per query, positionally aligned:
+`{ facets }` or `{ error }` (an `allSettled`-style union). A failure of one
+query — e.g. one failed `multi_search` entry — is reported in place and never
+discards its siblings’ facets; the promise rejects only for batch-level
+failures (foreign type, invalid query, the transport itself). This preserves
+the per-facet degradation granularity the per-facet resolvers had: the
+surface degrades exactly the facets of a failed query to empty lists and
+reports each via `onFacetError`.
+
+### Grouping stays in the surface; batching transport stays in the adapter
+
+The GraphQL surface owns skip-own-filter (a surface policy per ADR 4), so it
+also owns the grouping: selected facet fields are collected per request
+(a DataLoader batches the same-tick sibling resolvers) and grouped by their
+**effective `where`** — facets whose own field is unfiltered share one query,
+so the unfiltered browse collapses to a single facet query; each own-filtered
+facet gets its own variant. The adapter owns the engine specifics: one
+`multi_search`, one bundled reference-label lookup (or the in-memory label
+cache) shared by the whole batch.
+
+## Consequences
+
+- A typical page load costs the listing search plus one batched facet
+  round-trip (with the label cache on: exactly 2 Typesense round-trips),
+  restoring the pre-migration behaviour.
+- Breaking port change: every `SearchEngine` implementation must add
+  `searchFacets`. The executable contract suite (`@lde/search/testing`)
+  covers the new method.
+- Deliberately not done: facets whose effective `where` equals the listing
+  query’s could ride the listing search via `facet_by` (a 1-round-trip
+  browse). That needs `GraphQLResolveInfo` selection-walking, and inside one
+  `multi_search` the difference is negligible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30307,6 +30307,12 @@
         "node": ">= 12"
       }
     },
+    "node_modules/dataloader": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
+      "license": "MIT"
+    },
     "node_modules/dayjs": {
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
@@ -42906,17 +42912,18 @@
     },
     "packages/search-api-graphql": {
       "name": "@lde/search-api-graphql",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@lde/search": "^0.2.0",
+        "dataloader": "^2.2.3",
         "graphql": "^15.8.0",
         "tslib": "^2.3.0"
       }
     },
     "packages/search-typesense": {
       "name": "@lde/search-typesense",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@lde/search": "^0.2.0",

--- a/packages/search-api-graphql/README.md
+++ b/packages/search-api-graphql/README.md
@@ -85,12 +85,12 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
   filterable fields.
 - **`orderBy`**: `RELEVANCE` plus every `sortable` field, as an enum.
 - **Facets**: a keyed object with one field per `facetable` field; a bucket
-  carries `value` + `count` + a nullable `label` — the resolved data label for
+  carries `value` + `count` + a nullable `label` – the resolved data label for
   **reference** facets, `null` for token/free-string facets whose display the
   consumer owns (its own i18n, or the value itself). Selecting facet fields IS
   the request: each selected facet is computed with its own `where`-filter
   removed (skip-own-filter), and the whole selection is **batched per
-  request** — facets whose field carries no active filter share one query
+  request** – facets whose field carries no active filter share one query
   (the unfiltered browse collapses to a single query) and everything is
   dispatched as one `engine.searchFacets` call, so a typical page costs the
   listing search plus one batched facet round-trip.

--- a/packages/search-api-graphql/README.md
+++ b/packages/search-api-graphql/README.md
@@ -84,10 +84,16 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
   `FloatRange` / `DateRange`, or `Boolean`); omitted entirely for a type with no
   filterable fields.
 - **`orderBy`**: `RELEVANCE` plus every `sortable` field, as an enum.
-- **Facets**: an enum of every `facetable` field; a bucket carries `value` +
-  `count` + a nullable `label` — the resolved data label for **reference** facets,
-  `null` for token/free-string facets whose display the consumer owns (its own
-  i18n, or the value itself).
+- **Facets**: a keyed object with one field per `facetable` field; a bucket
+  carries `value` + `count` + a nullable `label` — the resolved data label for
+  **reference** facets, `null` for token/free-string facets whose display the
+  consumer owns (its own i18n, or the value itself). Selecting facet fields IS
+  the request: each selected facet is computed with its own `where`-filter
+  removed (skip-own-filter), and the whole selection is **batched per
+  request** — facets whose field carries no active filter share one query
+  (the unfiltered browse collapses to a single query) and everything is
+  dispatched as one `engine.searchFacets` call, so a typical page costs the
+  listing search plus one batched facet round-trip.
 
 ## Guarding the contract
 

--- a/packages/search-api-graphql/package.json
+++ b/packages/search-api-graphql/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "@lde/search": "^0.2.0",
+    "dataloader": "^2.2.3",
     "graphql": "^15.8.0",
     "tslib": "^2.3.0"
   }

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -40,6 +40,7 @@ import {
   toLanguageStrings,
   type LanguageOrder,
 } from './language.js';
+import { createFacetLoader, type FacetLoader } from './facet-batch.js';
 
 /** Populated per request by the transport; no framework type appears here. */
 export interface SearchContext {
@@ -50,9 +51,10 @@ export interface SearchContext {
   /** Parsed, ordered `Accept-Language`; drives locale selection and output order. */
   readonly acceptLanguage: readonly string[];
   /**
-   * Called when a single facet's computation fails. The facet degrades to an
-   * empty list (a supplementary facet must not fail the whole query); supply
-   * this to log the cause. Optional — omit to swallow silently.
+   * Called, once per selected facet field, when facet computation fails. The
+   * affected facets degrade to empty lists (a supplementary facet must not
+   * fail the whole query); supply this to log the cause. Optional — omit to
+   * swallow silently.
    */
   readonly onFacetError?: (field: string, error: unknown) => void;
 }
@@ -354,17 +356,18 @@ export function buildGraphQLSchema(
     });
 
     // Keyed facets object: one field per facetable field, typed by its kind
-    // (range fields → [RangeBucket!], else [ValueBucket!]). Each field's resolver
-    // computes that facet with its OWN where-filter removed (skip-own-filter), so a
+    // (range fields → [RangeBucket!], else [ValueBucket!]). Each field is
+    // computed with its OWN where-filter removed (skip-own-filter), so a
     // multi-select facet still lists its other options; only the selected fields
     // are resolved (GraphQL prunes the rest), so the selection IS the request.
+    // The selected fields load through a per-request batcher (createFacetLoader)
+    // that groups them by effective where and dispatches ONE engine.searchFacets
+    // call, instead of one engine search per facet.
     // Like `where`, omitted entirely for a type with no facetable fields (a
     // GraphQL object type must have at least one field).
     const facetable = facetableFields(searchType);
     const facetsType =
-      facetable.length === 0
-        ? undefined
-        : facetsTypeFor(searchType, typeName, facetable);
+      facetable.length === 0 ? undefined : facetsTypeFor(typeName, facetable);
 
     const resultType = new GraphQLObjectType({
       name: `${typeName}SearchResult`,
@@ -374,7 +377,7 @@ export function buildGraphQLSchema(
         page: { type: new GraphQLNonNull(GraphQLInt) },
         perPage: { type: new GraphQLNonNull(GraphQLInt) },
         // Resolved lazily, per selected key (skip-own-filter); the result object
-        // (which carries the resolved `query`) is the facets source.
+        // (which carries the per-request facet loader) is the facets source.
         ...(facetsType && {
           facets: {
             type: new GraphQLNonNull(facetsType),
@@ -413,8 +416,15 @@ export function buildGraphQLSchema(
           total: result.total,
           page: pageForOffset(finalQuery.offset, finalQuery.limit),
           perPage: finalQuery.limit,
-          // Carried for the facets resolver (skip-own-filter per key).
-          query: finalQuery,
+          // Carried for the facet field resolvers: the selected keys load
+          // through this per-request batcher (skip-own-filter, grouped by
+          // effective where, one engine dispatch).
+          loadFacet: createFacetLoader(
+            context.engine,
+            searchType,
+            finalQuery,
+            context.onFacetError,
+          ),
         };
       },
     };
@@ -422,7 +432,6 @@ export function buildGraphQLSchema(
 
   /** The keyed facets object for one type (only called with ≥ 1 facetable field). */
   function facetsTypeFor(
-    searchType: SearchType,
     typeName: string,
     facetable: readonly SearchField[],
   ): GraphQLObjectType {
@@ -438,38 +447,11 @@ export function buildGraphQLSchema(
             type: nonNullListOf(
               isRangeFacet(field) ? rangeBucket : valueBucket,
             ),
-            resolve: async (
-              source: Source,
-              _args: unknown,
-              context: SearchContext,
-            ) => {
-              const query = source.query as SearchQuery;
-              // Drop this facet's own filter so its other options still count
-              // (a removed `status` filter also drops the valid-only default, so
-              // the status facet counts across every status).
-              const facetQuery: SearchQuery = {
-                ...query,
-                where: query.where.filter(
-                  (filter) => filter.field !== field.name,
-                ),
-                facets: [field.name],
-                limit: 0,
-                offset: 0,
-              };
-              // A facet is supplementary: degrade a failed facet to an empty list
-              // rather than failing the whole query (which would null the non-null
-              // result and discard the items + every other facet).
-              try {
-                const result = await context.engine.search(
-                  searchType,
-                  facetQuery,
-                );
-                return result.facets[field.name] ?? [];
-              } catch (error) {
-                context.onFacetError?.(field.name, error);
-                return [];
-              }
-            },
+            // The skip-own-filter query building, the batching into one
+            // engine dispatch and the degrade-to-[] error handling all live
+            // in the loader (facet-batch.ts).
+            resolve: (source: Source) =>
+              (source.loadFacet as FacetLoader)(field.name),
           };
         }
         return fields;

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -51,10 +51,11 @@ export interface SearchContext {
   /** Parsed, ordered `Accept-Language`; drives locale selection and output order. */
   readonly acceptLanguage: readonly string[];
   /**
-   * Called, once per selected facet field, when facet computation fails. The
-   * affected facets degrade to empty lists (a supplementary facet must not
-   * fail the whole query); supply this to log the cause. Optional — omit to
-   * swallow silently.
+   * Called once per affected facet field when its computation fails — for a
+   * failed facet query only that query's fields, for a failed batch dispatch
+   * every selected field. The affected facets degrade to empty lists (a
+   * supplementary facet must not fail the whole query); supply this to log
+   * the cause. Optional — omit to swallow silently.
    */
   readonly onFacetError?: (field: string, error: unknown) => void;
 }
@@ -356,13 +357,10 @@ export function buildGraphQLSchema(
     });
 
     // Keyed facets object: one field per facetable field, typed by its kind
-    // (range fields → [RangeBucket!], else [ValueBucket!]). Each field is
-    // computed with its OWN where-filter removed (skip-own-filter), so a
-    // multi-select facet still lists its other options; only the selected fields
-    // are resolved (GraphQL prunes the rest), so the selection IS the request.
-    // The selected fields load through a per-request batcher (createFacetLoader)
-    // that groups them by effective where and dispatches ONE engine.searchFacets
-    // call, instead of one engine search per facet.
+    // (range fields → [RangeBucket!], else [ValueBucket!]). Only the selected
+    // fields are resolved (GraphQL prunes the rest), so the selection IS the
+    // request; how they are computed — skip-own-filter, batched into one
+    // engine dispatch — lives in facet-batch.ts.
     // Like `where`, omitted entirely for a type with no facetable fields (a
     // GraphQL object type must have at least one field).
     const facetable = facetableFields(searchType);
@@ -416,9 +414,7 @@ export function buildGraphQLSchema(
           total: result.total,
           page: pageForOffset(finalQuery.offset, finalQuery.limit),
           perPage: finalQuery.limit,
-          // Carried for the facet field resolvers: the selected keys load
-          // through this per-request batcher (skip-own-filter, grouped by
-          // effective where, one engine dispatch).
+          // Carried for the facet field resolvers (see facet-batch.ts).
           loadFacet: createFacetLoader(
             context.engine,
             searchType,

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -51,11 +51,11 @@ export interface SearchContext {
   /** Parsed, ordered `Accept-Language`; drives locale selection and output order. */
   readonly acceptLanguage: readonly string[];
   /**
-   * Called once per affected facet field when its computation fails — for a
+   * Called once per affected facet field when its computation fails – for a
    * failed facet query only that query's fields, for a failed batch dispatch
    * every selected field. The affected facets degrade to empty lists (a
    * supplementary facet must not fail the whole query); supply this to log
-   * the cause. Optional — omit to swallow silently.
+   * the cause. Optional – omit to swallow silently.
    */
   readonly onFacetError?: (field: string, error: unknown) => void;
 }
@@ -359,8 +359,8 @@ export function buildGraphQLSchema(
     // Keyed facets object: one field per facetable field, typed by its kind
     // (range fields → [RangeBucket!], else [ValueBucket!]). Only the selected
     // fields are resolved (GraphQL prunes the rest), so the selection IS the
-    // request; how they are computed — skip-own-filter, batched into one
-    // engine dispatch — lives in facet-batch.ts.
+    // request; how they are computed – skip-own-filter, batched into one
+    // engine dispatch – lives in facet-batch.ts.
     // Like `where`, omitted entirely for a type with no facetable fields (a
     // GraphQL object type must have at least one field).
     const facetable = facetableFields(searchType);

--- a/packages/search-api-graphql/src/facet-batch.ts
+++ b/packages/search-api-graphql/src/facet-batch.ts
@@ -1,0 +1,86 @@
+import DataLoader from 'dataloader';
+import type {
+  FacetBucket,
+  SearchEngine,
+  SearchQuery,
+  SearchType,
+} from '@lde/search';
+
+/** Resolves one selected facet field to its buckets; see {@link createFacetLoader}. */
+export type FacetLoader = (field: string) => Promise<readonly FacetBucket[]>;
+
+/**
+ * A per-request batcher behind the keyed facets object. Each selected facet
+ * field’s resolver calls the loader; GraphQL resolves the sibling facet
+ * fields synchronously, so the loads land in the same tick, where the
+ * DataLoader collects them into one batch, which is grouped into the fewest
+ * equivalent queries ({@link groupFacetQueries}) and dispatched as ONE
+ * `engine.searchFacets` call — one engine round-trip for the whole sidebar
+ * instead of one search per facet.
+ *
+ * A facet is supplementary: a failed batch degrades every facet in it to an
+ * empty list — reported per field via `onFacetError` — rather than failing
+ * the whole query (which would null the non-null result and discard the
+ * items).
+ */
+export function createFacetLoader(
+  engine: SearchEngine,
+  searchType: SearchType,
+  query: SearchQuery,
+  onFacetError?: (field: string, error: unknown) => void,
+): FacetLoader {
+  const loader = new DataLoader<string, readonly FacetBucket[]>(
+    async (fields) => {
+      const queries = groupFacetQueries(query, fields);
+      const buckets = new Map<string, readonly FacetBucket[]>();
+      try {
+        const results = await engine.searchFacets(searchType, queries);
+        queries.forEach((facetQuery, index) => {
+          for (const field of facetQuery.facets) {
+            buckets.set(field, results[index]?.[field] ?? []);
+          }
+        });
+      } catch (error) {
+        // Leave `buckets` empty: every facet in the batch degrades to [].
+        for (const field of fields) {
+          onFacetError?.(field, error);
+        }
+      }
+      return fields.map((field) => buckets.get(field) ?? []);
+    },
+  );
+  return (field) => loader.load(field);
+}
+
+/**
+ * Group the selected facet fields into the fewest facet-only queries with
+ * unchanged skip-own-filter semantics. Each facet counts with its OWN
+ * `where`-filter removed, so removal only matters for a facet whose field is
+ * actively filtered: every facet whose field carries no filter shares the
+ * untouched `where` — one query faceting all of them (the unfiltered browse
+ * collapses to a single query) — while each own-filtered facet gets its own
+ * query with its own effective `where`. (Dropping a facet’s filter also drops
+ * a policy default on that field, e.g. valid-only `status`, so the facet
+ * counts across every value.) The queries are facet-only: no hits (`limit:
+ * 0`) and, with no hits to order, no `orderBy`.
+ */
+export function groupFacetQueries(
+  query: SearchQuery,
+  fields: readonly string[],
+): SearchQuery[] {
+  const filteredFields = new Set(query.where.map((filter) => filter.field));
+  const facetOnly: SearchQuery = { ...query, orderBy: [], limit: 0, offset: 0 };
+  const sharedFields = fields.filter((field) => !filteredFields.has(field));
+  const queries: SearchQuery[] = [];
+  if (sharedFields.length > 0) {
+    queries.push({ ...facetOnly, facets: sharedFields });
+  }
+  for (const field of fields.filter((field) => filteredFields.has(field))) {
+    queries.push({
+      ...facetOnly,
+      where: query.where.filter((filter) => filter.field !== field),
+      facets: [field],
+    });
+  }
+  return queries;
+}

--- a/packages/search-api-graphql/src/facet-batch.ts
+++ b/packages/search-api-graphql/src/facet-batch.ts
@@ -15,11 +15,11 @@ export type FacetLoader = (field: string) => Promise<readonly FacetBucket[]>;
  * fields synchronously, so the loads land in the same tick, where the
  * DataLoader collects them into one batch, which is grouped into the fewest
  * equivalent queries ({@link groupFacetQueries}) and dispatched as ONE
- * `engine.searchFacets` call — one engine round-trip for the whole sidebar
+ * `engine.searchFacets` call – one engine round-trip for the whole sidebar
  * instead of one search per facet.
  *
  * A facet is supplementary: a failed facet query degrades exactly its own
- * facets to empty lists — reported per field via `onFacetError` — while its
+ * facets to empty lists – reported per field via `onFacetError` – while its
  * siblings keep their buckets; only a batch-level failure (the dispatch
  * itself rejecting) degrades every facet. Neither fails the whole GraphQL
  * query, which would null the non-null result and discard the items.
@@ -44,7 +44,7 @@ export function createFacetLoader(
             }
             return;
           }
-          // A failed (or missing — a port-contract breach) outcome degrades
+          // A failed (or missing – a port-contract breach) outcome degrades
           // exactly this query's facets; its siblings keep theirs.
           const error =
             outcome === undefined
@@ -72,8 +72,8 @@ export function createFacetLoader(
  * unchanged skip-own-filter semantics. Each facet counts with its OWN
  * `where`-filter removed, so removal only matters for a facet whose field is
  * actively filtered: every facet whose field carries no filter shares the
- * untouched `where` — one query faceting all of them (the unfiltered browse
- * collapses to a single query) — while each own-filtered facet gets its own
+ * untouched `where` – one query faceting all of them (the unfiltered browse
+ * collapses to a single query) – while each own-filtered facet gets its own
  * query with its own effective `where`. (Dropping a facet’s filter also drops
  * a policy default on that field, e.g. valid-only `status`, so the facet
  * counts across every value.) The queries are facet-only: no hits (`limit:

--- a/packages/search-api-graphql/src/facet-batch.ts
+++ b/packages/search-api-graphql/src/facet-batch.ts
@@ -18,10 +18,11 @@ export type FacetLoader = (field: string) => Promise<readonly FacetBucket[]>;
  * `engine.searchFacets` call — one engine round-trip for the whole sidebar
  * instead of one search per facet.
  *
- * A facet is supplementary: a failed batch degrades every facet in it to an
- * empty list — reported per field via `onFacetError` — rather than failing
- * the whole query (which would null the non-null result and discard the
- * items).
+ * A facet is supplementary: a failed facet query degrades exactly its own
+ * facets to empty lists — reported per field via `onFacetError` — while its
+ * siblings keep their buckets; only a batch-level failure (the dispatch
+ * itself rejecting) degrades every facet. Neither fails the whole GraphQL
+ * query, which would null the non-null result and discard the items.
  */
 export function createFacetLoader(
   engine: SearchEngine,
@@ -34,14 +35,28 @@ export function createFacetLoader(
       const queries = groupFacetQueries(query, fields);
       const buckets = new Map<string, readonly FacetBucket[]>();
       try {
-        const results = await engine.searchFacets(searchType, queries);
+        const outcomes = await engine.searchFacets(searchType, queries);
         queries.forEach((facetQuery, index) => {
+          const outcome = outcomes[index];
+          if (outcome !== undefined && !('error' in outcome)) {
+            for (const field of facetQuery.facets) {
+              buckets.set(field, outcome.facets[field] ?? []);
+            }
+            return;
+          }
+          // A failed (or missing — a port-contract breach) outcome degrades
+          // exactly this query's facets; its siblings keep theirs.
+          const error =
+            outcome === undefined
+              ? new Error('The engine returned no outcome for this query.')
+              : outcome.error;
           for (const field of facetQuery.facets) {
-            buckets.set(field, results[index]?.[field] ?? []);
+            onFacetError?.(field, error);
           }
         });
       } catch (error) {
-        // Leave `buckets` empty: every facet in the batch degrades to [].
+        // A batch-level failure leaves `buckets` empty: every facet in the
+        // batch degrades to [].
         for (const field of fields) {
           onFacetError?.(field, error);
         }

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { graphql, printSchema } from 'graphql';
 import {
   searchSchema,
-  type FacetMap,
+  type FacetsOutcome,
   type SearchEngine,
   type SearchQuery,
   type SearchResult,
@@ -97,7 +97,7 @@ function fakeEngine(result: SearchResult): {
       },
       async searchFacets(_searchType, queries) {
         batches.push(queries);
-        return queries.map(() => result.facets);
+        return queries.map(() => ({ facets: result.facets }));
       },
     },
     received: () => captured,
@@ -109,7 +109,7 @@ function fakeEngine(result: SearchResult): {
 const noFacets = async (
   _searchType: SearchType,
   queries: readonly SearchQuery[],
-): Promise<readonly FacetMap[]> => queries.map(() => ({}));
+): Promise<readonly FacetsOutcome[]> => queries.map(() => ({ facets: {} }));
 
 const canned: SearchResult = {
   total: 1,

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { graphql, printSchema } from 'graphql';
 import {
   searchSchema,
+  type FacetMap,
   type SearchEngine,
   type SearchQuery,
   type SearchResult,
@@ -77,12 +78,16 @@ const schema: SearchType = {
   ],
 };
 
-/** A fake engine that records the query it received and returns a canned result. */
+/** A fake engine that records the queries it received and returns a canned
+ *  result; each query in a `searchFacets` batch answers with the canned
+ *  facets. */
 function fakeEngine(result: SearchResult): {
   engine: SearchEngine;
   received: () => SearchQuery;
+  facetBatches: () => readonly (readonly SearchQuery[])[];
 } {
   let captured: SearchQuery;
+  const batches: (readonly SearchQuery[])[] = [];
   return {
     engine: {
       schema: searchSchema(schema),
@@ -90,10 +95,21 @@ function fakeEngine(result: SearchResult): {
         captured = query;
         return result;
       },
+      async searchFacets(_searchType, queries) {
+        batches.push(queries);
+        return queries.map(() => result.facets);
+      },
     },
     received: () => captured,
+    facetBatches: () => batches,
   };
 }
+
+/** A `searchFacets` stub for bespoke engines whose test selects no facets. */
+const noFacets = async (
+  _searchType: SearchType,
+  queries: readonly SearchQuery[],
+): Promise<readonly FacetMap[]> => queries.map(() => ({}));
 
 const canned: SearchResult = {
   total: 1,
@@ -326,8 +342,8 @@ describe('buildGraphQLSchema', () => {
     expect(facets.keyword).toEqual([{ value: 'kaarten', count: 3 }]);
   });
 
-  it('resolves every selected facet key, returning [] where the engine has none', async () => {
-    const { engine } = fakeEngine({
+  it('resolves every selected facet key through ONE batched engine dispatch, returning [] where the engine has none', async () => {
+    const { engine, facetBatches } = fakeEngine({
       total: 0,
       hits: [],
       facets: { keyword: [{ value: 'kaarten', count: 1 }] },
@@ -356,10 +372,24 @@ describe('buildGraphQLSchema', () => {
     ]) {
       expect(facets[key]).toEqual([]);
     }
+    // Unfiltered browse: the whole selection collapses to a single facet-only
+    // query inside a single searchFacets dispatch.
+    expect(facetBatches()).toHaveLength(1);
+    const [batch] = facetBatches();
+    expect(batch).toHaveLength(1);
+    expect(batch[0].facets).toEqual([
+      'keyword',
+      'publisher',
+      'terminologySource',
+      'status',
+      'iiif',
+      'size',
+    ]);
+    expect(batch[0].limit).toBe(0);
   });
 
   it('computes a facet with its own where-filter removed (skip-own-filter)', async () => {
-    const { engine, received } = fakeEngine({
+    const { engine, facetBatches } = fakeEngine({
       total: 0,
       hits: [],
       facets: { keyword: [{ value: 'kaarten', count: 1 }] },
@@ -372,7 +402,9 @@ describe('buildGraphQLSchema', () => {
     );
     // The keyword facet query is run with the keyword filter dropped (so its
     // other options still count), but other filters (status) retained.
-    const facetQuery = received();
+    const [batch] = facetBatches();
+    expect(batch).toHaveLength(1);
+    const facetQuery = batch[0];
     expect(facetQuery.facets).toEqual(['keyword']);
     expect(
       facetQuery.where.find((filter) => filter.field === 'keyword'),
@@ -380,24 +412,52 @@ describe('buildGraphQLSchema', () => {
     expect(facetQuery.where).toContainEqual({ field: 'status', in: ['valid'] });
   });
 
-  it('degrades a failed facet to an empty list without failing the whole query', async () => {
-    // A facet is supplementary: its computation runs a separate search (with
-    // `facets` set). Fail only that, leaving the listing search untouched.
+  it('groups the selected facets by effective where: unfiltered facets share one query, each own-filtered facet gets its own', async () => {
+    const { engine, facetBatches } = fakeEngine({
+      total: 0,
+      hits: [],
+      facets: {},
+    });
+    await run(
+      `{ datasets(where: { status: { in: ["valid"] } }) {
+        facets {
+          keyword { value count }
+          publisher { value count }
+          status { value count }
+        }
+      } }`,
+      { engine, acceptLanguage: ['nl'] },
+    );
+    // One dispatch: keyword + publisher (no own filter) share the untouched
+    // where; status (own-filtered) needs its own query with that filter dropped.
+    expect(facetBatches()).toHaveLength(1);
+    const [batch] = facetBatches();
+    expect(batch).toHaveLength(2);
+    expect(batch[0].facets).toEqual(['keyword', 'publisher']);
+    expect(batch[0].where).toEqual([{ field: 'status', in: ['valid'] }]);
+    expect(batch[1].facets).toEqual(['status']);
+    expect(batch[1].where).toEqual([]);
+  });
+
+  it('degrades a failed facet batch to empty lists without failing the whole query', async () => {
+    // A facet is supplementary: its computation runs through the batched
+    // searchFacets dispatch. Fail only that, leaving the listing search
+    // untouched.
     const failedFacets: string[] = [];
     const engine: SearchEngine = {
       schema: searchSchema(schema),
-      async search(_searchType, query) {
-        if (query.facets.length > 0) {
-          throw new Error('facet backend unavailable');
-        }
+      async search() {
         return canned;
+      },
+      async searchFacets() {
+        throw new Error('facet backend unavailable');
       },
     };
     const result = await run(
       `{ datasets {
         total
         items { id }
-        facets { keyword { value count } }
+        facets { keyword { value count } status { value count } }
       } }`,
       {
         engine,
@@ -406,15 +466,17 @@ describe('buildGraphQLSchema', () => {
       },
     );
 
-    // No top-level error: the failed facet degraded rather than nulling the
+    // No top-level error: the failed facets degraded rather than nulling the
     // non-null result and discarding the items.
     expect(result.errors).toBeUndefined();
     const data = result.data?.datasets as Record<string, unknown>;
     expect(data.total).toBe(1);
     expect((data.items as Record<string, unknown>[])[0].id).toBe('https://d/1');
-    // The failed facet degraded to an empty list, and the cause was reported.
+    // Every facet in the failed batch degraded to an empty list, and the
+    // cause was reported once per selected field.
     expect((data.facets as Record<string, unknown[]>).keyword).toEqual([]);
-    expect(failedFacets).toEqual(['keyword']);
+    expect((data.facets as Record<string, unknown[]>).status).toEqual([]);
+    expect(failedFacets.sort()).toEqual(['keyword', 'status']);
   });
 
   it('guards perPage: 0, resolving page to 1 rather than failing on NaN', async () => {
@@ -473,6 +535,7 @@ describe('buildGraphQLSchema', () => {
         captured = query;
         return canned;
       },
+      searchFacets: noFacets,
     };
     const gqlSchema = buildGraphQLSchema(searchSchema(schema), {
       types: {
@@ -599,6 +662,7 @@ describe('buildGraphQLSchema', () => {
           searchedTypes.push(searchType.type);
           return { total: 0, hits: [], facets: {} };
         },
+        searchFacets: noFacets,
       };
       const result = await graphql({
         schema: twoTypeSchema,
@@ -698,6 +762,7 @@ describe('und-locale text output', () => {
           ],
         };
       },
+      searchFacets: noFacets,
     };
     const result = await graphql({
       schema: gqlSchema,

--- a/packages/search-api-graphql/test/facet-batch.test.ts
+++ b/packages/search-api-graphql/test/facet-batch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   searchSchema,
-  type FacetMap,
+  type FacetsOutcome,
   type SearchEngine,
   type SearchQuery,
 } from '@lde/search';
@@ -39,16 +39,19 @@ function recordingEngine(): {
       async search() {
         throw new Error('not under test');
       },
-      async searchFacets(_searchType, queries): Promise<readonly FacetMap[]> {
+      async searchFacets(
+        _searchType,
+        queries,
+      ): Promise<readonly FacetsOutcome[]> {
         batches.push(queries);
-        return queries.map((query) =>
-          Object.fromEntries(
+        return queries.map((query) => ({
+          facets: Object.fromEntries(
             query.facets.map((field) => [
               field,
               [{ value: `${field}-value`, count: 1 }],
             ]),
           ),
-        );
+        }));
       },
     },
     batches,
@@ -161,6 +164,75 @@ describe('createFacetLoader', () => {
     expect(batches).toHaveLength(2);
     expect(batches[0][0].facets).toEqual(['keyword']);
     expect(batches[1][0].facets).toEqual(['status']);
+  });
+
+  it('degrades only the facets of a failed query outcome, keeping its siblings', async () => {
+    const failed: string[] = [];
+    const engine: SearchEngine = {
+      schema: searchSchema(dataset),
+      async search() {
+        throw new Error('not under test');
+      },
+      async searchFacets(
+        _searchType,
+        queries,
+      ): Promise<readonly FacetsOutcome[]> {
+        // Fail exactly the own-filtered status query; answer the rest.
+        return queries.map((query) =>
+          query.facets.includes('status')
+            ? { error: new Error('status query failed') }
+            : {
+                facets: Object.fromEntries(
+                  query.facets.map((field) => [
+                    field,
+                    [{ value: `${field}-value`, count: 1 }],
+                  ]),
+                ),
+              },
+        );
+      },
+    };
+    const filtered: SearchQuery = {
+      ...baseQuery,
+      where: [{ field: 'status', in: ['valid'] }],
+    };
+    const load = createFacetLoader(engine, dataset, filtered, (field) =>
+      failed.push(field),
+    );
+
+    const [keyword, status] = await Promise.all([
+      load('keyword'),
+      load('status'),
+    ]);
+
+    // The shared keyword query keeps its buckets; only status degraded.
+    expect(keyword).toEqual([{ value: 'keyword-value', count: 1 }]);
+    expect(status).toEqual([]);
+    expect(failed).toEqual(['status']);
+  });
+
+  it('treats a missing outcome (a port-contract breach) as a failed query', async () => {
+    const failed: [string, unknown][] = [];
+    const engine: SearchEngine = {
+      schema: searchSchema(dataset),
+      async search() {
+        throw new Error('not under test');
+      },
+      // Shorter than the queries list: a broken engine, not empty facets.
+      async searchFacets(): Promise<readonly FacetsOutcome[]> {
+        return [];
+      },
+    };
+    const load = createFacetLoader(engine, dataset, baseQuery, (field, error) =>
+      failed.push([field, error]),
+    );
+
+    const keyword = await load('keyword');
+
+    expect(keyword).toEqual([]);
+    expect(failed).toHaveLength(1);
+    expect(failed[0][0]).toBe('keyword');
+    expect(String(failed[0][1])).toMatch(/no outcome/);
   });
 
   it('degrades every field of a failed dispatch to [], reporting each', async () => {

--- a/packages/search-api-graphql/test/facet-batch.test.ts
+++ b/packages/search-api-graphql/test/facet-batch.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import {
+  searchSchema,
+  type FacetMap,
+  type SearchEngine,
+  type SearchQuery,
+} from '@lde/search';
+import { createFacetLoader, groupFacetQueries } from '../src/facet-batch.js';
+
+const dataset = {
+  name: 'Dataset',
+  type: 'http://www.w3.org/ns/dcat#Dataset',
+  fields: [
+    { name: 'keyword', kind: 'keyword', facetable: true, filterable: true },
+    { name: 'status', kind: 'keyword', facetable: true, filterable: true },
+    { name: 'publisher', kind: 'reference', facetable: true },
+  ],
+} as const;
+
+const baseQuery: SearchQuery = {
+  where: [],
+  orderBy: [],
+  limit: 20,
+  offset: 40,
+  facets: [],
+  locale: 'nl',
+};
+
+/** An engine that records every searchFacets batch and answers each query
+ *  with a bucket per requested facet field. */
+function recordingEngine(): {
+  engine: SearchEngine;
+  batches: readonly (readonly SearchQuery[])[];
+} {
+  const batches: (readonly SearchQuery[])[] = [];
+  return {
+    engine: {
+      schema: searchSchema(dataset),
+      async search() {
+        throw new Error('not under test');
+      },
+      async searchFacets(_searchType, queries): Promise<readonly FacetMap[]> {
+        batches.push(queries);
+        return queries.map((query) =>
+          Object.fromEntries(
+            query.facets.map((field) => [
+              field,
+              [{ value: `${field}-value`, count: 1 }],
+            ]),
+          ),
+        );
+      },
+    },
+    batches,
+  };
+}
+
+describe('groupFacetQueries', () => {
+  it('collapses an unfiltered selection to a single facet-only query', () => {
+    const queries = groupFacetQueries(baseQuery, [
+      'keyword',
+      'status',
+      'publisher',
+    ]);
+    expect(queries).toEqual([
+      {
+        ...baseQuery,
+        facets: ['keyword', 'status', 'publisher'],
+        limit: 0,
+        offset: 0,
+      },
+    ]);
+  });
+
+  it('gives each own-filtered facet its own query with that filter removed', () => {
+    const filtered: SearchQuery = {
+      ...baseQuery,
+      where: [
+        { field: 'keyword', in: ['x'] },
+        { field: 'status', in: ['valid'] },
+      ],
+    };
+    const queries = groupFacetQueries(filtered, [
+      'keyword',
+      'status',
+      'publisher',
+    ]);
+    // publisher (no own filter) keeps the untouched where; keyword and status
+    // each drop only their own filter.
+    expect(queries).toEqual([
+      { ...filtered, facets: ['publisher'], limit: 0, offset: 0 },
+      {
+        ...filtered,
+        where: [{ field: 'status', in: ['valid'] }],
+        facets: ['keyword'],
+        limit: 0,
+        offset: 0,
+      },
+      {
+        ...filtered,
+        where: [{ field: 'keyword', in: ['x'] }],
+        facets: ['status'],
+        limit: 0,
+        offset: 0,
+      },
+    ]);
+  });
+
+  it('returns no queries for an empty selection', () => {
+    expect(groupFacetQueries(baseQuery, [])).toEqual([]);
+  });
+
+  it('drops the listing orderBy: a facet-only query has no hits to order', () => {
+    const sorted: SearchQuery = {
+      ...baseQuery,
+      orderBy: [{ field: 'relevance', direction: 'desc' }],
+    };
+    const [facetQuery] = groupFacetQueries(sorted, ['keyword']);
+    expect(facetQuery.orderBy).toEqual([]);
+    expect(facetQuery.limit).toBe(0);
+  });
+});
+
+describe('createFacetLoader', () => {
+  it('collects same-tick loads into one dispatch and resolves each field from it', async () => {
+    const { engine, batches } = recordingEngine();
+    const load = createFacetLoader(engine, dataset, baseQuery);
+
+    const [keyword, status] = await Promise.all([
+      load('keyword'),
+      load('status'),
+    ]);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(1);
+    expect(batches[0][0].facets).toEqual(['keyword', 'status']);
+    expect(keyword).toEqual([{ value: 'keyword-value', count: 1 }]);
+    expect(status).toEqual([{ value: 'status-value', count: 1 }]);
+  });
+
+  it('deduplicates a field loaded twice in the same tick', async () => {
+    const { engine, batches } = recordingEngine();
+    const load = createFacetLoader(engine, dataset, baseQuery);
+
+    const [first, second] = await Promise.all([
+      load('keyword'),
+      load('keyword'),
+    ]);
+
+    expect(batches[0][0].facets).toEqual(['keyword']);
+    expect(first).toEqual(second);
+  });
+
+  it('starts a fresh batch for a load arriving after the flush', async () => {
+    const { engine, batches } = recordingEngine();
+    const load = createFacetLoader(engine, dataset, baseQuery);
+
+    await load('keyword');
+    await load('status');
+
+    expect(batches).toHaveLength(2);
+    expect(batches[0][0].facets).toEqual(['keyword']);
+    expect(batches[1][0].facets).toEqual(['status']);
+  });
+
+  it('degrades every field of a failed dispatch to [], reporting each', async () => {
+    const failed: [string, unknown][] = [];
+    const engine: SearchEngine = {
+      schema: searchSchema(dataset),
+      async search() {
+        throw new Error('not under test');
+      },
+      async searchFacets() {
+        throw new Error('facet backend unavailable');
+      },
+    };
+    const load = createFacetLoader(engine, dataset, baseQuery, (field, error) =>
+      failed.push([field, error]),
+    );
+
+    const [keyword, status] = await Promise.all([
+      load('keyword'),
+      load('status'),
+    ]);
+
+    expect(keyword).toEqual([]);
+    expect(status).toEqual([]);
+    expect(failed.map(([field]) => field).sort()).toEqual([
+      'keyword',
+      'status',
+    ]);
+  });
+});

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          // Branches dipped when the monolingual-text output branch was
-          // deleted in favour of the single und-locale text model.
-          branches: 92.38,
+          // Full-suite baseline, re-anchored when covered branches are
+          // deleted (autoUpdate only ever raises; see AGENTS.md).
+          branches: 92.66,
           statements: 100,
         },
       },

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -14,7 +14,7 @@ export default mergeConfig(
           lines: 100,
           // Full-suite baseline, re-anchored when covered branches are
           // deleted (autoUpdate only ever raises; see AGENTS.md).
-          branches: 92.66,
+          branches: 93.04,
           statements: 100,
         },
       },

--- a/packages/search-typesense/README.md
+++ b/packages/search-typesense/README.md
@@ -28,6 +28,11 @@ search/sort keys) matches what the projection writes, via
 - reconstructs the logical `SearchResult` (`parseSearchResponse`) — language
   maps, labelled references, labelled facet buckets.
 
+`searchFacets` — the port’s batch entry point — answers a whole batch of
+facet-only queries (e.g. a faceted sidebar’s skip-own-filter variants) as a
+**single `multi_search` round-trip**, with one bundled label lookup shared by
+every facet result in the batch.
+
 The pure halves `buildSearchParams` and `parseSearchResponse` are exported for
 direct use and testing.
 

--- a/packages/search-typesense/README.md
+++ b/packages/search-typesense/README.md
@@ -31,7 +31,8 @@ search/sort keys) matches what the projection writes, via
 `searchFacets` — the port’s batch entry point — answers a whole batch of
 facet-only queries (e.g. a faceted sidebar’s skip-own-filter variants) as a
 **single `multi_search` round-trip**, with one bundled label lookup shared by
-every facet result in the batch.
+every facet result in the batch. A failed entry is reported in place as a
+per-query outcome, so its siblings’ facets survive.
 
 The pure halves `buildSearchParams` and `parseSearchResponse` are exported for
 direct use and testing.

--- a/packages/search-typesense/README.md
+++ b/packages/search-typesense/README.md
@@ -28,7 +28,7 @@ search/sort keys) matches what the projection writes, via
 - reconstructs the logical `SearchResult` (`parseSearchResponse`) — language
   maps, labelled references, labelled facet buckets.
 
-`searchFacets` — the port’s batch entry point — answers a whole batch of
+`searchFacets` – the port’s batch entry point – answers a whole batch of
 facet-only queries (e.g. a faceted sidebar’s skip-own-filter variants) as a
 **single `multi_search` round-trip**, with one bundled label lookup shared by
 every facet result in the batch. A failed entry is reported in place as a

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -1,7 +1,7 @@
 import type { Client } from 'typesense';
 import {
   type FacetBucket,
-  type FacetMap,
+  type FacetsOutcome,
   type LocalizedValue,
   type Reference,
   type ReferenceField,
@@ -70,8 +70,10 @@ export interface TypesenseSearchEngineOptions<
  * `labels` collection in one lookup, and reconstructs the engine-neutral
  * {@link SearchResult} ({@link parseSearchResponse}). `searchFacets` answers
  * a whole facet batch (e.g. a sidebar’s skip-own-filter query variants) as a
- * single `multi_search` round-trip with one shared label lookup. Every engine
- * specific stays here; consumers see only logical documents.
+ * single `multi_search` round-trip with one shared label lookup; a failed
+ * entry is reported in place as a per-query outcome, so it never discards
+ * its siblings’ facets. Every engine specific stays here; consumers see only
+ * logical documents.
  *
  * With a schema built by `searchSchema` over `defineSearchType` literals,
  * `search()` accepts only the deployment’s own types and returns typo-safe
@@ -150,12 +152,13 @@ export function createTypesenseSearchEngine<
 
   // Labels are supplementary: a failed lookup (e.g. the sidecar collection
   // mid-rebuild) degrades to id-only references rather than failing the whole
-  // search, so the listing still renders with bare IRIs.
+  // search, so the listing still renders with bare IRIs. `iris` is a thunk so
+  // the cached and no-sidecar paths never pay for collecting them.
   async function resolveLabels(
     cachedLabelsPromise:
       | Promise<ReadonlyMap<string, LocalizedValue>>
       | undefined,
-    iris: readonly string[],
+    iris: () => readonly string[],
   ): Promise<ReadonlyMap<string, LocalizedValue>> {
     if (cachedLabelsPromise !== undefined) {
       return cachedLabelsPromise;
@@ -164,7 +167,7 @@ export function createTypesenseSearchEngine<
       return new Map();
     }
     try {
-      return await fetchLabels(client, options.labelsCollection, iris);
+      return await fetchLabels(client, options.labelsCollection, iris());
     } catch (error) {
       options.onLabelError?.(error);
       return new Map();
@@ -188,8 +191,7 @@ export function createTypesenseSearchEngine<
         .collections(collections.get(searchType.type) as string)
         .documents()
         .search(params)) as TypesenseSearchResponse;
-      const labels = await resolveLabels(
-        cachedLabelsPromise,
+      const labels = await resolveLabels(cachedLabelsPromise, () =>
         referenceIris(response, searchType),
       );
       return parseSearchResponse(response, searchType, labels);
@@ -197,7 +199,7 @@ export function createTypesenseSearchEngine<
     async searchFacets(
       searchType: SearchType,
       queries: readonly SearchQuery[],
-    ): Promise<readonly FacetMap[]> {
+    ): Promise<readonly FacetsOutcome[]> {
       assertTypeInSchema(schema, searchType);
       for (const query of queries) {
         assertValidQuery(query, searchType);
@@ -208,13 +210,14 @@ export function createTypesenseSearchEngine<
       const collection = collections.get(searchType.type) as string;
       const cachedLabelsPromise = startCachedLabels();
       // The whole batch travels as ONE multi_search round-trip. Each query
-      // compiles as facet-only regardless of the limit it carries: hits are
-      // never returned across this method, so none are transferred.
+      // compiles as facet-only regardless of what it carries: no hits
+      // (per_page 0) and no ordering — nothing is transferred or sorted that
+      // this method cannot return.
       const { results } = (await client.multiSearch.perform({
         searches: queries.map((query) => ({
           collection,
           ...buildSearchParams(
-            { ...query, limit: 0, offset: 0 },
+            { ...query, orderBy: [], limit: 0, offset: 0 },
             searchType,
             options,
           ),
@@ -222,27 +225,29 @@ export function createTypesenseSearchEngine<
       })) as {
         results: readonly (TypesenseSearchResponse | TypesenseErrorEntry)[];
       };
-      // multi_search reports a failed entry inline instead of rejecting the
-      // call; surface it as a rejection so a caller never mistakes a failed
-      // batch for empty facets.
-      const responses = results.map((result, index) => {
-        if ('error' in result) {
-          throw new Error(
-            `Typesense facet search ${index + 1}/${results.length} failed${
-              result.code !== undefined ? ` (${result.code})` : ''
-            }: ${result.error}`,
-          );
-        }
-        return result;
-      });
-      // One label lookup serves every facet result in the batch.
-      const labels = await resolveLabels(cachedLabelsPromise, [
+      // One label lookup serves every successful facet result in the batch.
+      const responses = results.filter(
+        (result): result is TypesenseSearchResponse => !('error' in result),
+      );
+      const labels = await resolveLabels(cachedLabelsPromise, () => [
         ...new Set(
           responses.flatMap((response) => referenceIris(response, searchType)),
         ),
       ]);
-      return responses.map(
-        (response) => parseSearchResponse(response, searchType, labels).facets,
+      // multi_search reports a failed entry inline instead of rejecting the
+      // call; pass that through as a per-query outcome — naming the facets,
+      // not the position, since the batch order is the caller's internal —
+      // so one failed query never discards its siblings' facets.
+      return results.map((result, index) =>
+        'error' in result
+          ? {
+              error: new Error(
+                `Typesense facet search for “${queries[index].facets.join('”, “')}” failed${
+                  result.code !== undefined ? ` (${result.code})` : ''
+                }: ${result.error}`,
+              ),
+            }
+          : { facets: parseSearchResponse(result, searchType, labels).facets },
       );
     },
   };
@@ -345,9 +350,19 @@ export async function fetchLabels(
     });
   }
   const { results } = (await client.multiSearch.perform({ searches })) as {
-    results: readonly TypesenseSearchResponse[];
+    results: readonly (TypesenseSearchResponse | TypesenseErrorEntry)[];
   };
   for (const result of results) {
+    // multi_search reports a failed entry inline instead of rejecting; throw
+    // so the caller's degradation path (onLabelError, id-only references)
+    // engages rather than mistaking the failure for absent labels.
+    if ('error' in result) {
+      throw new Error(
+        `Typesense label lookup failed${
+          result.code !== undefined ? ` (${result.code})` : ''
+        }: ${result.error}`,
+      );
+    }
     for (const hit of result.hits ?? []) {
       labels.set(String(hit.document.id), labelToLocalizedValue(hit.document));
     }

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -1,6 +1,7 @@
 import type { Client } from 'typesense';
 import {
   type FacetBucket,
+  type FacetMap,
   type LocalizedValue,
   type Reference,
   type ReferenceField,
@@ -67,8 +68,10 @@ export interface TypesenseSearchEngineOptions<
  * ({@link buildSearchParams}), runs it against the type’s collection,
  * resolves the reference labels for the page of hits from the sidecar
  * `labels` collection in one lookup, and reconstructs the engine-neutral
- * {@link SearchResult} ({@link parseSearchResponse}). Every engine specific
- * stays here; consumers see only logical documents.
+ * {@link SearchResult} ({@link parseSearchResponse}). `searchFacets` answers
+ * a whole facet batch (e.g. a sidebar’s skip-own-filter query variants) as a
+ * single `multi_search` round-trip with one shared label lookup. Every engine
+ * specific stays here; consumers see only logical documents.
  *
  * With a schema built by `searchSchema` over `defineSearchType` literals,
  * `search()` accepts only the deployment’s own types and returns typo-safe
@@ -130,6 +133,44 @@ export function createTypesenseSearchEngine<
     return inFlightLoad;
   }
 
+  // Cached path: the once-loaded full collection serves labels by in-memory
+  // lookup (no per-search round-trip). The load does not depend on the
+  // response, so it is started BEFORE awaiting the search and runs alongside
+  // it; it never rejects (a failed load degrades to an empty map), so it
+  // cannot leave an unhandled rejection behind if the search itself fails.
+  // `undefined` when the cache (or the sidecar) is not configured.
+  function startCachedLabels():
+    | Promise<ReadonlyMap<string, LocalizedValue>>
+    | undefined {
+    return options.labelsCollection !== undefined &&
+      options.labelCacheTtlMs !== undefined
+      ? cachedAllLabels(options.labelsCollection, options.labelCacheTtlMs)
+      : undefined;
+  }
+
+  // Labels are supplementary: a failed lookup (e.g. the sidecar collection
+  // mid-rebuild) degrades to id-only references rather than failing the whole
+  // search, so the listing still renders with bare IRIs.
+  async function resolveLabels(
+    cachedLabelsPromise:
+      | Promise<ReadonlyMap<string, LocalizedValue>>
+      | undefined,
+    iris: readonly string[],
+  ): Promise<ReadonlyMap<string, LocalizedValue>> {
+    if (cachedLabelsPromise !== undefined) {
+      return cachedLabelsPromise;
+    }
+    if (options.labelsCollection === undefined) {
+      return new Map();
+    }
+    try {
+      return await fetchLabels(client, options.labelsCollection, iris);
+    } catch (error) {
+      options.onLabelError?.(error);
+      return new Map();
+    }
+  }
+
   const engine: SearchEngine = {
     schema,
     async search(
@@ -142,38 +183,67 @@ export function createTypesenseSearchEngine<
       assertTypeInSchema(schema, searchType);
       assertValidQuery(query, searchType);
       const params = buildSearchParams(query, searchType, options);
-      // Cached path: the once-loaded full collection serves labels by in-memory
-      // lookup (no per-search round-trip). The load does not depend on the
-      // response, so it runs alongside the search; it never rejects (a failed
-      // load degrades to an empty map), so it cannot leave an unhandled
-      // rejection behind if the search itself fails.
-      const cachedLabelsPromise =
-        options.labelsCollection !== undefined &&
-        options.labelCacheTtlMs !== undefined
-          ? cachedAllLabels(options.labelsCollection, options.labelCacheTtlMs)
-          : undefined;
+      const cachedLabelsPromise = startCachedLabels();
       const response = (await client
         .collections(collections.get(searchType.type) as string)
         .documents()
         .search(params)) as TypesenseSearchResponse;
-      // Labels are supplementary: a failed lookup (e.g. the sidecar collection
-      // mid-rebuild) degrades to id-only references rather than failing the whole
-      // search, so the listing still renders with bare IRIs.
-      let labels: ReadonlyMap<string, LocalizedValue> = new Map();
-      if (cachedLabelsPromise !== undefined) {
-        labels = await cachedLabelsPromise;
-      } else if (options.labelsCollection !== undefined) {
-        try {
-          labels = await fetchLabels(
-            client,
-            options.labelsCollection,
-            referenceIris(response, searchType),
-          );
-        } catch (error) {
-          options.onLabelError?.(error);
-        }
-      }
+      const labels = await resolveLabels(
+        cachedLabelsPromise,
+        referenceIris(response, searchType),
+      );
       return parseSearchResponse(response, searchType, labels);
+    },
+    async searchFacets(
+      searchType: SearchType,
+      queries: readonly SearchQuery[],
+    ): Promise<readonly FacetMap[]> {
+      assertTypeInSchema(schema, searchType);
+      for (const query of queries) {
+        assertValidQuery(query, searchType);
+      }
+      if (queries.length === 0) {
+        return [];
+      }
+      const collection = collections.get(searchType.type) as string;
+      const cachedLabelsPromise = startCachedLabels();
+      // The whole batch travels as ONE multi_search round-trip. Each query
+      // compiles as facet-only regardless of the limit it carries: hits are
+      // never returned across this method, so none are transferred.
+      const { results } = (await client.multiSearch.perform({
+        searches: queries.map((query) => ({
+          collection,
+          ...buildSearchParams(
+            { ...query, limit: 0, offset: 0 },
+            searchType,
+            options,
+          ),
+        })),
+      })) as {
+        results: readonly (TypesenseSearchResponse | TypesenseErrorEntry)[];
+      };
+      // multi_search reports a failed entry inline instead of rejecting the
+      // call; surface it as a rejection so a caller never mistakes a failed
+      // batch for empty facets.
+      const responses = results.map((result, index) => {
+        if ('error' in result) {
+          throw new Error(
+            `Typesense facet search ${index + 1}/${results.length} failed${
+              result.code !== undefined ? ` (${result.code})` : ''
+            }: ${result.error}`,
+          );
+        }
+        return result;
+      });
+      // One label lookup serves every facet result in the batch.
+      const labels = await resolveLabels(cachedLabelsPromise, [
+        ...new Set(
+          responses.flatMap((response) => referenceIris(response, searchType)),
+        ),
+      ]);
+      return responses.map(
+        (response) => parseSearchResponse(response, searchType, labels).facets,
+      );
     },
   };
   // The runtime object is string-keyed; the literal-schema typing narrows it.
@@ -303,6 +373,13 @@ function labelToLocalizedValue(
     map.und = [document.label];
   }
   return map;
+}
+
+/** A failed entry in a `multi_search` response: Typesense reports a
+ *  per-search failure inline (the call itself still resolves). */
+interface TypesenseErrorEntry {
+  readonly error: string;
+  readonly code?: number;
 }
 
 /** The subset of a Typesense search response this adapter reads. */

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -211,7 +211,7 @@ export function createTypesenseSearchEngine<
       const cachedLabelsPromise = startCachedLabels();
       // The whole batch travels as ONE multi_search round-trip. Each query
       // compiles as facet-only regardless of what it carries: no hits
-      // (per_page 0) and no ordering — nothing is transferred or sorted that
+      // (per_page 0) and no ordering – nothing is transferred or sorted that
       // this method cannot return.
       const { results } = (await client.multiSearch.perform({
         searches: queries.map((query) => ({
@@ -235,8 +235,8 @@ export function createTypesenseSearchEngine<
         ),
       ]);
       // multi_search reports a failed entry inline instead of rejecting the
-      // call; pass that through as a per-query outcome — naming the facets,
-      // not the position, since the batch order is the caller's internal —
+      // call; pass that through as a per-query outcome – naming the facets,
+      // not the position, since the batch order is the caller's internal –
       // so one failed query never discards its siblings' facets.
       return results.map((result, index) =>
         'error' in result

--- a/packages/search-typesense/test/fake-typesense-client.ts
+++ b/packages/search-typesense/test/fake-typesense-client.ts
@@ -1,0 +1,84 @@
+import type { Client } from 'typesense';
+
+/** The backtick-escaped ids of a `filter_by: id:[…]` clause – the wire form
+ *  `escapeFilterValue` produces. */
+export function filterByIds(filterBy: string): string[] {
+  return [...filterBy.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+}
+
+/** An entry answerer that resolves a label lookup from `docsById`: the
+ *  requested ids that exist come back as label documents. */
+export function labelLookup(
+  docsById: Record<string, Record<string, unknown>>,
+): (search: Record<string, unknown>) => Record<string, unknown> {
+  return (search) => {
+    const hits = filterByIds(String(search.filter_by))
+      .filter((id) => docsById[id] !== undefined)
+      .map((id) => ({ document: { id, ...docsById[id] } }));
+    return { found: hits.length, hits };
+  };
+}
+
+export interface FakeTypesenseClientOptions {
+  /** Answer for `collections().documents().search()`. */
+  readonly searchResponse?: Record<string, unknown>;
+  /** The labels-collection export endpoint (JSONL); calls are counted. */
+  readonly exportJsonl?: () => Promise<string>;
+  /** Answers one `multi_search` entry (an inline `{ error }` entry included);
+   *  a throw rejects the whole perform. */
+  readonly multiSearch?: (
+    search: Record<string, unknown>,
+    index: number,
+  ) => Record<string, unknown>;
+}
+
+export interface FakeTypesenseClient {
+  readonly client: Client;
+  /** Every `multi_search` POST’s `searches` array, in call order, so batching
+   *  is observable. */
+  readonly performs: readonly (readonly Record<string, unknown>[])[];
+  /** How often the documents export endpoint was called, so the label cache’s
+   *  load behaviour is observable. */
+  readonly exportCalls: () => number;
+}
+
+/**
+ * A configurable fake Typesense client covering the three endpoints the
+ * engine touches: document search, documents export (the label cache), and
+ * `multi_search` (facet batches and label lookups). Unconfigured endpoints
+ * reject, so a test never silently exercises a path it did not declare.
+ */
+export function fakeTypesenseClient(
+  options: FakeTypesenseClientOptions = {},
+): FakeTypesenseClient {
+  const performs: (readonly Record<string, unknown>[])[] = [];
+  let exportCalls = 0;
+  const client = {
+    collections: () => ({
+      documents: () => ({
+        search: () =>
+          Promise.resolve(options.searchResponse ?? { found: 0, hits: [] }),
+        export: () => {
+          exportCalls += 1;
+          return options.exportJsonl === undefined
+            ? Promise.reject(new Error('No exportJsonl configured.'))
+            : options.exportJsonl();
+        },
+      }),
+    }),
+    multiSearch: {
+      perform: async (request: { searches: Record<string, unknown>[] }) => {
+        performs.push(request.searches);
+        if (options.multiSearch === undefined) {
+          throw new Error('No multiSearch configured.');
+        }
+        return { results: request.searches.map(options.multiSearch) };
+      },
+    },
+  };
+  return {
+    client: client as unknown as Client,
+    performs,
+    exportCalls: () => exportCalls,
+  };
+}

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -420,6 +420,239 @@ describe('createTypesenseSearchEngine label cache (labelCacheTtlMs)', () => {
   });
 });
 
+/** The backtick-escaped ids of a `filter_by: id:[…]` clause — the wire form
+ *  `escapeFilterValue` produces; shared by the label-lookup fakes. */
+function filterByIds(filterBy: string): string[] {
+  return [...filterBy.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+}
+
+describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () => {
+  const facetBrowse: SearchQuery = {
+    where: [],
+    orderBy: [],
+    limit: 0,
+    offset: 0,
+    facets: [],
+    locale: 'nl',
+  };
+
+  // A fake client whose multi_search answers each entry via `perEntry`,
+  // recording every POST so the batching is observable.
+  function fakeClient(
+    perEntry: (
+      search: Record<string, unknown>,
+      index: number,
+    ) => Record<string, unknown>,
+  ) {
+    const performs: Record<string, unknown>[][] = [];
+    const client = {
+      multiSearch: {
+        perform: (request: { searches: Record<string, unknown>[] }) => {
+          performs.push(request.searches);
+          return Promise.resolve({
+            results: request.searches.map(perEntry),
+          });
+        },
+      },
+    };
+    return { client: client as unknown as Client, performs };
+  }
+
+  it('sends the whole batch as ONE multi_search and maps the results positionally', async () => {
+    const { client, performs } = fakeClient((search) => ({
+      found: 0,
+      hits: [],
+      facet_counts: [
+        {
+          field_name: search.facet_by,
+          counts: [{ value: `${search.facet_by}-value`, count: 1 }],
+        },
+      ],
+    }));
+    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
+      collections: { Dataset: 'datasets' },
+    });
+
+    const facetMaps = await engine.searchFacets(schema, [
+      { ...facetBrowse, facets: ['keyword'] },
+      // A non-zero limit still compiles facet-only: the port never returns
+      // hits, so the adapter normalizes rather than transferring a page.
+      { ...facetBrowse, limit: 10, facets: ['status'] },
+    ]);
+
+    expect(performs).toHaveLength(1);
+    expect(performs[0]).toHaveLength(2);
+    expect(performs[0][0]).toMatchObject({
+      collection: 'datasets',
+      facet_by: 'keyword',
+      per_page: 0,
+    });
+    expect(performs[0][1]).toMatchObject({
+      collection: 'datasets',
+      facet_by: 'status',
+      per_page: 0,
+    });
+    expect(facetMaps[0].keyword).toEqual([
+      { value: 'keyword-value', count: 1 },
+    ]);
+    expect(facetMaps[1].status).toEqual([{ value: 'status-value', count: 1 }]);
+  });
+
+  it('makes no request for an empty batch', async () => {
+    const { client, performs } = fakeClient(() => ({ found: 0, hits: [] }));
+    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
+      collections: { Dataset: 'datasets' },
+    });
+    await expect(engine.searchFacets(schema, [])).resolves.toEqual([]);
+    expect(performs).toHaveLength(0);
+  });
+
+  it('surfaces a failed multi_search entry as a rejection, not as empty facets', async () => {
+    const { client } = fakeClient((_search, index) =>
+      index === 1
+        ? { code: 404, error: 'collection not found' }
+        : { found: 0, hits: [], facet_counts: [] },
+    );
+    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
+      collections: { Dataset: 'datasets' },
+    });
+    await expect(
+      engine.searchFacets(schema, [
+        { ...facetBrowse, facets: ['keyword'] },
+        { ...facetBrowse, facets: ['status'] },
+      ]),
+    ).rejects.toThrow(/facet search 2\/2 failed \(404\): collection not found/);
+  });
+
+  it('reports a failed entry that carries no status code', async () => {
+    const { client } = fakeClient(() => ({ error: 'malformed query' }));
+    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
+      collections: { Dataset: 'datasets' },
+    });
+    await expect(
+      engine.searchFacets(schema, [{ ...facetBrowse, facets: ['keyword'] }]),
+    ).rejects.toThrow(/facet search 1\/1 failed: malformed query/);
+  });
+
+  it('serves batch labels from the in-memory cache without a per-batch lookup', async () => {
+    let exportCalls = 0;
+    const performs: Record<string, unknown>[][] = [];
+    const client = {
+      collections: () => ({
+        documents: () => ({
+          export: () => {
+            exportCalls += 1;
+            return Promise.resolve(
+              JSON.stringify({
+                id: 'https://org/1',
+                label_nl: 'Het Utrechts Archief',
+              }),
+            );
+          },
+        }),
+      }),
+      multiSearch: {
+        perform: (request: { searches: Record<string, unknown>[] }) => {
+          performs.push(request.searches);
+          return Promise.resolve({
+            results: request.searches.map(() => ({
+              found: 0,
+              hits: [],
+              facet_counts: [
+                {
+                  field_name: 'publisher',
+                  counts: [{ value: 'https://org/1', count: 1 }],
+                },
+              ],
+            })),
+          });
+        },
+      },
+    } as unknown as Client;
+    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
+      collections: { Dataset: 'datasets' },
+      labelsCollection: 'labels',
+      labelCacheTtlMs: 60_000,
+    });
+
+    const facetMaps = await engine.searchFacets(schema, [
+      { ...facetBrowse, facets: ['publisher'] },
+    ]);
+
+    // ONE export populated the cache; the only multi_search is the facet
+    // batch itself — no per-batch label lookup.
+    expect(exportCalls).toBe(1);
+    expect(performs).toHaveLength(1);
+    expect(facetMaps[0].publisher).toEqual([
+      {
+        value: 'https://org/1',
+        count: 1,
+        label: { nl: ['Het Utrechts Archief'] },
+      },
+    ]);
+  });
+
+  it('resolves reference-facet labels for the whole batch in one bundled lookup', async () => {
+    const labelDocs: Record<string, Record<string, unknown>> = {
+      'https://org/1': { label_nl: 'Het Utrechts Archief' },
+      'https://org/2': { label_nl: 'Rijksmuseum' },
+    };
+    const { client, performs } = fakeClient((search, index) => {
+      if (search.query_by === 'label') {
+        const ids = filterByIds(String(search.filter_by));
+        return {
+          found: ids.length,
+          hits: ids
+            .filter((id) => labelDocs[id] !== undefined)
+            .map((id) => ({ document: { id, ...labelDocs[id] } })),
+        };
+      }
+      return {
+        found: 0,
+        hits: [],
+        facet_counts: [
+          {
+            field_name: 'publisher',
+            counts: [
+              {
+                value: index === 0 ? 'https://org/1' : 'https://org/2',
+                count: 1,
+              },
+            ],
+          },
+        ],
+      };
+    });
+    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
+      collections: { Dataset: 'datasets' },
+      labelsCollection: 'labels',
+    });
+
+    const facetMaps = await engine.searchFacets(schema, [
+      { ...facetBrowse, facets: ['publisher'] },
+      {
+        ...facetBrowse,
+        where: [{ field: 'status', in: ['valid'] }],
+        facets: ['publisher'],
+      },
+    ]);
+
+    // One facet multi_search + ONE label lookup shared by the whole batch.
+    expect(performs).toHaveLength(2);
+    expect(performs[1]).toHaveLength(1);
+    expect(facetMaps[0].publisher).toEqual([
+      {
+        value: 'https://org/1',
+        count: 1,
+        label: { nl: ['Het Utrechts Archief'] },
+      },
+    ]);
+    expect(facetMaps[1].publisher).toEqual([
+      { value: 'https://org/2', count: 1, label: { nl: ['Rijksmuseum'] } },
+    ]);
+  });
+});
+
 describe('fetchLabels', () => {
   // A fake Typesense client whose multi_search returns the requested ids that
   // exist in `docsById`, recording each POST's per-search id-lists so batching
@@ -431,9 +664,7 @@ describe('fetchLabels', () => {
       multiSearch: {
         perform: (request: { searches: { readonly filter_by: string }[] }) => {
           const batches = request.searches.map((search) =>
-            [...search.filter_by.matchAll(/`([^`]+)`/g)].map(
-              (match) => match[1],
-            ),
+            filterByIds(search.filter_by),
           );
           posts.push(batches);
           const results = batches.map((ids) => {

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -473,7 +473,7 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
       collections: { Dataset: 'datasets' },
     });
 
-    const facetMaps = await engine.searchFacets(schema, [
+    const outcomes = await engine.searchFacets(schema, [
       { ...facetBrowse, facets: ['keyword'] },
       // A non-zero limit still compiles facet-only: the port never returns
       // hits, so the adapter normalizes rather than transferring a page.
@@ -492,10 +492,12 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
       facet_by: 'status',
       per_page: 0,
     });
-    expect(facetMaps[0].keyword).toEqual([
-      { value: 'keyword-value', count: 1 },
-    ]);
-    expect(facetMaps[1].status).toEqual([{ value: 'status-value', count: 1 }]);
+    expect(outcomes[0]).toEqual({
+      facets: { keyword: [{ value: 'keyword-value', count: 1 }] },
+    });
+    expect(outcomes[1]).toEqual({
+      facets: { status: [{ value: 'status-value', count: 1 }] },
+    });
   });
 
   it('makes no request for an empty batch', async () => {
@@ -507,7 +509,7 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     expect(performs).toHaveLength(0);
   });
 
-  it('surfaces a failed multi_search entry as a rejection, not as empty facets', async () => {
+  it('reports a failed entry as an in-place error outcome, keeping its siblings', async () => {
     const { client } = fakeClient((_search, index) =>
       index === 1
         ? { code: 404, error: 'collection not found' }
@@ -516,12 +518,22 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
       collections: { Dataset: 'datasets' },
     });
-    await expect(
-      engine.searchFacets(schema, [
-        { ...facetBrowse, facets: ['keyword'] },
-        { ...facetBrowse, facets: ['status'] },
-      ]),
-    ).rejects.toThrow(/facet search 2\/2 failed \(404\): collection not found/);
+
+    const outcomes = await engine.searchFacets(schema, [
+      { ...facetBrowse, facets: ['keyword'] },
+      { ...facetBrowse, facets: ['status'] },
+    ]);
+
+    // The sibling entry's facets survive the failed one.
+    expect(outcomes[0]).toEqual({ facets: {} });
+    const failed = outcomes[1];
+    if (!('error' in failed)) {
+      throw new Error('Expected an error outcome.');
+    }
+    // The error names the failed query's facets, not its batch position.
+    expect(String(failed.error)).toMatch(
+      /facet search for “status” failed \(404\): collection not found/,
+    );
   });
 
   it('reports a failed entry that carries no status code', async () => {
@@ -529,9 +541,15 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
       collections: { Dataset: 'datasets' },
     });
-    await expect(
-      engine.searchFacets(schema, [{ ...facetBrowse, facets: ['keyword'] }]),
-    ).rejects.toThrow(/facet search 1\/1 failed: malformed query/);
+    const [outcome] = await engine.searchFacets(schema, [
+      { ...facetBrowse, facets: ['keyword'] },
+    ]);
+    if (!('error' in outcome)) {
+      throw new Error('Expected an error outcome.');
+    }
+    expect(String(outcome.error)).toMatch(
+      /facet search for “keyword” failed: malformed query/,
+    );
   });
 
   it('serves batch labels from the in-memory cache without a per-batch lookup', async () => {
@@ -575,7 +593,7 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
       labelCacheTtlMs: 60_000,
     });
 
-    const facetMaps = await engine.searchFacets(schema, [
+    const outcomes = await engine.searchFacets(schema, [
       { ...facetBrowse, facets: ['publisher'] },
     ]);
 
@@ -583,13 +601,17 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     // batch itself — no per-batch label lookup.
     expect(exportCalls).toBe(1);
     expect(performs).toHaveLength(1);
-    expect(facetMaps[0].publisher).toEqual([
-      {
-        value: 'https://org/1',
-        count: 1,
-        label: { nl: ['Het Utrechts Archief'] },
+    expect(outcomes[0]).toEqual({
+      facets: {
+        publisher: [
+          {
+            value: 'https://org/1',
+            count: 1,
+            label: { nl: ['Het Utrechts Archief'] },
+          },
+        ],
       },
-    ]);
+    });
   });
 
   it('resolves reference-facet labels for the whole batch in one bundled lookup', async () => {
@@ -628,7 +650,7 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
       labelsCollection: 'labels',
     });
 
-    const facetMaps = await engine.searchFacets(schema, [
+    const outcomes = await engine.searchFacets(schema, [
       { ...facetBrowse, facets: ['publisher'] },
       {
         ...facetBrowse,
@@ -640,16 +662,24 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     // One facet multi_search + ONE label lookup shared by the whole batch.
     expect(performs).toHaveLength(2);
     expect(performs[1]).toHaveLength(1);
-    expect(facetMaps[0].publisher).toEqual([
-      {
-        value: 'https://org/1',
-        count: 1,
-        label: { nl: ['Het Utrechts Archief'] },
+    expect(outcomes[0]).toEqual({
+      facets: {
+        publisher: [
+          {
+            value: 'https://org/1',
+            count: 1,
+            label: { nl: ['Het Utrechts Archief'] },
+          },
+        ],
       },
-    ]);
-    expect(facetMaps[1].publisher).toEqual([
-      { value: 'https://org/2', count: 1, label: { nl: ['Rijksmuseum'] } },
-    ]);
+    });
+    expect(outcomes[1]).toEqual({
+      facets: {
+        publisher: [
+          { value: 'https://org/2', count: 1, label: { nl: ['Rijksmuseum'] } },
+        ],
+      },
+    });
   });
 });
 
@@ -719,6 +749,34 @@ describe('fetchLabels', () => {
     const labels = await fetchLabels(client, 'labels', []);
     expect(labels.size).toBe(0);
     expect(posts).toHaveLength(0);
+  });
+
+  it('throws on an inline multi_search error entry instead of returning no labels', async () => {
+    // multi_search reports a failed entry inline (the call still resolves);
+    // fetchLabels must throw so the engine's degradation path (onLabelError,
+    // id-only references) engages instead of silently missing every label.
+    const client = {
+      multiSearch: {
+        perform: () =>
+          Promise.resolve({
+            results: [{ code: 503, error: 'lookup failed' }],
+          }),
+      },
+    } as unknown as Pick<Client, 'multiSearch'>;
+    await expect(
+      fetchLabels(client, 'labels', ['https://org/1']),
+    ).rejects.toThrow(/label lookup failed \(503\): lookup failed/);
+
+    // An error entry without a status code still throws.
+    const clientWithoutCode = {
+      multiSearch: {
+        perform: () =>
+          Promise.resolve({ results: [{ error: 'lookup failed' }] }),
+      },
+    } as unknown as Pick<Client, 'multiSearch'>;
+    await expect(
+      fetchLabels(clientWithoutCode, 'labels', ['https://org/1']),
+    ).rejects.toThrow(/label lookup failed: lookup failed/);
   });
 });
 

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -11,6 +11,21 @@ import {
   fetchLabels,
   parseSearchResponse,
 } from '../src/search.js';
+import {
+  fakeTypesenseClient,
+  filterByIds,
+  labelLookup,
+} from './fake-typesense-client.js';
+
+// Document-search hits referencing labelled organizations; the second stores
+// a scalar (non-array) reference value. Shared by the label fakes.
+const referenceHits = {
+  found: 2,
+  hits: [
+    { document: { id: 'https://d/1', publisher: ['https://org/1'] } },
+    { document: { id: 'https://d/2', publisher: 'https://org/2' } },
+  ],
+};
 
 const schema: SearchType = {
   name: 'Dataset',
@@ -210,47 +225,23 @@ describe('createTypesenseSearchEngine label degradation', () => {
     locale: 'nl',
   };
 
-  // A fake client whose document search succeeds but whose label lookup
-  // (multi_search) rejects, so the engine must degrade to id-only references.
-  function fakeClient(): Client {
-    return {
-      collections: () => ({
-        documents: () => ({
-          search: () =>
-            Promise.resolve({
-              found: 1,
-              hits: [
-                {
-                  document: { id: 'https://d/1', publisher: ['https://org/1'] },
-                },
-                // A scalar (non-array) stored reference value.
-                {
-                  document: { id: 'https://d/2', publisher: 'https://org/2' },
-                },
-              ],
-            }),
-        }),
-      }),
-      multiSearch: {
-        perform: () =>
-          Promise.reject(new Error('labels collection unavailable')),
-      },
-    } as unknown as Client;
-  }
-
   it('degrades to id-only references when the label lookup fails, reporting the cause', async () => {
     let capturedError: unknown;
-    const engine = createTypesenseSearchEngine(
-      fakeClient(),
-      searchSchema(schema),
-      {
-        collections: { Dataset: 'datasets' },
-        labelsCollection: 'labels',
-        onLabelError: (error) => {
-          capturedError = error;
-        },
+    // The document search succeeds but the label lookup (multi_search)
+    // rejects, so the engine must degrade to id-only references.
+    const { client } = fakeTypesenseClient({
+      searchResponse: referenceHits,
+      multiSearch: () => {
+        throw new Error('labels collection unavailable');
       },
-    );
+    });
+    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
+      collections: { Dataset: 'datasets' },
+      labelsCollection: 'labels',
+      onLabelError: (error) => {
+        capturedError = error;
+      },
+    });
     const result = await engine.search(schema, baseQuery);
     // The reference is present but unlabelled: the failed lookup degraded
     // rather than failing the whole search.
@@ -281,38 +272,13 @@ describe('createTypesenseSearchEngine label cache (labelCacheTtlMs)', () => {
     label_nl: 'Het Utrechts Archief',
   });
 
-  // A fake client whose document search always returns one hit referencing
-  // `https://org/1`, and whose `labels` collection export is driven by
-  // `exportImpl`. Counters make the export-call count observable.
+  // Document search always answers `referenceHits`; the `labels` collection
+  // export is driven per test, its call count observable via `exportCalls`.
   function fakeClient(exportImpl: () => Promise<string>) {
-    let exportCalls = 0;
-    const client = {
-      collections: () => ({
-        documents: () => ({
-          search: () =>
-            Promise.resolve({
-              found: 1,
-              hits: [
-                {
-                  document: { id: 'https://d/1', publisher: ['https://org/1'] },
-                },
-                // A scalar (non-array) stored reference value.
-                {
-                  document: { id: 'https://d/2', publisher: 'https://org/2' },
-                },
-              ],
-            }),
-          export: () => {
-            exportCalls += 1;
-            return exportImpl();
-          },
-        }),
-      }),
-    };
-    return {
-      client: client as unknown as Client,
-      exportCalls: () => exportCalls,
-    };
+    return fakeTypesenseClient({
+      searchResponse: referenceHits,
+      exportJsonl: exportImpl,
+    });
   }
 
   afterEach(() => {
@@ -420,12 +386,6 @@ describe('createTypesenseSearchEngine label cache (labelCacheTtlMs)', () => {
   });
 });
 
-/** The backtick-escaped ids of a `filter_by: id:[…]` clause — the wire form
- *  `escapeFilterValue` produces; shared by the label-lookup fakes. */
-function filterByIds(filterBy: string): string[] {
-  return [...filterBy.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
-}
-
 describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () => {
   const facetBrowse: SearchQuery = {
     where: [],
@@ -436,39 +396,19 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     locale: 'nl',
   };
 
-  // A fake client whose multi_search answers each entry via `perEntry`,
-  // recording every POST so the batching is observable.
-  function fakeClient(
-    perEntry: (
-      search: Record<string, unknown>,
-      index: number,
-    ) => Record<string, unknown>,
-  ) {
-    const performs: Record<string, unknown>[][] = [];
-    const client = {
-      multiSearch: {
-        perform: (request: { searches: Record<string, unknown>[] }) => {
-          performs.push(request.searches);
-          return Promise.resolve({
-            results: request.searches.map(perEntry),
-          });
-        },
-      },
-    };
-    return { client: client as unknown as Client, performs };
-  }
-
   it('sends the whole batch as ONE multi_search and maps the results positionally', async () => {
-    const { client, performs } = fakeClient((search) => ({
-      found: 0,
-      hits: [],
-      facet_counts: [
-        {
-          field_name: search.facet_by,
-          counts: [{ value: `${search.facet_by}-value`, count: 1 }],
-        },
-      ],
-    }));
+    const { client, performs } = fakeTypesenseClient({
+      multiSearch: (search) => ({
+        found: 0,
+        hits: [],
+        facet_counts: [
+          {
+            field_name: search.facet_by,
+            counts: [{ value: `${search.facet_by}-value`, count: 1 }],
+          },
+        ],
+      }),
+    });
     const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
       collections: { Dataset: 'datasets' },
     });
@@ -501,7 +441,9 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
   });
 
   it('makes no request for an empty batch', async () => {
-    const { client, performs } = fakeClient(() => ({ found: 0, hits: [] }));
+    const { client, performs } = fakeTypesenseClient({
+      multiSearch: () => ({ found: 0, hits: [] }),
+    });
     const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
       collections: { Dataset: 'datasets' },
     });
@@ -510,11 +452,12 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
   });
 
   it('reports a failed entry as an in-place error outcome, keeping its siblings', async () => {
-    const { client } = fakeClient((_search, index) =>
-      index === 1
-        ? { code: 404, error: 'collection not found' }
-        : { found: 0, hits: [], facet_counts: [] },
-    );
+    const { client } = fakeTypesenseClient({
+      multiSearch: (_search, index) =>
+        index === 1
+          ? { code: 404, error: 'collection not found' }
+          : { found: 0, hits: [], facet_counts: [] },
+    });
     const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
       collections: { Dataset: 'datasets' },
     });
@@ -537,7 +480,9 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
   });
 
   it('reports a failed entry that carries no status code', async () => {
-    const { client } = fakeClient(() => ({ error: 'malformed query' }));
+    const { client } = fakeTypesenseClient({
+      multiSearch: () => ({ error: 'malformed query' }),
+    });
     const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
       collections: { Dataset: 'datasets' },
     });
@@ -553,40 +498,25 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
   });
 
   it('serves batch labels from the in-memory cache without a per-batch lookup', async () => {
-    let exportCalls = 0;
-    const performs: Record<string, unknown>[][] = [];
-    const client = {
-      collections: () => ({
-        documents: () => ({
-          export: () => {
-            exportCalls += 1;
-            return Promise.resolve(
-              JSON.stringify({
-                id: 'https://org/1',
-                label_nl: 'Het Utrechts Archief',
-              }),
-            );
+    const { client, performs, exportCalls } = fakeTypesenseClient({
+      exportJsonl: () =>
+        Promise.resolve(
+          JSON.stringify({
+            id: 'https://org/1',
+            label_nl: 'Het Utrechts Archief',
+          }),
+        ),
+      multiSearch: () => ({
+        found: 0,
+        hits: [],
+        facet_counts: [
+          {
+            field_name: 'publisher',
+            counts: [{ value: 'https://org/1', count: 1 }],
           },
-        }),
+        ],
       }),
-      multiSearch: {
-        perform: (request: { searches: Record<string, unknown>[] }) => {
-          performs.push(request.searches);
-          return Promise.resolve({
-            results: request.searches.map(() => ({
-              found: 0,
-              hits: [],
-              facet_counts: [
-                {
-                  field_name: 'publisher',
-                  counts: [{ value: 'https://org/1', count: 1 }],
-                },
-              ],
-            })),
-          });
-        },
-      },
-    } as unknown as Client;
+    });
     const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
       collections: { Dataset: 'datasets' },
       labelsCollection: 'labels',
@@ -598,8 +528,8 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     ]);
 
     // ONE export populated the cache; the only multi_search is the facet
-    // batch itself — no per-batch label lookup.
-    expect(exportCalls).toBe(1);
+    // batch itself – no per-batch label lookup.
+    expect(exportCalls()).toBe(1);
     expect(performs).toHaveLength(1);
     expect(outcomes[0]).toEqual({
       facets: {
@@ -619,31 +549,25 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
       'https://org/1': { label_nl: 'Het Utrechts Archief' },
       'https://org/2': { label_nl: 'Rijksmuseum' },
     };
-    const { client, performs } = fakeClient((search, index) => {
-      if (search.query_by === 'label') {
-        const ids = filterByIds(String(search.filter_by));
-        return {
-          found: ids.length,
-          hits: ids
-            .filter((id) => labelDocs[id] !== undefined)
-            .map((id) => ({ document: { id, ...labelDocs[id] } })),
-        };
-      }
-      return {
-        found: 0,
-        hits: [],
-        facet_counts: [
-          {
-            field_name: 'publisher',
-            counts: [
-              {
-                value: index === 0 ? 'https://org/1' : 'https://org/2',
-                count: 1,
-              },
-            ],
-          },
-        ],
-      };
+    const { client, performs } = fakeTypesenseClient({
+      multiSearch: (search, index) =>
+        search.query_by === 'label'
+          ? labelLookup(labelDocs)(search)
+          : {
+              found: 0,
+              hits: [],
+              facet_counts: [
+                {
+                  field_name: 'publisher',
+                  counts: [
+                    {
+                      value: index === 0 ? 'https://org/1' : 'https://org/2',
+                      count: 1,
+                    },
+                  ],
+                },
+              ],
+            },
     });
     const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
       collections: { Dataset: 'datasets' },
@@ -684,37 +608,16 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
 });
 
 describe('fetchLabels', () => {
-  // A fake Typesense client whose multi_search returns the requested ids that
-  // exist in `docsById`, recording each POST's per-search id-lists so batching
-  // is observable. (Resolving via multi_search/POST avoids the GET query-string
-  // limit that a large id-list would otherwise overflow.)
-  function fakeClient(docsById: Record<string, Record<string, unknown>>) {
-    const posts: string[][][] = [];
-    const client = {
-      multiSearch: {
-        perform: (request: { searches: { readonly filter_by: string }[] }) => {
-          const batches = request.searches.map((search) =>
-            filterByIds(search.filter_by),
-          );
-          posts.push(batches);
-          const results = batches.map((ids) => {
-            const hits = ids
-              .filter((id) => docsById[id] !== undefined)
-              .map((id) => ({ document: { id, ...docsById[id] } }));
-            return { found: hits.length, hits };
-          });
-          return Promise.resolve({ results });
-        },
-      },
-    };
-    return { client: client as unknown as Pick<Client, 'multiSearch'>, posts };
-  }
-
+  // Resolving via multi_search/POST avoids the GET query-string limit that a
+  // large id-list would otherwise overflow; each POST's per-search id-lists
+  // are recoverable from `performs` so batching is observable.
   it('resolves labels via multi_search, merging per-locale variants', async () => {
-    const { client, posts } = fakeClient({
-      'https://org/1': { label: 'KB', label_nl: 'KB' },
-      // Only a default label (no locale variant) → untagged (`und`) fallback.
-      'https://org/3': { label: 'Untagged' },
+    const { client, performs } = fakeTypesenseClient({
+      multiSearch: labelLookup({
+        'https://org/1': { label: 'KB', label_nl: 'KB' },
+        // Only a default label (no locale variant) → untagged (`und`) fallback.
+        'https://org/3': { label: 'Untagged' },
+      }),
     });
     const labels = await fetchLabels(client, 'labels', [
       'https://org/1',
@@ -725,7 +628,7 @@ describe('fetchLabels', () => {
     expect(labels.get('https://org/3')).toEqual({ und: ['Untagged'] });
     // An IRI absent from the collection yields no entry.
     expect(labels.has('https://org/2')).toBe(false);
-    expect(posts).toHaveLength(1);
+    expect(performs).toHaveLength(1);
   });
 
   it('batches a large id-list under the per_page cap, in a single POST', async () => {
@@ -736,44 +639,42 @@ describe('fetchLabels', () => {
     const docsById = Object.fromEntries(
       ids.map((id) => [id, { label_nl: id }]),
     );
-    const { client, posts } = fakeClient(docsById);
+    const { client, performs } = fakeTypesenseClient({
+      multiSearch: labelLookup(docsById),
+    });
     const labels = await fetchLabels(client, 'labels', ids);
     // 450 ids → batches of 200, 200, 50, bundled into one round-trip.
-    expect(posts).toHaveLength(1);
-    expect(posts[0].map((batch) => batch.length)).toEqual([200, 200, 50]);
+    expect(performs).toHaveLength(1);
+    expect(
+      performs[0].map((search) => filterByIds(String(search.filter_by)).length),
+    ).toEqual([200, 200, 50]);
     expect(labels.size).toBe(450);
   });
 
   it('makes no request for an empty id-list', async () => {
-    const { client, posts } = fakeClient({});
+    const { client, performs } = fakeTypesenseClient({
+      multiSearch: labelLookup({}),
+    });
     const labels = await fetchLabels(client, 'labels', []);
     expect(labels.size).toBe(0);
-    expect(posts).toHaveLength(0);
+    expect(performs).toHaveLength(0);
   });
 
   it('throws on an inline multi_search error entry instead of returning no labels', async () => {
     // multi_search reports a failed entry inline (the call still resolves);
     // fetchLabels must throw so the engine's degradation path (onLabelError,
     // id-only references) engages instead of silently missing every label.
-    const client = {
-      multiSearch: {
-        perform: () =>
-          Promise.resolve({
-            results: [{ code: 503, error: 'lookup failed' }],
-          }),
-      },
-    } as unknown as Pick<Client, 'multiSearch'>;
+    const { client } = fakeTypesenseClient({
+      multiSearch: () => ({ code: 503, error: 'lookup failed' }),
+    });
     await expect(
       fetchLabels(client, 'labels', ['https://org/1']),
     ).rejects.toThrow(/label lookup failed \(503\): lookup failed/);
 
     // An error entry without a status code still throws.
-    const clientWithoutCode = {
-      multiSearch: {
-        perform: () =>
-          Promise.resolve({ results: [{ error: 'lookup failed' }] }),
-      },
-    } as unknown as Pick<Client, 'multiSearch'>;
+    const { client: clientWithoutCode } = fakeTypesenseClient({
+      multiSearch: () => ({ error: 'lookup failed' }),
+    });
     await expect(
       fetchLabels(clientWithoutCode, 'labels', ['https://org/1']),
     ).rejects.toThrow(/label lookup failed: lookup failed/);

--- a/packages/search-typesense/test/search-engine.test.ts
+++ b/packages/search-typesense/test/search-engine.test.ts
@@ -229,7 +229,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
   });
 
   it('answers a whole facet batch in one searchFacets call, positionally, with labelled reference buckets', async () => {
-    const facetMaps = await engine.searchFacets(datasetSchema, [
+    const outcomes = await engine.searchFacets(datasetSchema, [
       // Unfiltered: counts across all documents, faceting two fields at once.
       { ...baseQuery, limit: 0, facets: ['keyword', 'publisher'] },
       // Filtered (as a skip-own-filter variant would be): valid only.
@@ -241,18 +241,22 @@ describe('createTypesenseSearchEngine (integration)', () => {
       },
     ]);
 
-    expect(facetMaps).toHaveLength(2);
+    expect(outcomes).toHaveLength(2);
+    const [unfiltered, filtered] = outcomes;
+    if ('error' in unfiltered || 'error' in filtered) {
+      throw new Error('Expected facets outcomes.');
+    }
 
-    const keyword = [...(facetMaps[0].keyword ?? [])].sort(
-      (a, b) => b.count - a.count,
+    const keyword = [...(unfiltered.facets.keyword ?? [])].sort(
+      (first, second) => second.count - first.count,
     );
     expect(keyword).toEqual([
       { value: 'kaarten', count: 2 },
       { value: 'atlas', count: 1 },
     ]);
     // Reference facets carry resolved labels, exactly as in search().
-    const publisher = [...(facetMaps[0].publisher ?? [])].sort(
-      (a, b) => b.count - a.count,
+    const publisher = [...(unfiltered.facets.publisher ?? [])].sort(
+      (first, second) => second.count - first.count,
     );
     expect(publisher).toEqual([
       {
@@ -268,8 +272,8 @@ describe('createTypesenseSearchEngine (integration)', () => {
     ]);
 
     // The filtered query counts only the valid documents (d1, d2).
-    const filteredKeyword = [...(facetMaps[1].keyword ?? [])].sort((a, b) =>
-      a.value.localeCompare(b.value),
+    const filteredKeyword = [...(filtered.facets.keyword ?? [])].sort(
+      (first, second) => first.value.localeCompare(second.value),
     );
     expect(filteredKeyword).toEqual([
       { value: 'atlas', count: 1 },

--- a/packages/search-typesense/test/search-engine.test.ts
+++ b/packages/search-typesense/test/search-engine.test.ts
@@ -228,6 +228,55 @@ describe('createTypesenseSearchEngine (integration)', () => {
     ]);
   });
 
+  it('answers a whole facet batch in one searchFacets call, positionally, with labelled reference buckets', async () => {
+    const facetMaps = await engine.searchFacets(datasetSchema, [
+      // Unfiltered: counts across all documents, faceting two fields at once.
+      { ...baseQuery, limit: 0, facets: ['keyword', 'publisher'] },
+      // Filtered (as a skip-own-filter variant would be): valid only.
+      {
+        ...baseQuery,
+        limit: 0,
+        where: [{ field: 'status', in: ['valid'] }],
+        facets: ['keyword'],
+      },
+    ]);
+
+    expect(facetMaps).toHaveLength(2);
+
+    const keyword = [...(facetMaps[0].keyword ?? [])].sort(
+      (a, b) => b.count - a.count,
+    );
+    expect(keyword).toEqual([
+      { value: 'kaarten', count: 2 },
+      { value: 'atlas', count: 1 },
+    ]);
+    // Reference facets carry resolved labels, exactly as in search().
+    const publisher = [...(facetMaps[0].publisher ?? [])].sort(
+      (a, b) => b.count - a.count,
+    );
+    expect(publisher).toEqual([
+      {
+        value: 'https://org/1',
+        count: 2,
+        label: { nl: ['Het Utrechts Archief'] },
+      },
+      {
+        value: 'https://org/2',
+        count: 1,
+        label: { nl: ['Rijksmuseum'], en: ['Rijksmuseum'] },
+      },
+    ]);
+
+    // The filtered query counts only the valid documents (d1, d2).
+    const filteredKeyword = [...(facetMaps[1].keyword ?? [])].sort((a, b) =>
+      a.value.localeCompare(b.value),
+    );
+    expect(filteredKeyword).toEqual([
+      { value: 'atlas', count: 1 },
+      { value: 'kaarten', count: 1 },
+    ]);
+  });
+
   it('always rejects a structurally invalid query, before reaching the engine', async () => {
     await expect(
       engine.search(datasetSchema, {

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these — see AGENTS.md.
-          functions: 97.22,
-          lines: 95.41,
-          branches: 90.99,
-          statements: 95.45,
+          functions: 97.29,
+          lines: 95.42,
+          branches: 91.16,
+          statements: 95.48,
         },
       },
     },

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these — see AGENTS.md.
-          functions: 96.92,
-          lines: 95.11,
-          branches: 90.73,
-          statements: 95.16,
+          functions: 97.22,
+          lines: 95.41,
+          branches: 90.99,
+          statements: 95.45,
         },
       },
     },

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these — see AGENTS.md.
-          functions: 97.29,
-          lines: 95.42,
-          branches: 91.16,
-          statements: 95.48,
+          functions: 97.7,
+          lines: 95.4,
+          branches: 90.09,
+          statements: 95.46,
         },
       },
     },

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -286,9 +286,9 @@ await engine.search(OTHER_TYPE, query); // compile error: not in this schema
 ```
 
 `searchFacets(type, queries)` is the port’s **batch entry point**: several
-facet-only queries — e.g. a faceted sidebar’s skip-own-filter variants —
+facet-only queries – e.g. a faceted sidebar’s skip-own-filter variants –
 answered in one engine round-trip (Typesense: a single `multi_search`), one
-outcome per query, positionally aligned — its facet map, or an in-place error,
+outcome per query, positionally aligned – its facet map, or an in-place error,
 so one failed query never discards its siblings’ facets. The same schema
 binding, per-query validation and typed facet keys apply to every query in
 the batch.

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -288,8 +288,10 @@ await engine.search(OTHER_TYPE, query); // compile error: not in this schema
 `searchFacets(type, queries)` is the port’s **batch entry point**: several
 facet-only queries — e.g. a faceted sidebar’s skip-own-filter variants —
 answered in one engine round-trip (Typesense: a single `multi_search`), one
-facet map per query, positionally aligned. The same schema binding, per-query
-validation and typed facet keys apply to every query in the batch.
+outcome per query, positionally aligned — its facet map, or an in-place error,
+so one failed query never discards its siblings’ facets. The same schema
+binding, per-query validation and typed facet keys apply to every query in
+the batch.
 
 This only works when the types were declared with `defineSearchType` (or
 captured `as const satisfies SearchType`) and composed with `searchSchema()`;

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -285,6 +285,12 @@ result.hits[0].document.title; // typed: only DATASET’s output fields are keys
 await engine.search(OTHER_TYPE, query); // compile error: not in this schema
 ```
 
+`searchFacets(type, queries)` is the port’s **batch entry point**: several
+facet-only queries — e.g. a faceted sidebar’s skip-own-filter variants —
+answered in one engine round-trip (Typesense: a single `multi_search`), one
+facet map per query, positionally aligned. The same schema binding, per-query
+validation and typed facet keys apply to every query in the batch.
+
 This only works when the types were declared with `defineSearchType` (or
 captured `as const satisfies SearchType`) and composed with `searchSchema()`;
 a plain `: SearchSchema` annotation widens gracefully to string keys.

--- a/packages/search/src/engine.ts
+++ b/packages/search/src/engine.ts
@@ -41,6 +41,24 @@ export interface SearchEngine<
     searchType: T,
     query: SearchQuery,
   ): Promise<SearchResult<FacetFieldsOf<T>, OutputFieldsOf<T>>>;
+  /**
+   * The batch entry point: answer several facet-only queries against one type
+   * in a single engine round-trip (where the engine supports one, e.g.
+   * Typesense `multi_search`), returning one {@link FacetMap} per query,
+   * positionally aligned with `queries`. This is what keeps a faceted
+   * sidebar — one skip-own-filter query variant per filtered facet — from
+   * fanning out into per-facet engine calls. Only the facet buckets come
+   * back: an engine answers every query in the batch facet-only (as if
+   * `limit: 0`, whatever the query carries), so hits are never transferred.
+   * Reference-facet buckets carry resolved labels exactly as in
+   * {@link search}. The port contract holds for every query in the batch
+   * (foreign `searchType` rejected, each query validated); an empty `queries`
+   * resolves to `[]` without touching the engine.
+   */
+  searchFacets<T extends Types[number]>(
+    searchType: T,
+    queries: readonly SearchQuery[],
+  ): Promise<readonly FacetMap<FacetFieldsOf<T>>[]>;
 }
 
 /** What an engine returns: logical hits, a total, and the requested facets. */

--- a/packages/search/src/engine.ts
+++ b/packages/search/src/engine.ts
@@ -46,7 +46,7 @@ export interface SearchEngine<
    * in a single engine round-trip (where the engine supports one, e.g.
    * Typesense `multi_search`), returning one {@link FacetsOutcome} per query,
    * positionally aligned with `queries`. This is what keeps a faceted
-   * sidebar — one skip-own-filter query variant per filtered facet — from
+   * sidebar – one skip-own-filter query variant per filtered facet – from
    * fanning out into per-facet engine calls. Only facet buckets come back: an
    * engine answers every query in the batch facet-only (as if `limit: 0` and
    * without ordering, whatever the query carries), so hits are never
@@ -65,7 +65,7 @@ export interface SearchEngine<
 }
 
 /**
- * One query’s outcome in a {@link SearchEngine.searchFacets} batch — its
+ * One query’s outcome in a {@link SearchEngine.searchFacets} batch – its
  * facet buckets, or the error that failed it. The `allSettled`-style shape
  * keeps one failed query (e.g. one failed `multi_search` entry) from
  * discarding its siblings’ results: a caller degrades exactly the facets of

--- a/packages/search/src/engine.ts
+++ b/packages/search/src/engine.ts
@@ -44,22 +44,36 @@ export interface SearchEngine<
   /**
    * The batch entry point: answer several facet-only queries against one type
    * in a single engine round-trip (where the engine supports one, e.g.
-   * Typesense `multi_search`), returning one {@link FacetMap} per query,
+   * Typesense `multi_search`), returning one {@link FacetsOutcome} per query,
    * positionally aligned with `queries`. This is what keeps a faceted
    * sidebar — one skip-own-filter query variant per filtered facet — from
-   * fanning out into per-facet engine calls. Only the facet buckets come
-   * back: an engine answers every query in the batch facet-only (as if
-   * `limit: 0`, whatever the query carries), so hits are never transferred.
-   * Reference-facet buckets carry resolved labels exactly as in
-   * {@link search}. The port contract holds for every query in the batch
-   * (foreign `searchType` rejected, each query validated); an empty `queries`
-   * resolves to `[]` without touching the engine.
+   * fanning out into per-facet engine calls. Only facet buckets come back: an
+   * engine answers every query in the batch facet-only (as if `limit: 0` and
+   * without ordering, whatever the query carries), so hits are never
+   * transferred. Reference-facet buckets carry resolved labels exactly as in
+   * {@link search}. A failure of one query is reported in place
+   * (`{ error }`) rather than by rejecting, so it never discards its
+   * siblings’ facets; the returned promise rejects only for batch-level
+   * failures (a foreign `searchType`, a structurally invalid query, the
+   * transport itself). The port contract holds for every query in the batch;
+   * an empty `queries` resolves to `[]` without touching the engine.
    */
   searchFacets<T extends Types[number]>(
     searchType: T,
     queries: readonly SearchQuery[],
-  ): Promise<readonly FacetMap<FacetFieldsOf<T>>[]>;
+  ): Promise<readonly FacetsOutcome<FacetFieldsOf<T>>[]>;
 }
+
+/**
+ * One query’s outcome in a {@link SearchEngine.searchFacets} batch — its
+ * facet buckets, or the error that failed it. The `allSettled`-style shape
+ * keeps one failed query (e.g. one failed `multi_search` entry) from
+ * discarding its siblings’ results: a caller degrades exactly the facets of
+ * the failed query. Discriminate with `'error' in outcome`.
+ */
+export type FacetsOutcome<FacetField extends string = string> =
+  | { readonly facets: FacetMap<FacetField> }
+  | { readonly error: unknown };
 
 /** What an engine returns: logical hits, a total, and the requested facets. */
 export interface SearchResult<

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -50,6 +50,7 @@ export type {
   Reference,
   FacetBucket,
   FacetMap,
+  FacetsOutcome,
   FacetFieldsOf,
   OutputFieldsOf,
 } from './engine.js';

--- a/packages/search/src/testing.ts
+++ b/packages/search/src/testing.ts
@@ -19,7 +19,7 @@ import {
  * prose. Covers schema binding (a type outside the bound schema is rejected),
  * the always-on query validation (a structurally invalid query is rejected
  * before it reaches the engine) and the result shape of a browse query and a
- * `searchFacets` batch — for every type in the schema.
+ * `searchFacets` batch – for every type in the schema.
  *
  * ```ts
  * describeSearchEngineContract('TypesenseSearchEngine', () => engine);

--- a/packages/search/src/testing.ts
+++ b/packages/search/src/testing.ts
@@ -130,18 +130,27 @@ export function describeSearchEngineContract(
       }
     });
 
-    it('answers a searchFacets batch with one facet map per query, positionally', async () => {
+    it('answers a searchFacets batch with one facets outcome per query, positionally', async () => {
       for (const searchType of types()) {
         const facets = facetableFields(searchType).map((field) => field.name);
         const queries: SearchQuery[] = [
           { ...browse(searchType), limit: 0, facets },
-          { ...browse(searchType), limit: 0, facets: [] },
+          // Facet-only regardless of the limit the query carries: this one
+          // keeps its non-zero browse limit and must be answered the same.
+          { ...browse(searchType), facets: [] },
         ];
-        const results = await engine().searchFacets(searchType, queries);
-        expect(results).toHaveLength(queries.length);
-        for (const facetMap of results) {
-          expect(facetMap).toBeTypeOf('object');
-          for (const buckets of Object.values(facetMap)) {
+        const outcomes = await engine().searchFacets(searchType, queries);
+        expect(outcomes).toHaveLength(queries.length);
+        for (const outcome of outcomes) {
+          // A valid query in a healthy engine yields facets, not an error.
+          expect('error' in outcome ? outcome.error : undefined).toBe(
+            undefined,
+          );
+          if ('error' in outcome) {
+            continue;
+          }
+          expect(outcome.facets).toBeTypeOf('object');
+          for (const buckets of Object.values(outcome.facets)) {
             for (const bucket of buckets ?? []) {
               expect(typeof bucket.value).toBe('string');
               expect(typeof bucket.count).toBe('number');

--- a/packages/search/src/testing.ts
+++ b/packages/search/src/testing.ts
@@ -6,7 +6,11 @@ import {
   type FilterOperator,
   type SearchQuery,
 } from './query.js';
-import { filterableFields, type SearchType } from './schema.js';
+import {
+  facetableFields,
+  filterableFields,
+  type SearchType,
+} from './schema.js';
 
 /**
  * The executable {@link SearchEngine} port contract (import from
@@ -14,8 +18,8 @@ import { filterableFields, type SearchType } from './schema.js';
  * live instance of itself, so the port rules hold by test rather than by
  * prose. Covers schema binding (a type outside the bound schema is rejected),
  * the always-on query validation (a structurally invalid query is rejected
- * before it reaches the engine) and the result shape of a browse query — for
- * every type in the schema.
+ * before it reaches the engine) and the result shape of a browse query and a
+ * `searchFacets` batch — for every type in the schema.
  *
  * ```ts
  * describeSearchEngineContract('TypesenseSearchEngine', () => engine);
@@ -95,6 +99,62 @@ export function describeSearchEngineContract(
         };
         await expect(engine().search(searchType, query)).rejects.toThrow(
           /operator-mismatch/,
+        );
+      }
+    });
+
+    it('rejects a searchFacets batch for a type outside its schema', async () => {
+      const foreign: SearchType = {
+        name: 'NotInSchema',
+        type: 'urn:test:not-in-schema',
+        fields: [],
+      };
+      await expect(
+        engine().searchFacets(foreign, [browse(foreign)]),
+      ).rejects.toThrow(/not in this engine/);
+    });
+
+    it('rejects a structurally invalid query anywhere in a searchFacets batch', async () => {
+      for (const searchType of types()) {
+        const queries: SearchQuery[] = [
+          { ...browse(searchType), limit: 0 },
+          {
+            ...browse(searchType),
+            limit: 0,
+            facets: ['fieldThatDoesNotExist'],
+          },
+        ];
+        await expect(
+          engine().searchFacets(searchType, queries),
+        ).rejects.toThrow(/unknown-field/);
+      }
+    });
+
+    it('answers a searchFacets batch with one facet map per query, positionally', async () => {
+      for (const searchType of types()) {
+        const facets = facetableFields(searchType).map((field) => field.name);
+        const queries: SearchQuery[] = [
+          { ...browse(searchType), limit: 0, facets },
+          { ...browse(searchType), limit: 0, facets: [] },
+        ];
+        const results = await engine().searchFacets(searchType, queries);
+        expect(results).toHaveLength(queries.length);
+        for (const facetMap of results) {
+          expect(facetMap).toBeTypeOf('object');
+          for (const buckets of Object.values(facetMap)) {
+            for (const bucket of buckets ?? []) {
+              expect(typeof bucket.value).toBe('string');
+              expect(typeof bucket.count).toBe('number');
+            }
+          }
+        }
+      }
+    });
+
+    it('resolves an empty searchFacets batch to an empty list', async () => {
+      for (const searchType of types()) {
+        await expect(engine().searchFacets(searchType, [])).resolves.toEqual(
+          [],
         );
       }
     });

--- a/packages/search/test/engine.test.ts
+++ b/packages/search/test/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { SearchEngine, SearchResult } from '../src/engine.js';
+import type { FacetMap, SearchEngine, SearchResult } from '../src/engine.js';
 import type { SearchQuery } from '../src/query.js';
 import { defineSearchType, searchSchema } from '../src/schema.js';
 import type { SearchType } from '../src/schema.js';
@@ -36,6 +36,16 @@ const fake: SearchEngine = {
       ],
       facets: { keyword: [{ value: 'kaarten', count: 3 }] },
     };
+  },
+  async searchFacets(
+    _searchType: SearchType,
+    queries: readonly SearchQuery[],
+  ): Promise<readonly FacetMap[]> {
+    return queries.map((query) =>
+      query.facets.includes('keyword')
+        ? { keyword: [{ value: 'kaarten', count: 3 }] }
+        : {},
+    );
   },
 };
 
@@ -111,6 +121,11 @@ describe('typed schema-bound engine', () => {
           facets: { format: [{ value: 'text/turtle', count: 2 }] },
         };
       },
+      async searchFacets(_searchType, queries): Promise<readonly FacetMap[]> {
+        return queries.map(() => ({
+          format: [{ value: 'text/turtle', count: 2 }],
+        }));
+      },
     };
     const engine = untyped as SearchEngine<
       readonly [typeof dataset, typeof person]
@@ -131,7 +146,16 @@ describe('typed schema-bound engine', () => {
     void result.facets.formaat;
     expect(result.hits[0].document.title).toEqual({ nl: ['Titel'] });
 
+    // The batch entry point is typed the same way: per-query facet maps keyed
+    // by the type passed.
+    const [batchedFacets] = await engine.searchFacets(dataset, [query]);
+    expect(batchedFacets.format).toEqual([{ value: 'text/turtle', count: 2 }]);
+    // @ts-expect-error — a facet key outside the declaration is a compile error
+    void batchedFacets.formaat;
+
     // @ts-expect-error — a type outside the engine's schema is a compile error
     void engine.search(organization, query);
+    // @ts-expect-error — a type outside the engine's schema is a compile error
+    void engine.searchFacets(organization, [query]);
   });
 });

--- a/packages/search/test/engine.test.ts
+++ b/packages/search/test/engine.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import type { FacetMap, SearchEngine, SearchResult } from '../src/engine.js';
+import type {
+  FacetsOutcome,
+  SearchEngine,
+  SearchResult,
+} from '../src/engine.js';
 import type { SearchQuery } from '../src/query.js';
 import { defineSearchType, searchSchema } from '../src/schema.js';
 import type { SearchType } from '../src/schema.js';
@@ -40,11 +44,11 @@ const fake: SearchEngine = {
   async searchFacets(
     _searchType: SearchType,
     queries: readonly SearchQuery[],
-  ): Promise<readonly FacetMap[]> {
+  ): Promise<readonly FacetsOutcome[]> {
     return queries.map((query) =>
       query.facets.includes('keyword')
-        ? { keyword: [{ value: 'kaarten', count: 3 }] }
-        : {},
+        ? { facets: { keyword: [{ value: 'kaarten', count: 3 }] } }
+        : { facets: {} },
     );
   },
 };
@@ -121,9 +125,12 @@ describe('typed schema-bound engine', () => {
           facets: { format: [{ value: 'text/turtle', count: 2 }] },
         };
       },
-      async searchFacets(_searchType, queries): Promise<readonly FacetMap[]> {
+      async searchFacets(
+        _searchType,
+        queries,
+      ): Promise<readonly FacetsOutcome[]> {
         return queries.map(() => ({
-          format: [{ value: 'text/turtle', count: 2 }],
+          facets: { format: [{ value: 'text/turtle', count: 2 }] },
         }));
       },
     };
@@ -146,16 +153,21 @@ describe('typed schema-bound engine', () => {
     void result.facets.formaat;
     expect(result.hits[0].document.title).toEqual({ nl: ['Titel'] });
 
-    // The batch entry point is typed the same way: per-query facet maps keyed
-    // by the type passed.
-    const [batchedFacets] = await engine.searchFacets(dataset, [query]);
-    expect(batchedFacets.format).toEqual([{ value: 'text/turtle', count: 2 }]);
+    // The batch entry point is typed the same way: per-query outcomes whose
+    // facet maps are keyed by the type passed.
+    const [batchedOutcome] = await engine.searchFacets(dataset, [query]);
+    if ('error' in batchedOutcome) {
+      throw new Error('Expected a facets outcome.');
+    }
+    expect(batchedOutcome.facets.format).toEqual([
+      { value: 'text/turtle', count: 2 },
+    ]);
     // @ts-expect-error — a facet key outside the declaration is a compile error
-    void batchedFacets.formaat;
+    void batchedOutcome.facets.formaat;
 
-    // @ts-expect-error — a type outside the engine's schema is a compile error
+    // @ts-expect-error — a type outside the engine’s schema is a compile error
     void engine.search(organization, query);
-    // @ts-expect-error — a type outside the engine's schema is a compile error
+    // @ts-expect-error — a type outside the engine’s schema is a compile error
     void engine.searchFacets(organization, [query]);
   });
 });

--- a/packages/search/test/engine.test.ts
+++ b/packages/search/test/engine.test.ts
@@ -149,7 +149,7 @@ describe('typed schema-bound engine', () => {
     const result = await engine.search(dataset, query);
 
     expect(result.facets.format).toEqual([{ value: 'text/turtle', count: 2 }]);
-    // @ts-expect-error — a facet key outside the declaration is a compile error
+    // @ts-expect-error – a facet key outside the declaration is a compile error
     void result.facets.formaat;
     expect(result.hits[0].document.title).toEqual({ nl: ['Titel'] });
 
@@ -162,12 +162,12 @@ describe('typed schema-bound engine', () => {
     expect(batchedOutcome.facets.format).toEqual([
       { value: 'text/turtle', count: 2 },
     ]);
-    // @ts-expect-error — a facet key outside the declaration is a compile error
+    // @ts-expect-error – a facet key outside the declaration is a compile error
     void batchedOutcome.facets.formaat;
 
-    // @ts-expect-error — a type outside the engine’s schema is a compile error
+    // @ts-expect-error – a type outside the engine’s schema is a compile error
     void engine.search(organization, query);
-    // @ts-expect-error — a type outside the engine’s schema is a compile error
+    // @ts-expect-error – a type outside the engine’s schema is a compile error
     void engine.searchFacets(organization, [query]);
   });
 });


### PR DESCRIPTION
Fix #532

The keyed `DatasetFacets` surface resolved each selected facet through its own `engine.search` call, so a typical listing page fanned out into 1 listing search + N facet searches. This PR batches the whole facet selection into one engine round-trip, restoring the pre-migration single-`multi_search` behaviour: a typical page now costs the listing search plus one batched facet search (with the label cache on, exactly 2 Typesense round-trips). Recorded as [ADR 5](docs/decisions/0005-batch-facet-queries-through-the-engine-port.md).

## Port (`@lde/search`) — breaking

- `SearchEngine` gains the batch entry point `searchFacets(searchType, queries)`, returning one `FacetsOutcome` per query, positionally: `{ facets }` or `{ error }` (an `allSettled`-style union). A failure of one query is reported in place and never discards its siblings’ facets; the promise rejects only for batch-level failures (foreign type, invalid query, transport). Engines answer every query facet-only — as if `limit: 0` and without ordering, whatever the query carries — so hits are never transferred. Existing `SearchEngine` implementations must add the method.
- The executable port-contract suite (`@lde/search/testing`) covers the new method: foreign-type rejection, per-query validation, positional alignment (including a non-zero-limit query), and the empty batch.

## Typesense adapter (`@lde/search-typesense`)

- `searchFacets` compiles each query with the existing `buildSearchParams` (normalized to `per_page: 0`, no `sort_by`) and sends the whole batch as **one `multi_search`**.
- A failed `multi_search` entry (reported inline by Typesense) becomes a per-query error outcome naming the affected facet fields, so its siblings’ facets survive; `fetchLabels` now also throws on an inline error entry, engaging the label degradation path (`onLabelError`, id-only references) instead of silently missing every label.
- Reference-facet labels for the entire batch resolve in one bundled lookup, or from the in-memory cache when `labelCacheTtlMs` is set; the label-degradation logic is shared between `search` and `searchFacets`.

## GraphQL surface (`@lde/search-api-graphql`)

- Selected facet fields load through a per-request DataLoader (`facet-batch.ts`): same-tick loads are collected, grouped by their **effective `where`** after skip-own-filter — facets whose own field is unfiltered share one query, so the unfiltered browse collapses to a single facet query; each own-filtered facet gets its own variant — and dispatched as one `engine.searchFacets` call.
- Facet counts, skip-own-filter semantics, per-facet failure isolation (`onFacetError` fires only for the fields of the query that actually failed), reference labels, and the public SDL are unchanged. Facet-only queries drop the listing `orderBy` (nothing to order).
- New direct dependency: `dataloader` (GraphQL Foundation’s reference batching implementation) instead of a hand-rolled microtask batcher.

## Deliberately not done

- Riding same-`where` facets on the main listing search via `facet_by` for a 1-round-trip browse — needs `GraphQLResolveInfo` selection-walking; inside one `multi_search` the difference is negligible (see ADR 5).
- Overlapping the listing search with the facet dispatch (pre-existing sequencing; the facet queries derive only from the resolved query, so this is a possible follow-up).
