### PR TITLE
feat(search-pipeline): compose search indexing as a pipeline instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ await pipeline.run();
 <tr>
   <td><a href="packages/search-typesense">@lde/search-typesense</a></td>
   <td><a href="https://www.npmjs.com/package/@lde/search-typesense"><img src="https://img.shields.io/npm/v/@lde/search-typesense" alt="npm"></a></td>
-  <td>Typesense engine adapter: transactional Blue/green and In-place index rebuild writers</td>
+  <td>Typesense engine adapter: transactional Blue/green (build fresh, swap atomically) and In-place (update the live index) rebuild writers</td>
 </tr>
 <tr>
   <td><a href="packages/text-normalization">@lde/text-normalization</a></td>

--- a/README.md
+++ b/README.md
@@ -149,9 +149,14 @@ await pipeline.run();
   <td>Engine- and domain-agnostic GraphQL surface for search: builds an executable GraphQL schema from a SearchSchema at runtime, one root query field per type</td>
 </tr>
 <tr>
+  <td><a href="packages/search-pipeline">@lde/search-pipeline</a></td>
+  <td><a href="https://www.npmjs.com/package/@lde/search-pipeline"><img src="https://img.shields.io/npm/v/@lde/search-pipeline" alt="npm"></a></td>
+  <td>Search indexing as an @lde/pipeline instance: projects extracted RDF into search documents and feeds them to a transactional engine writer</td>
+</tr>
+<tr>
   <td><a href="packages/search-typesense">@lde/search-typesense</a></td>
   <td><a href="https://www.npmjs.com/package/@lde/search-typesense"><img src="https://img.shields.io/npm/v/@lde/search-typesense" alt="npm"></a></td>
-  <td>Typesense engine adapter: a single-flight, streaming blue/green index rebuild</td>
+  <td>Typesense engine adapter: transactional Blue/green and In-place index rebuild writers</td>
 </tr>
 <tr>
   <td><a href="packages/text-normalization">@lde/text-normalization</a></td>
@@ -238,6 +243,9 @@ graph TD
     search-api-graphql --> search
     search-typesense --> search
     search-typesense --> text-normalization
+    search-typesense --> pipeline
+    search-pipeline --> search
+    search-pipeline --> pipeline
   end
 
   subgraph Monitoring

--- a/package-lock.json
+++ b/package-lock.json
@@ -24953,6 +24953,10 @@
       "resolved": "packages/search-api-graphql",
       "link": true
     },
