### PR TITLE
feat(pipeline-shacl-validator): add conformanceDisallows severity set

### DIFF
--- a/packages/pipeline-shacl-validator/README.md
+++ b/packages/pipeline-shacl-validator/README.md
@@ -44,6 +44,33 @@ const pipeline = new Pipeline({
 await pipeline.run();
 ```
 
+### Severity and conformance (`conformanceDisallows`)
+
+By default, a result of _any_ severity (`sh:Violation`, `sh:Warning` or
+`sh:Info`) makes validation fail. This matches the
+[SHACL 1.2 default conformance-disallow set](https://www.w3.org/TR/shacl12-core/#conformanceDisallows).
+
+To fail on selected severities only (e.g. treat warnings and info as advisory,
+as SHOULD-level findings usually are) pass the set of severity IRIs that
+disallow conformance:
+
+```typescript
+import { ShaclValidator, severity } from '@lde/pipeline-shacl-validator';
+
+const validator = new ShaclValidator({
+  shapesFile: './shapes.ttl',
+  conformanceDisallows: [severity.violation],
+});
+```
+
+Results outside the set are still reported; they just no longer flip `conforms`
+to `false` or count towards `violations`. Custom severity IRIs (allowed by SHACL
+1.2) work too.
+
+When the option is set, the written report stays self-describing per SHACL 1.2:
+its `sh:conforms` reflects the configured set, and the set itself is declared on
+the report via `sh:conformanceDisallows`.
+
 ### `onInvalid` options
 
 | Value     | Behaviour                                                        |
@@ -54,7 +81,8 @@ await pipeline.run();
 
 ### Report writers
 
-Each `validate()` call that produces violations fans the SHACL report quads
+Each `validate()` call that produces validation results (of any severity,
+whether or not they fail conformance) fans the SHACL report quads
 (`sh:ValidationResult` triples, etc.) out to every configured `reportWriter`
 via `Writer.write(dataset, quads)`. Each writer's `Writer.flush(dataset)` is
 invoked from `ShaclValidator.report(dataset)` — i.e. once the pipeline

--- a/packages/pipeline-shacl-validator/src/index.ts
+++ b/packages/pipeline-shacl-validator/src/index.ts
@@ -6,5 +6,6 @@ export type {
 } from '@lde/pipeline';
 export {
   ShaclValidator,
+  severity,
   type ShaclValidatorOptions,
 } from './shacl-validator.js';

--- a/packages/pipeline-shacl-validator/src/shacl-validator.ts
+++ b/packages/pipeline-shacl-validator/src/shacl-validator.ts
@@ -16,21 +16,50 @@ import rdf from 'rdf-ext';
 import { rdfDereferencer } from 'rdf-dereference';
 import { skolemizeReport } from './skolemize-report.js';
 
+const shacl = 'http://www.w3.org/ns/shacl#';
+
+/**
+ * The severity level IRIs defined by SHACL Core, for use in
+ * {@link ShaclValidatorOptions.conformanceDisallows}.
+ */
+export const severity = {
+  info: `${shacl}Info`,
+  warning: `${shacl}Warning`,
+  violation: `${shacl}Violation`,
+} as const;
+
 /** Options for {@link ShaclValidator}. */
 export interface ShaclValidatorOptions {
   /** Path to an RDF file containing SHACL shapes (any format supported by rdf-dereference). */
   shapesFile: string;
   /**
    * Writers that receive the per-dataset SHACL validation report quads. The
-   * validator opens one run per writer (lazily, on the first violation) and
-   * streams each batch with violations to it; each run is flushed per dataset
-   * from {@link ShaclValidator.report}.
+   * validator opens one run per writer (lazily, on the first validation
+   * result of any severity) and streams each batch with results to it; each
+   * run is flushed per dataset from {@link ShaclValidator.report}.
    *
    * Pass a {@link FileWriter} to mirror the previous on-disk behaviour, a
    * {@link SparqlUpdateWriter} to land reports in a named graph, or any custom
    * writer. Validators with no `reportWriters` only produce aggregate counts.
    */
   reportWriters?: Writer[];
+  /**
+   * Severity level IRIs that disallow conformance — the SHACL 1.2
+   * conformance-disallow set (`sh:conformanceDisallows`). A result whose
+   * `sh:resultSeverity` is in this set flips `conforms` to `false` and counts
+   * towards `violations`; results outside the set are still streamed to
+   * `reportWriters` but do not fail validation.
+   *
+   * Defaults to the SHACL 1.2 default set — `sh:Violation`, `sh:Warning` and
+   * `sh:Info` — so any result fails validation, matching `shacl-engine`’s own
+   * `report.conforms`. Pass `[severity.violation]` to fail on violations only;
+   * custom severity IRIs are supported.
+   *
+   * When set, the written report carries `sh:conformanceDisallows` triples and
+   * an `sh:conforms` value computed against this set, so stored reports stay
+   * self-describing per SHACL 1.2.
+   */
+  conformanceDisallows?: readonly string[];
 }
 
 interface DatasetAccumulator {
@@ -50,6 +79,8 @@ export class ShaclValidator implements Validator {
   private readonly shapesFile: string;
   private readonly reportWriters: Writer[];
   private reportRuns: RunWriter[] | undefined;
+  private readonly conformanceDisallows: readonly string[] | undefined;
+  private readonly disallowedSeverities: Set<string>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private shapesDataset: any | undefined;
   private readonly accumulators = new Map<string, DatasetAccumulator>();
@@ -57,6 +88,10 @@ export class ShaclValidator implements Validator {
   constructor(options: ShaclValidatorOptions) {
     this.shapesFile = options.shapesFile;
     this.reportWriters = options.reportWriters ?? [];
+    this.conformanceDisallows = options.conformanceDisallows;
+    this.disallowedSeverities = new Set(
+      options.conformanceDisallows ?? Object.values(severity),
+    );
   }
 
   async validate(quads: Quad[], dataset: Dataset): Promise<ValidationResult> {
@@ -70,8 +105,16 @@ export class ShaclValidator implements Validator {
     const validator = new ShaclEngine(shapes, { factory: rdf });
     const report = await validator.validate({ dataset: dataDataset });
 
-    const violations = report.results.length as number;
-    const conforms = report.conforms as boolean;
+    // Conformance checking per SHACL 1.2 (§6.6): a result fails validation
+    // only if its severity is in the conformance-disallow set. shacl-engine’s
+    // report.conforms hardcodes the default set, so compute conformance here.
+    // The engine sets a severity on every result (sh:Violation when the shape
+    // declares none).
+    const results = report.results as { severity: { value: string } }[];
+    const violations = results.filter((result) =>
+      this.disallowedSeverities.has(result.severity.value),
+    ).length;
+    const conforms = violations === 0;
 
     // Accumulate per dataset.
     const key = dataset.iri.toString();
@@ -85,15 +128,17 @@ export class ShaclValidator implements Validator {
     if (!conforms) acc.conforms = false;
     this.accumulators.set(key, acc);
 
-    if (violations > 0 && this.reportWriters.length > 0) {
+    // Reports are written whenever there are results, conforming or not, so
+    // below-threshold results (e.g. warnings) stay visible to consumers.
+    if (results.length > 0 && this.reportWriters.length > 0) {
       // Skolemise the report's blank nodes to dataset-scoped IRIs before writing.
       // shacl-engine emits the report and every result as blank nodes, whose
       // labels are not unique across the per-dataset n-quads files a file-based
       // store cats into one index — fusing one dataset's violations into
       // another's (see ldelements/lde#478).
-      const reportQuads = skolemizeReport(
-        report.dataset,
-        dataset.iri.toString(),
+      const reportQuads = this.amendReport(
+        skolemizeReport(report.dataset, dataset.iri.toString()),
+        conforms,
       );
       for (const run of await this.runs()) {
         await run.write(dataset, asyncIterableOf(reportQuads));
@@ -103,7 +148,7 @@ export class ShaclValidator implements Validator {
     // Surface where to look for the report in halt-mode error messages
     // (read by @lde/pipeline's Stage.validateBuffer when onInvalid:'halt').
     const message =
-      violations > 0 && this.reportWriters.length > 0
+      results.length > 0 && this.reportWriters.length > 0
         ? `Report sent to ${this.reportWriters.length} writer(s)`
         : undefined;
 
@@ -147,6 +192,52 @@ export class ShaclValidator implements Validator {
       ),
     );
     return this.reportRuns;
+  }
+
+  /**
+   * Rewrite the report’s `sh:conforms` to the value computed against the
+   * configured conformance-disallow set and declare that set on the report
+   * as `sh:conformanceDisallows` (SHACL 1.2 §6.7.1.2). Reports are left
+   * untouched when the option is absent: the engine’s own `sh:conforms`
+   * already reflects the default set.
+   */
+  private amendReport(reportQuads: Quad[], conforms: boolean): Quad[] {
+    if (!this.conformanceDisallows) return reportQuads;
+
+    // Anchor on the report's identity: the engine emits exactly one
+    // `a sh:ValidationReport`, on the report node (results are separate nodes
+    // typed sh:ValidationResult).
+    const reportNode = reportQuads.find(
+      (q) =>
+        q.predicate.value ===
+          'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
+        q.object.value === `${shacl}ValidationReport`,
+    )!.subject;
+
+    // Rewrite that node's sh:conforms to the value computed against the
+    // disallow set; the set itself is declared below.
+    const amended = reportQuads.map((q) =>
+      q.subject.equals(reportNode) && q.predicate.value === `${shacl}conforms`
+        ? (rdf.quad(
+            q.subject,
+            q.predicate,
+            rdf.literal(
+              String(conforms),
+              rdf.namedNode('http://www.w3.org/2001/XMLSchema#boolean'),
+            ),
+          ) as Quad)
+        : q,
+    );
+    for (const level of this.conformanceDisallows) {
+      amended.push(
+        rdf.quad(
+          reportNode!,
+          rdf.namedNode(`${shacl}conformanceDisallows`),
+          rdf.namedNode(level),
+        ),
+      );
+    }
+    return amended;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/pipeline-shacl-validator/test/fixtures/custom-severity-only.ttl
+++ b/packages/pipeline-shacl-validator/test/fixtures/custom-severity-only.ttl
@@ -1,0 +1,6 @@
+@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:alice a ex:Person ;
+  ex:name "Alice"^^xsd:string ;
+  ex:nickname "Ali" .

--- a/packages/pipeline-shacl-validator/test/fixtures/shapes-severities.ttl
+++ b/packages/pipeline-shacl-validator/test/fixtures/shapes-severities.ttl
@@ -1,0 +1,25 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:PersonSeveritiesShape
+  a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:property [
+    sh:path ex:name ;
+    sh:minCount 1 ;
+    sh:datatype xsd:string ;
+    sh:message "A person must have at least one name of type xsd:string." ;
+  ] ;
+  sh:property [
+    sh:path ex:nickname ;
+    sh:minCount 1 ;
+    sh:severity sh:Warning ;
+    sh:message "A person should have a nickname." ;
+  ] ;
+  sh:property [
+    sh:path ex:email ;
+    sh:minCount 1 ;
+    sh:severity ex:Critical ;
+    sh:message "A person must have an email address (custom severity)." ;
+  ] .

--- a/packages/pipeline-shacl-validator/test/fixtures/warning-only.ttl
+++ b/packages/pipeline-shacl-validator/test/fixtures/warning-only.ttl
@@ -1,0 +1,6 @@
+@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:alice a ex:Person ;
+  ex:name "Alice"^^xsd:string ;
+  ex:email "alice@example.org" .

--- a/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
+++ b/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
@@ -12,9 +12,12 @@ import {
   type RunContext,
   type Writer,
 } from '@lde/pipeline';
-import { ShaclValidator } from '../src/shacl-validator.js';
+import { ShaclValidator, severity } from '../src/shacl-validator.js';
 
 const SH_RESULT = 'http://www.w3.org/ns/shacl#result';
+const SH_CONFORMS = 'http://www.w3.org/ns/shacl#conforms';
+const SH_CONFORMANCE_DISALLOWS =
+  'http://www.w3.org/ns/shacl#conformanceDisallows';
 
 /**
  * A transactional fake report writer exposing its run's `write` and `flush`
@@ -320,6 +323,149 @@ describe('ShaclValidator', () => {
     const report = await validator.report(dataset);
     expect(report.conforms).toBe(true);
     expect(report.quadsValidated).toBe(quads.length * 2);
+  });
+
+  describe('conformanceDisallows', () => {
+    const severitiesShapesFile = join(
+      __dirname,
+      'fixtures',
+      'shapes-severities.ttl',
+    );
+
+    it('fails on warning-only results by default, per the SHACL 1.2 default set', async () => {
+      const validator = new ShaclValidator({
+        shapesFile: severitiesShapesFile,
+      });
+
+      const result = await validator.validate(
+        parseFixture('warning-only.ttl'),
+        dataset,
+      );
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations).toBe(1);
+    });
+
+    it('lets warning-only results conform when only sh:Violation disallows conformance', async () => {
+      const validator = new ShaclValidator({
+        shapesFile: severitiesShapesFile,
+        conformanceDisallows: [severity.violation],
+      });
+
+      const result = await validator.validate(
+        parseFixture('warning-only.ttl'),
+        dataset,
+      );
+
+      expect(result.conforms).toBe(true);
+      expect(result.violations).toBe(0);
+    });
+
+    it('still fails on violations when only sh:Violation disallows conformance', async () => {
+      const validator = new ShaclValidator({
+        shapesFile: severitiesShapesFile,
+        conformanceDisallows: [severity.violation],
+      });
+
+      // Triggers all three property shapes: one Violation, one Warning, one
+      // custom severity — only the Violation counts.
+      const result = await validator.validate(
+        parseFixture('invalid.ttl'),
+        dataset,
+      );
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations).toBe(1);
+    });
+
+    it('supports custom severity IRIs in the disallow set', async () => {
+      const validator = new ShaclValidator({
+        shapesFile: severitiesShapesFile,
+        conformanceDisallows: ['http://example.org/Critical'],
+      });
+
+      const result = await validator.validate(
+        parseFixture('custom-severity-only.ttl'),
+        dataset,
+      );
+
+      expect(result.conforms).toBe(false);
+      expect(result.violations).toBe(1);
+    });
+
+    it('streams below-threshold results to writers even when the dataset conforms', async () => {
+      let received: Quad[] = [];
+      const writer = makeReportWriter();
+      writer.write.mockImplementation(async (_dataset: Dataset, quads) => {
+        received = await collectQuads(quads);
+      });
+      const validator = new ShaclValidator({
+        shapesFile: severitiesShapesFile,
+        conformanceDisallows: [severity.violation],
+        reportWriters: [writer],
+      });
+
+      const result = await validator.validate(
+        parseFixture('warning-only.ttl'),
+        dataset,
+      );
+
+      expect(result.conforms).toBe(true);
+      expect(
+        received.filter((quad) => quad.predicate.value === SH_RESULT),
+      ).toHaveLength(1);
+    });
+
+    it('writes a report whose sh:conforms and sh:conformanceDisallows reflect the configured set', async () => {
+      let received: Quad[] = [];
+      const writer = makeReportWriter();
+      writer.write.mockImplementation(async (_dataset: Dataset, quads) => {
+        received = await collectQuads(quads);
+      });
+      const validator = new ShaclValidator({
+        shapesFile: severitiesShapesFile,
+        conformanceDisallows: [severity.violation],
+        reportWriters: [writer],
+      });
+
+      await validator.validate(parseFixture('warning-only.ttl'), dataset);
+
+      const conformsQuads = received.filter(
+        (quad) => quad.predicate.value === SH_CONFORMS,
+      );
+      expect(conformsQuads).toHaveLength(1);
+      expect(conformsQuads[0].object.value).toBe('true');
+      const disallowsQuads = received.filter(
+        (quad) => quad.predicate.value === SH_CONFORMANCE_DISALLOWS,
+      );
+      expect(disallowsQuads.map((quad) => quad.object.value)).toEqual([
+        severity.violation,
+      ]);
+    });
+
+    it('does not add sh:conformanceDisallows to reports when the option is absent', async () => {
+      const received = await reportQuadsFor('invalid.ttl');
+
+      expect(
+        received.some(
+          (quad) => quad.predicate.value === SH_CONFORMANCE_DISALLOWS,
+        ),
+      ).toBe(false);
+    });
+
+    it('accumulates conformance against the configured set across validate calls', async () => {
+      const validator = new ShaclValidator({
+        shapesFile: severitiesShapesFile,
+        conformanceDisallows: [severity.violation],
+      });
+
+      await validator.validate(parseFixture('warning-only.ttl'), dataset);
+      await validator.validate(parseFixture('valid.ttl'), dataset);
+
+      const report = await validator.report(dataset);
+      expect(report.conforms).toBe(true);
+      expect(report.violations).toBe(0);
+    });
   });
 
   describe('with FileWriter', () => {


### PR DESCRIPTION
Adds an optional `conformanceDisallows` setting to `ShaclValidator`, implementing the [SHACL 1.2 conformance-disallow set](https://www.w3.org/TR/shacl12-core/#conformanceDisallows): the set of severity IRIs whose presence among validation results makes validation fail.

## Why

`shacl-engine`’s `report.conforms` hardcodes the SHACL 1.2 default set – any `sh:Violation`, `sh:Warning` or `sh:Info` result fails validation. Consumers such as the Dataset Knowledge Graph want warnings to be advisory (SHOULD-level findings, including requirements staged via `nde:futureChange`), matching the Dataset Register’s violation-only semantics – see netwerk-digitaal-erfgoed/dataset-knowledge-graph#411. Other users do want warnings to fail validation, so the default is unchanged.

SHACL 1.2 models this as a *set* of disallowed severities rather than a “minimum severity”, since severities (including custom ones) have no normative ordering – an ordered threshold was explicitly rejected in [w3c/data-shapes#453](https://github.com/w3c/data-shapes/issues/453). The spec sanctions this option: “The conformance-disallow set is defined by the validation engine. A validation engine MAY provide mechanisms to customize this set.”

## What

- `conformanceDisallows?: readonly string[]` on `ShaclValidatorOptions`; defaults to the SHACL 1.2 default set (`sh:Violation`, `sh:Warning`, `sh:Info`), preserving existing behaviour. Custom severity IRIs are supported.
- `conforms` and `violations` are computed from result severities against the set, instead of reading `report.conforms` (also fixing `violations` counting results the engine did not treat as non-conforming).
- Reports are streamed to `reportWriters` whenever there are results – below-threshold results (e.g. warnings) stay visible to consumers even when the dataset conforms.
- Forward support for SHACL 1.2 ahead of the engine: when the option is set, the written report carries `sh:conformanceDisallows` triples and an `sh:conforms` recomputed against the set, keeping stored reports self-describing.
- Exports a `severity` constant with the three SHACL Core level IRIs.
