### PR TITLE
fix(release): unblock the search 0.3.0 release version bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42888,7 +42888,7 @@
     },
     "packages/search": {
       "name": "@lde/search",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@lde/text-normalization": "^0.1.1",
@@ -42915,7 +42915,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.2.0",
+        "@lde/search": "^0.3.0",
         "dataloader": "^2.2.3",
         "graphql": "^15.8.0",
         "tslib": "^2.3.0"
@@ -42926,7 +42926,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.2.0",
+        "@lde/search": "^0.3.0",
         "@lde/text-normalization": "^0.1.1",
         "tslib": "^2.3.0",
         "typesense": "^3.0.6"

--- a/packages/search-api-graphql/package.json
+++ b/packages/search-api-graphql/package.json
@@ -25,7 +25,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@lde/search": "^0.2.0",
+    "@lde/search": "^0.3.0",
     "dataloader": "^2.2.3",
     "graphql": "^15.8.0",
     "tslib": "^2.3.0"

--- a/packages/search-typesense/package.json
+++ b/packages/search-typesense/package.json
@@ -25,7 +25,7 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
-    "@lde/search": "^0.2.0",
+    "@lde/search": "^0.3.0",
     "@lde/text-normalization": "^0.1.1",
     "tslib": "^2.3.0",
     "typesense": "^3.0.6"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lde/search",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Engine- and domain-agnostic core for RDF-backed search: a unified declarative field model (SearchField/SearchType/SearchSchema), a neutral query IR, the SearchEngine port with logical result types, and a streaming CONSTRUCT-to-document projection. Bakes in no engine, protocol, or domain.",
   "repository": {
     "url": "git+https://github.com/ldelements/lde.git",


### PR DESCRIPTION
The [release run for PR #554](https://github.com/ldelements/lde/actions/runs/28792446087/job/85374302429) failed while versioning `@lde/search` 0.2.0 → 0.3.0 (breaking bump):

> `preserveMatchingDependencyRanges` is enabled for `dependencies` and the new version `^0.3.0` is outside the current range for `@lde/search` in manifest `packages/search-api-graphql/package.json`. Please update the range before releasing.

Same situation as #551, same recipe:

- Widen the `@lde/search` dependency ranges in `search-typesense` and `search-api-graphql` to `^0.3.0`.
- Pre-state the `@lde/search` version as 0.3.0 so npm workspaces keep linking the local package instead of trying to resolve the not-yet-published 0.3.0 from the registry. `nx release` resolves the current version from the git tag, so it still computes 0.2.0 → 0.3.0 and writes the same value.
- Sync `package-lock.json`.

Verified with `npx nx release version --dry-run`: no more range error; `@lde/search` → 0.3.0, `@lde/search-typesense` → 0.3.0, `@lde/search-api-graphql` → 0.2.0.

Note: this is the second release blocked this way in two days. If breaking bumps stay frequent, consider setting `release.version.preserveMatchingDependencyRanges: false` (restores the pre-Nx-23 auto-rewrite of dependent ranges) – though that would also need the lockfile handling revisited, since `skipLockFileUpdate: true` would leave `package-lock.json` stale after the release commit rewrites ranges.