+    "node_modules/@lde/search-pipeline": {
+      "resolved": "packages/search-pipeline",
+      "link": true
+    },
     "node_modules/@lde/search-typesense": {
       "resolved": "packages/search-typesense",
       "link": true
@@ -42919,6 +42923,37 @@
         "dataloader": "^2.2.3",
         "graphql": "^15.8.0",
         "tslib": "^2.3.0"
+      }
+    },
+    "packages/search-pipeline": {
+      "name": "@lde/search-pipeline",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@lde/search": "^0.3.0",
+        "@rdfjs/types": "^2.0.1",
+        "tslib": "^2.3.0"
+      },
+      "devDependencies": {
+        "n3": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@lde/dataset": "^0.7.8",
+        "@lde/pipeline": "^0.31.4"
+      }
+    },
+    "packages/search-pipeline/node_modules/n3": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-2.1.1.tgz",
+      "integrity": "sha512-kqg8ers6Lc+uAmHeS+ycd3b8mC4x8wr8V8Fi6+w7l4hX6b0KZ5bT05Tf49qM2mujwaqZT3+08zcgtXgfxivbVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "packages/search-typesense": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42545,7 +42545,7 @@
     },
     "packages/pipeline": {
       "name": "@lde/pipeline",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "^0.7.8",
@@ -42571,7 +42571,7 @@
     },
     "packages/pipeline-console-reporter": {
       "name": "@lde/pipeline-console-reporter",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -42582,7 +42582,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.32.0"
+        "@lde/pipeline": "^0.33.0"
       }
     },
     "packages/pipeline-console-reporter/node_modules/ansi-regex": {
@@ -42762,7 +42762,7 @@
     },
     "packages/pipeline-shacl-sampler": {
       "name": "@lde/pipeline-shacl-sampler",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -42773,7 +42773,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.32.0"
+        "@lde/pipeline": "^0.33.0"
       }
     },
     "packages/pipeline-shacl-sampler/node_modules/n3": {
@@ -42791,7 +42791,7 @@
     },
     "packages/pipeline-shacl-validator": {
       "name": "@lde/pipeline-shacl-validator",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -42805,7 +42805,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.32.0"
+        "@lde/pipeline": "^0.33.0"
       }
     },
     "packages/pipeline-shacl-validator/node_modules/n3": {
@@ -42824,7 +42824,7 @@
     },
     "packages/pipeline-void": {
       "name": "@lde/pipeline-void",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -42835,7 +42835,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.32.0"
+        "@lde/pipeline": "^0.33.0"
       }
     },
     "packages/pipeline-void/node_modules/n3": {
@@ -42939,7 +42939,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.31.4"
+        "@lde/pipeline": "^0.33.0"
       }
     },
     "packages/search-pipeline/node_modules/n3": {
@@ -42958,7 +42958,7 @@
     },
     "packages/search-typesense": {
       "name": "@lde/search-typesense",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@lde/search": "^0.3.0",
@@ -42971,7 +42971,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.32.0"
+        "@lde/pipeline": "^0.33.0"
       }
     },
     "packages/search/node_modules/n3": {

--- a/packages/search-pipeline/README.md
+++ b/packages/search-pipeline/README.md
@@ -1,0 +1,79 @@
+# @lde/search-pipeline
+
+Search indexing as an [`@lde/pipeline`](../pipeline) Configurable Pipeline
+instance: this package supplies the glue between the pipeline’s quad world
+and a search engine’s document world, so indexing reuses the existing spine –
+Discovery → Selection → Iteration → change-gate (skip-unchanged) – instead of
+rebuilding it per consumer.
+
+The division of labour ([ADR 6](../../docs/decisions/0006-make-the-writer-transaction-aware.md)):
+
+- [`@lde/search`](../search) owns the engine-agnostic projection (framed
+  document + field model) and stays pipeline-free;
+- `@lde/search-<engine>` (e.g. [`@lde/search-typesense`](../search-typesense))
+  is the engine adapter: a transactional `Writer` consuming projected
+  documents, owning the run lifecycle (Blue/green alias swap or In-place
+  sweeps, cross-pod lock);
+- **this package** composes them: `searchIndexWriter` is the one
+  type-changing step (quad → document), shared across engines.
+
+## Usage
+
+```typescript
+import { Pipeline, Stage, SparqlConstructReader } from '@lde/pipeline';
+import { searchSchema } from '@lde/search';
+import { BlueGreenRebuild } from '@lde/search-typesense';
+import { searchIndexWriter } from '@lde/search-pipeline';
+
+const schema = searchSchema({
+  name: 'dataset',
+  type: 'http://www.w3.org/ns/dcat#Dataset',
+  fields: [
+    {
+      name: 'title',
+      kind: 'text',
+      path: 'http://purl.org/dc/terms/title',
+      locales: ['und'],
+      output: true,
+      searchable: true,
+    },
+  ],
+});
+
+const pipeline = new Pipeline({
+  datasetSelector,
+  stages: [
+    new Stage({
+      name: 'extract',
+      readers: new SparqlConstructReader({ query: '…' }),
+    }),
+  ],
+  writers: searchIndexWriter({
+    schema,
+    writer: new BlueGreenRebuild(
+      typesenseClient,
+      schema.get('http://www.w3.org/ns/dcat#Dataset')!,
+      {
+        name: 'datasets',
+      },
+    ),
+  }),
+});
+
+await pipeline.run();
+```
+
+Each dataset’s extracted CONSTRUCT quads are buffered until the dataset
+completes, then framed by root type and projected into flat search documents
+(`@lde/search`’s `projectGraph`), and written to the engine run – before the
+engine acts on the dataset’s completion, so an In-place stale sweep never
+races its own documents. The run lifecycle (run context, per-dataset flush
+outcome, commit/abort) passes through unchanged: the engine writer’s update
+mode governs, and the pipeline never branches on it.
+
+## Memory
+
+Memory is bounded by one dataset’s extraction and released at each dataset
+flush – nothing accumulates across datasets. Streaming bounded entity batches
+_within_ one huge dataset needs the two-level iteration (dataset →
+entity-URI batches) and is not implemented yet.

--- a/packages/search-pipeline/eslint.config.mjs
+++ b/packages/search-pipeline/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/packages/search-pipeline/package.json
+++ b/packages/search-pipeline/package.json
@@ -34,6 +34,6 @@
   },
   "peerDependencies": {
     "@lde/dataset": "^0.7.8",
-    "@lde/pipeline": "^0.31.4"
+    "@lde/pipeline": "^0.33.0"
   }
 }

