### PR TITLE
build(release): always rewrite dependent ranges when versioning

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -75,6 +75,7 @@
       "conventionalCommits": true,
       "updateDependents": "auto",
       "versionPrefix": "^",
+      "preserveMatchingDependencyRanges": false,
       "fallbackCurrentVersionResolver": "disk",
       "adjustSemverBumpsForZeroMajorVersion": true,
       "versionActionsOptions": {


### PR DESCRIPTION
Prevents the failure mode fixed by #551 and #557 from recurring.

Nx 23 enables `preserveMatchingDependencyRanges` by default: when a breaking bump pushes a workspace dependency outside its dependents’ declared ranges (e.g. `@lde/search` 0.2.0 → 0.3.0 against `"@lde/search": "^0.2.0"`), `nx release` aborts versioning and asks for a manual range update – which has now blocked two releases in two days.

Setting it to `false` restores the pre-Nx-23 behaviour this repo relied on: `nx release` rewrites the dependent ranges itself during versioning (as visible in every release commit before the Nx 23 upgrade), so breaking bumps release without manual intervention.

Verified with `npx nx release version --dry-run` against the pre-#557 manifests (`^0.2.0` ranges): versioning completes without the range error and rewrites the ranges to `^0.3.0`.