--- a/packages/search-pipeline/package.json
+++ b/packages/search-pipeline/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@lde/search-pipeline",
+  "version": "0.1.0",
+  "description": "Search indexing as an @lde/pipeline Configurable Pipeline: projects extracted RDF into engine-agnostic search documents and feeds them to a transactional search-engine writer",
+  "repository": {
+    "url": "git+https://github.com/ldelements/lde.git",
+    "directory": "packages/search-pipeline"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@lde/search": "^0.3.0",
+    "@rdfjs/types": "^2.0.1",
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "n3": "^2.1.0"
+  },
+  "peerDependencies": {
+    "@lde/dataset": "^0.7.8",
+    "@lde/pipeline": "^0.31.4"
+  }
+}

--- a/packages/search-pipeline/src/index.ts
+++ b/packages/search-pipeline/src/index.ts
@@ -1,0 +1,2 @@
+export { searchIndexWriter } from './search-index-writer.js';
+export type { SearchIndexWriterOptions } from './search-index-writer.js';

--- a/packages/search-pipeline/src/search-index-writer.ts
+++ b/packages/search-pipeline/src/search-index-writer.ts
@@ -1,0 +1,110 @@
+import type { Quad } from '@rdfjs/types';
+import type { Dataset } from '@lde/dataset';
+import type {
+  DatasetOutcome,
+  RunContext,
+  RunWriter,
+  Writer,
+} from '@lde/pipeline';
+import {
+  projectGraph,
+  type SearchDocument,
+  type SearchSchema,
+} from '@lde/search';
+
+/** Options for {@link searchIndexWriter}. */
+export interface SearchIndexWriterOptions {
+  /**
+   * The declarative schema driving the projection: one {@link SearchType} per
+   * root type, each mapping framed RDF to flat search-document fields.
+   */
+  schema: SearchSchema;
+  /**
+   * The engine adapter the projected documents are written to – e.g.
+   * `@lde/search-typesense`’s `BlueGreenRebuild` or `InPlaceRebuild`. The
+   * run lifecycle (context, per-dataset flush outcome, commit/abort) is
+   * forwarded unchanged, so the engine writer’s update mode governs.
+   */
+  writer: Writer<SearchDocument>;
+}
+
+/**
+ * The projection step of a search-indexing pipeline, as a quad `Writer`: it
+ * turns each dataset’s extracted CONSTRUCT quads into engine-agnostic search
+ * documents ({@link projectGraph}: frame by root type, then project each node
+ * with its type’s declaration) and feeds them to the engine writer. This is
+ * the one type-changing step (quad → document), shared across engines –
+ * which is why it lives here and not inside an engine adapter.
+ *
+ * A dataset’s quads are buffered until its flush and projected then, so the
+ * documents land before the engine acts on the dataset’s completion (e.g. an
+ * In-place stale sweep). Memory is bounded by one dataset’s extraction, and
+ * released at each flush – nothing accumulates across datasets. Streaming
+ * bounded entity batches *within* one huge dataset needs the two-level
+ * iteration (dataset → entity-URI batches) and is not implemented yet.
+ */
+export function searchIndexWriter(
+  options: SearchIndexWriterOptions,
+): Writer<Quad> {
+  const { schema, writer } = options;
+  return {
+    async openRun(context: RunContext): Promise<RunWriter<Quad>> {
+      const run = await writer.openRun(context);
+      // One buffered pass per dataset, keyed by IRI. The pipeline processes
+      // datasets sequentially, but keeping the key explicit makes a write
+      // after another dataset's flush safe too.
+      const passes = new Map<string, { dataset: Dataset; quads: Quad[] }>();
+
+      const project = async (pass: {
+        dataset: Dataset;
+        quads: Quad[];
+      }): Promise<void> => {
+        passes.delete(pass.dataset.iri.toString());
+        if (pass.quads.length === 0) {
+          return;
+        }
+        await run.write(pass.dataset, projectGraph(pass.quads, schema));
+      };
+
+      return {
+        write: async (dataset: Dataset, quads: AsyncIterable<Quad>) => {
+          const key = dataset.iri.toString();
+          let pass = passes.get(key);
+          if (pass === undefined) {
+            pass = { dataset, quads: [] };
+            passes.set(key, pass);
+          }
+          for await (const quad of quads) {
+            pass.quads.push(quad);
+          }
+        },
+
+        flush: async (dataset: Dataset, outcome: DatasetOutcome) => {
+          const pass = passes.get(dataset.iri.toString());
+          if (pass !== undefined) {
+            await project(pass);
+          }
+          await run.flush?.(dataset, outcome);
+        },
+
+        reset: async (dataset: Dataset) => {
+          // Discard the buffered pass so the re-run replaces it, and let the
+          // engine writer discard whatever it already holds for the dataset.
+          passes.delete(dataset.iri.toString());
+          await run.reset?.(dataset);
+        },
+
+        commit: async () => {
+          // Safety net: project passes that were never flushed, so a
+          // committed run never silently drops written quads.
+          for (const pass of [...passes.values()]) {
+            await project(pass);
+          }
+          await run.commit();
+        },
+
+        abort: (error: unknown) => run.abort(error),
+      };
+    },
+  };
+}

--- a/packages/search-pipeline/test/search-index-writer.test.ts
+++ b/packages/search-pipeline/test/search-index-writer.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DataFactory } from 'n3';
+import type { Quad } from '@rdfjs/types';
+import { Dataset } from '@lde/dataset';
+import type { RunContext, RunWriter, Writer } from '@lde/pipeline';
+import { searchSchema, type SearchDocument } from '@lde/search';
+import { searchIndexWriter } from '../src/search-index-writer.js';
+
+const { namedNode, literal, quad } = DataFactory;
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const PERSON = 'https://example.org/Person';
+const WORK = 'https://example.org/CreativeWork';
+const NAME = 'https://example.org/name';
+
+const schema = searchSchema(
+  {
+    name: 'person',
+    type: PERSON,
+    fields: [{ name: 'name', kind: 'keyword', path: NAME }],
+  },
+  {
+    name: 'work',
+    type: WORK,
+    fields: [{ name: 'name', kind: 'keyword', path: NAME }],
+  },
+);
+
+const dataset = new Dataset({
+  iri: new URL('http://example.org/dataset/1'),
+  distributions: [],
+});
+
+function personQuads(iri: string, name: string): Quad[] {
+  return [
+    quad(namedNode(iri), namedNode(RDF_TYPE), namedNode(PERSON)),
+    quad(namedNode(iri), namedNode(NAME), literal(name)),
+  ];
+}
+
+async function* stream<Item>(items: readonly Item[]): AsyncIterable<Item> {
+  yield* items;
+}
+
+function makeRunContext(): RunContext {
+  return {
+    runId: 'run-1',
+    startedAt: '2026-07-06T12:00:00.000Z',
+    selectedSources: () => [dataset.iri.toString()],
+  };
+}
+
+/** A fake engine writer capturing every per-dataset document write. */
+function makeEngineWriter() {
+  const writes: { dataset: Dataset; documents: SearchDocument[] }[] = [];
+  const runWriter = {
+    write: vi.fn(
+      async (written: Dataset, documents: AsyncIterable<SearchDocument>) => {
+        const collected: SearchDocument[] = [];
+        for await (const document of documents) {
+          collected.push(document);
+        }
+        writes.push({ dataset: written, documents: collected });
+      },
+    ),
+    flush: vi.fn().mockResolvedValue(undefined),
+    reset: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn().mockResolvedValue(undefined),
+  };
+  const writer: Writer<SearchDocument> & {
+    openRun: ReturnType<typeof vi.fn>;
+  } = {
+    openRun: vi.fn().mockResolvedValue(runWriter),
+  };
+  return { writer, runWriter, writes };
+}
+
+async function openRun(
+  engine: ReturnType<typeof makeEngineWriter>,
+): Promise<RunWriter<Quad>> {
+  return searchIndexWriter({ schema, writer: engine.writer }).openRun(
+    makeRunContext(),
+  );
+}
+
+describe('searchIndexWriter', () => {
+  it('projects a dataset’s quads into documents and writes them to the engine on flush', async () => {
+    const engine = makeEngineWriter();
+    const run = await openRun(engine);
+
+    await run.write(
+      dataset,
+      stream([
+        ...personQuads('http://example.org/person/1', 'Alice'),
+        ...personQuads('http://example.org/person/2', 'Bob'),
+      ]),
+    );
+    await run.flush?.(dataset, 'success');
+
+    expect(engine.writes).toHaveLength(1);
+    expect(engine.writes[0].dataset).toBe(dataset);
+    expect(engine.writes[0].documents).toEqual([
+      { id: 'http://example.org/person/1', name: ['Alice'] },
+      { id: 'http://example.org/person/2', name: ['Bob'] },
+    ]);
+    expect(engine.runWriter.flush).toHaveBeenCalledExactlyOnceWith(
+      dataset,
+      'success',
+    );
+  });
+
+  it('projects every root type in the schema', async () => {
+    const engine = makeEngineWriter();
+    const run = await openRun(engine);
+
+    await run.write(
+      dataset,
+      stream([
+        ...personQuads('http://example.org/person/1', 'Alice'),
+        quad(
+          namedNode('http://example.org/work/1'),
+          namedNode(RDF_TYPE),
+          namedNode(WORK),
+        ),
+        quad(
+          namedNode('http://example.org/work/1'),
+          namedNode(NAME),
+          literal('Nachtwacht'),
+        ),
+      ]),
+    );
+    await run.flush?.(dataset, 'success');
+
+    const ids = engine.writes[0].documents.map((document) => document.id);
+    expect(ids).toContain('http://example.org/person/1');
+    expect(ids).toContain('http://example.org/work/1');
+  });
+
+  it('combines multiple writes for one dataset into a single projection', async () => {
+    // A dataset writes once per stage; all stages’ quads project together.
+    const engine = makeEngineWriter();
+    const run = await openRun(engine);
+
+    await run.write(
+      dataset,
+      stream(personQuads('http://example.org/person/1', 'Alice')),
+    );
+    await run.write(
+      dataset,
+      stream(personQuads('http://example.org/person/2', 'Bob')),
+    );
+    await run.flush?.(dataset, 'success');
+
+    expect(engine.writes).toHaveLength(1);
+    expect(engine.writes[0].documents.map((document) => document.id)).toEqual([
+      'http://example.org/person/1',
+      'http://example.org/person/2',
+    ]);
+  });
+
+  it('does not accumulate quads across dataset flushes', async () => {
+    const engine = makeEngineWriter();
+    const run = await openRun(engine);
+
+    await run.write(
+      dataset,
+      stream(personQuads('http://example.org/person/1', 'Alice')),
+    );
+    await run.flush?.(dataset, 'success');
+    await run.write(
+      dataset,
+      stream(personQuads('http://example.org/person/2', 'Bob')),
+    );
+    await run.flush?.(dataset, 'success');
+
+    expect(engine.writes).toHaveLength(2);
+    expect(engine.writes[1].documents.map((document) => document.id)).toEqual([
+      'http://example.org/person/2',
+    ]);
+  });
+
+  it('forwards a flush without any writes, but writes no documents', async () => {
+    const engine = makeEngineWriter();
+    const run = await openRun(engine);
+
+    await run.flush?.(dataset, 'success');
+
+    expect(engine.runWriter.write).not.toHaveBeenCalled();
+    expect(engine.runWriter.flush).toHaveBeenCalledExactlyOnceWith(
+      dataset,
+      'success',
+    );
+  });
+
+  it('writes no documents for a dataset whose extraction was empty', async () => {
+    const engine = makeEngineWriter();
+    const run = await openRun(engine);
+
+    await run.write(dataset, stream([]));
+    await run.flush?.(dataset, 'success');
+
+    expect(engine.runWriter.write).not.toHaveBeenCalled();
+    expect(engine.runWriter.flush).toHaveBeenCalledOnce();
+  });
+
+  it('reset discards the buffered pass and forwards to the engine', async () => {
+    const engine = makeEngineWriter();
+    const run = await openRun(engine);
+
+    await run.write(
+      dataset,
+      stream(personQuads('http://example.org/person/1', 'Endpoint pass')),
+    );
+    await run.reset?.(dataset);
+    await run.write(
+      dataset,
+      stream(personQuads('http://example.org/person/1', 'Dump pass')),
+    );
+    await run.flush?.(dataset, 'success');
+
+    expect(engine.runWriter.reset).toHaveBeenCalledExactlyOnceWith(dataset);
+    expect(engine.writes).toHaveLength(1);
+    expect(engine.writes[0].documents).toEqual([
+      { id: 'http://example.org/person/1', name: ['Dump pass'] },
+    ]);
+  });
+
+  it('projects never-flushed leftovers on commit, then commits the engine run', async () => {
+    const engine = makeEngineWriter();
+    const run = await openRun(engine);
+
+    await run.write(
+      dataset,
+      stream(personQuads('http://example.org/person/1', 'Alice')),
+    );
+    await run.commit();
+
+    expect(engine.writes).toHaveLength(1);
+    expect(engine.runWriter.commit).toHaveBeenCalledOnce();
+  });
+
+  it('tolerates an engine writer without flush and reset', async () => {
+    const written: SearchDocument[] = [];
+    const minimalEngine: Writer<SearchDocument> = {
+      openRun: async () => ({
+        write: async (_dataset, documents) => {
+          for await (const document of documents) {
+            written.push(document);
+          }
+        },
+        commit: () => Promise.resolve(),
+        abort: () => Promise.resolve(),
+      }),
+    };
+    const run = await searchIndexWriter({
+      schema,
+      writer: minimalEngine,
+    }).openRun(makeRunContext());
+
+    await run.write(
+      dataset,
+      stream(personQuads('http://example.org/person/1', 'Alice')),
+    );
+    await run.reset?.(dataset);
+    await run.write(
+      dataset,
+      stream(personQuads('http://example.org/person/1', 'Alice')),
+    );
+    await run.flush?.(dataset, 'success');
+
+    expect(written).toHaveLength(1);
+  });
+
+  it('forwards abort with the run failure', async () => {
+    const engine = makeEngineWriter();
+    const run = await openRun(engine);
+    const failure = new Error('selection died');
+
+    await run.abort(failure);
+
+    expect(engine.runWriter.abort).toHaveBeenCalledExactlyOnceWith(failure);
+  });
+
+  it('opens the engine run with the pipeline’s run context', async () => {
+    const engine = makeEngineWriter();
+    const context = makeRunContext();
+
+    await searchIndexWriter({ schema, writer: engine.writer }).openRun(context);
+
+    expect(engine.writer.openRun).toHaveBeenCalledExactlyOnceWith(context);
+  });
+});

--- a/packages/search-pipeline/tsconfig.json
+++ b/packages/search-pipeline/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/search-pipeline/tsconfig.lib.json
+++ b/packages/search-pipeline/tsconfig.lib.json
@@ -1,0 +1,36 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../dataset/tsconfig.lib.json"
+    },
+    {
+      "path": "../pipeline/tsconfig.lib.json"
+    },
+    {
+      "path": "../search/tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx",
+    "test/**/*.test.js",
+    "test/**/*.spec.js",
+    "test/**/*.test.jsx",
+    "test/**/*.spec.jsx"
+  ]
+}

--- a/packages/search-pipeline/tsconfig.spec.json
+++ b/packages/search-pipeline/tsconfig.spec.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "types": ["node"]
+  },
+  "include": [
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx",
+    "test/**/*.test.js",
+    "test/**/*.spec.js",
+    "test/**/*.test.jsx",
+    "test/**/*.spec.jsx",
+    "test/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/search-pipeline/vite.config.ts
+++ b/packages/search-pipeline/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vite.base.config.js';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    root: __dirname,
+    cacheDir: '../../node_modules/.vite/packages/search-pipeline',
+    test: {
+      coverage: {
+        thresholds: {
+          autoUpdate: true,
+          functions: 100,
+          lines: 100,
+          branches: 100,
+          statements: 100,
+        },
+      },
+    },
+  }),
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -79,6 +79,9 @@
     },
     {
       "path": "./packages/search-api-graphql"
+    },
+    {
+      "path": "./packages/search-pipeline"
     }
   ]
 }


### PR DESCRIPTION
Slice 3 of #534, stacked on #560: the new `@lde/search-pipeline` package that makes search indexing an `@lde/pipeline` Configurable Pipeline instance.

## What it does

`searchIndexWriter({ schema, writer })` is the one type-changing step (quad → document), shared across engines – which is why it lives here and not inside an engine adapter:

- buffers each dataset’s extracted CONSTRUCT quads until the dataset flushes;
- frames and projects them with `@lde/search`’s `projectGraph` (engine-agnostic);
- writes the documents to the engine writer’s run **before** forwarding the flush, so an In-place stale sweep never races its own documents;
- passes the run lifecycle through unchanged (run context, per-dataset `flush` outcome, `reset` for the dump-fallback discard, commit/abort) – the engine writer’s update mode governs, and the pipeline never branches on it.

With this, a search index rebuild is a plain `Pipeline` with an extraction `SparqlConstructReader` and `writers: searchIndexWriter({ schema, writer: new BlueGreenRebuild(...) })` – reusing Discovery → Selection → change-gate (skip-unchanged) instead of the bespoke full-rebuild indexer.

## Scope notes

- Memory is bounded by one dataset’s extraction and released per flush; nothing accumulates across datasets (pinned by a spec). Bounded entity batches *within* one huge dataset need the two-level iteration (dataset → entity-URI batches) from #534 and are explicitly future work (documented in the README).
- 100% coverage baseline; unit-tested against a fake engine writer – the engine writers themselves have their own testcontainer suites (#560).

## Releasing

New package: after merge, the first version must be published manually per the `npm-bootstrap-package` flow (`npm view @lde/search-pipeline` → 404 today).

Part of #534 (slice 3 of 4; next: per-reference label sources + facet-by-name search).
