### PR TITLE
feat(search)!: per-reference label sources

### DIFF
--- a/docs/decisions/0005-batch-facet-queries-through-the-engine-port.md
+++ b/docs/decisions/0005-batch-facet-queries-through-the-engine-port.md
@@ -16,7 +16,7 @@ The keyed facets object of ADR 4 resolves each selected facet with its own
 `where`-filter removed (skip-own-filter). Implemented as one `engine.search`
 call per selected facet, a typical listing page fanned out into 1 listing
 search + N facet searches – ~4–5× the engine round-trips of the pre-migration
-direct-Typesense path, which computed the whole sidebar in a single
+direct-Typesense path, which computed every facet in a single
 `multi_search`. Skip-own-filter only _changes_ the result for a facet whose
 own field is actively filtered; for every other facet the dedicated query is
 identical except for its `facet_by`.

--- a/docs/decisions/0007-resolve-reference-labels-from-per-reference-label-sources.md
+++ b/docs/decisions/0007-resolve-reference-labels-from-per-reference-label-sources.md
@@ -1,0 +1,59 @@
+# 7. Resolve reference labels from per-reference label sources
+
+Date: 2026-07-06
+
+## Status
+
+Proposed
+
+Amends the reference model of
+[ADR 3 (Search API core query model)](./0003-search-api-core-query-model.md);
+part of search as a Configurable Pipeline instance
+([#534](https://github.com/ldelements/lde/issues/534)).
+
+## Context
+
+Reference labels resolved from one global sidecar `labels` collection,
+configured engine-side (`labelsCollection`). With typed entity collections
+(persons, organizations, terms) becoming first-class searchable collections,
+every referenced entity lives in some typed collection already – a separate
+IRI→label sidecar duplicates data that the typed collection carries, and the
+engine option cannot say _which_ collection resolves _which_ reference. The
+planned facet-by-name typeahead needs exactly that: a per-reference target
+collection to search by label.
+
+## Decision
+
+- A reference declares its label source **in the schema**:
+  `ReferenceField.labelSource` names the `SearchType` whose collection
+  resolves the reference’s labels. The declaration stays engine-agnostic –
+  the engine maps type → collection via its existing `collections` option, so
+  a label source is just another entry there. One declaration drives
+  projection, resolution and (later) typeahead.
+- The named type must declare an `output`, `searchable` text field called
+  `label`: something to reconstruct a label from, and something to type
+  ahead against. `searchSchema` validates this schema-wide, so a dangling or
+  unsuitable label source fails at startup, not per query.
+- A reference without a `labelSource` is id-only: its IRIs never travel in a
+  label lookup.
+- **The global labels collection is dropped, not kept as a fallback for
+  typeless referents** (resolving open decision 1 of #534): every reference
+  that wants labels names a typed source. One model, no second path.
+- The Typesense engine bundles all sources’ lookups into the single
+  `multi_search` it already used, and the opt-in in-memory cache
+  (`labelCacheTtlMs`) now caches per source collection. Labels reconstruct
+  from the source type’s `label` declaration (its per-locale display
+  fields), with a bare untagged `label` value as the `und` fallback.
+
+## Consequences
+
+- Breaking for `@lde/search-typesense` consumers: `labelsCollection` is gone.
+  The Dataset Register declares its labels data as a `SearchType` (e.g. per
+  entity kind), adds its collection(s) to `collections`, and sets
+  `labelSource` on each reference field. Label collections are rebuilt via
+  `buildCollectionSchema` so the physical label fields exist.
+- Reference facet buckets are labelled from the facet field’s own source,
+  exactly as hit references are.
+- The facet-by-name typeahead (issue #534, with #533’s value-query IR) gets
+  its target for free: the reference’s `labelSource` names the collection to
+  search by label.

--- a/docs/decisions/0008-resolve-reference-labels-from-per-reference-label-sources.md
+++ b/docs/decisions/0008-resolve-reference-labels-from-per-reference-label-sources.md
@@ -4,7 +4,7 @@ Date: 2026-07-06
 
 ## Status
 
-Proposed
+Accepted
 
 Amends the reference model of
 [ADR 3 (Search API core query model)](./0003-search-api-core-query-model.md);

--- a/docs/decisions/0008-resolve-reference-labels-from-per-reference-label-sources.md
+++ b/docs/decisions/0008-resolve-reference-labels-from-per-reference-label-sources.md
@@ -1,4 +1,4 @@
-# 7. Resolve reference labels from per-reference label sources
+# 8. Resolve reference labels from per-reference label sources
 
 Date: 2026-07-06
 

--- a/packages/search-typesense/README.md
+++ b/packages/search-typesense/README.md
@@ -26,20 +26,28 @@ they cost no RAM; only the folded `*_search_${locale}`, facet/reference and
 `*_sort_${locale}` companions are indexed. Keeping retrieval-only fields
 un-indexed is the lever for holding a large index’s RAM down.
 
-`createTypesenseSearchEngine(client, { collection, labelsCollection })` is the
+`createTypesenseSearchEngine(client, schema, { collections })` is the
 `SearchEngine` implementation. Each search:
 
 - validates the query against the search type (the port contract — a
   structurally invalid query is rejected, never sent);
 - compiles it into Typesense search params (`buildSearchParams`);
 - runs the search;
-- resolves reference (and reference-facet) labels from the sidecar `labels`
-  collection in a single lookup;
+- resolves reference (and reference-facet) labels **per reference field**
+  from the collection of the `SearchType` its `labelSource` names – all
+  sources bundled into a single lookup. A reference without a `labelSource`
+  stays id-only. With `labelCacheTtlMs` set, each label-source collection is
+  instead loaded once into an in-memory cache;
 - reconstructs the logical `SearchResult` (`parseSearchResponse`) — language
   maps, labelled references, labelled facet buckets.
 
+A label source is just another `SearchType` in the schema (with an `output`,
+`searchable` text field called `label`) whose collection appears in
+`collections` – a typed entity collection and a ‘labels collection’ are the
+same kind of thing.
+
 `searchFacets` – the port’s batch entry point – answers a whole batch of
-facet-only queries (e.g. a faceted sidebar’s skip-own-filter variants) as a
+facet-only queries (e.g. a faceted listing’s skip-own-filter variants) as a
 **single `multi_search` round-trip**, with one bundled label lookup shared by
 every facet result in the batch. A failed entry is reported in place as a
 per-query outcome, so its siblings’ facets survive.

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -64,7 +64,8 @@ export interface TypesenseSearchEngineOptions<
 /**
  * One reference field’s resolved label source: the collection it reads, the
  * source type’s `label` declaration (for reconstructing localized labels) and
- * the physical field a label search queries.
+ * the comma-joined physical search fields (one per locale) a label search
+ * queries.
  */
 export interface LabelSource {
   readonly collection: string;
@@ -134,7 +135,7 @@ export function createTypesenseSearchEngine<
               {
                 collection: collections.get(source.type) as string,
                 labelField,
-                queryBy: physicalFields(labelField).search[0],
+                queryBy: physicalFields(labelField).search.join(','),
               },
             ];
           }),
@@ -383,7 +384,10 @@ async function loadAllLabels(
       continue;
     }
     const document = JSON.parse(line) as Record<string, unknown>;
-    labels.set(String(document.id), labelValue(document, source.labelField));
+    const label = labelValue(document, source.labelField);
+    if (label !== undefined) {
+      labels.set(String(document.id), label);
+    }
   }
   return labels;
 }
@@ -502,10 +506,13 @@ export async function fetchLabels(
       );
     }
     for (const hit of result.hits ?? []) {
-      labels.set(
-        String(hit.document.id),
-        labelValue(hit.document, groupPerSearch[index].source.labelField),
+      const label = labelValue(
+        hit.document,
+        groupPerSearch[index].source.labelField,
       );
+      if (label !== undefined) {
+        labels.set(String(hit.document.id), label);
+      }
     }
   });
   return labels;
@@ -518,18 +525,20 @@ const LABEL_BATCH_SIZE = 200;
 /**
  * Reconstruct a label document into a language map via the source type’s
  * `label` declaration (its per-locale display fields), with a bare untagged
- * `label` value as the `und` fallback when no locale variant exists.
+ * `label` value as the `und` fallback when no locale variant exists, or
+ * `undefined` when the document carries no usable label – so the reference
+ * stays id-only rather than gaining an empty label.
  */
 function labelValue(
   document: Record<string, unknown>,
   labelField: TextField,
-): LocalizedValue {
+): LocalizedValue | undefined {
   const localized = localizedValue(document, labelField);
   if (localized !== undefined) {
     return localized;
   }
   const untagged = document[labelField.name];
-  return typeof untagged === 'string' ? { und: [untagged] } : {};
+  return typeof untagged === 'string' ? { und: [untagged] } : undefined;
 }
 
 /** Merge per-collection label maps into one IRI-keyed map (URI identity). */

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -154,6 +154,26 @@ export function createTypesenseSearchEngine<
       ],
     ]),
   );
+  // The output reference fields that carry hit labels, each paired with its
+  // resolved label source – fixed at construction, so labelLookupGroups need
+  // not re-derive or re-resolve them on every search.
+  const outputReferenceSources = new Map<
+    string,
+    readonly { name: string; source: LabelSource }[]
+  >(
+    [...schema.values()].map((searchType) => {
+      const sources = labelSources.get(searchType.type);
+      return [
+        searchType.type,
+        referenceFields(searchType)
+          .filter((field) => field.output === true && sources?.has(field.name))
+          .map((field) => ({
+            name: field.name,
+            source: sources!.get(field.name)!,
+          })),
+      ];
+    }),
+  );
 
   // Process-lifetime cache per label-source collection, held in the engine
   // closure. Populated lazily on the first cached search; `inFlightLoads` is
@@ -291,8 +311,8 @@ export function createTypesenseSearchEngine<
       const labels = await resolveLabels(cachedLabelsPromise, () =>
         labelLookupGroups(
           [response],
-          searchType,
           labelSources.get(searchType.type),
+          outputReferenceSources.get(searchType.type) ?? [],
         ),
       );
       return parseSearchResponse(response, searchType, labels);
@@ -333,8 +353,8 @@ export function createTypesenseSearchEngine<
       const labels = await resolveLabels(cachedLabelsPromise, () =>
         labelLookupGroups(
           responses,
-          searchType,
           labelSources.get(searchType.type),
+          outputReferenceSources.get(searchType.type) ?? [],
         ),
       );
       // multi_search reports a failed entry inline instead of rejecting the
@@ -399,27 +419,17 @@ async function loadAllLabels(
  */
 function labelLookupGroups(
   responses: readonly TypesenseSearchResponse[],
-  searchType: SearchType,
   sources: ReadonlyMap<string, LabelSource> | undefined,
+  outputSources: readonly { name: string; source: LabelSource }[],
 ): LabelLookupGroup[] {
   if (sources === undefined || sources.size === 0) {
     return [];
   }
-  // Hits only carry labels for OUTPUT reference fields: reconstructDocument skips
-  // non-output fields, so resolving a non-output reference's hit labels (e.g. a
-  // facet-only `class` with dozens of IRIs per hit) is pure waste.
-  const outputReferenceFields = referenceFields(searchType)
-    .filter((field) => field.output === true && sources.has(field.name))
-    .map((field) => field.name);
   const irisByCollection = new Map<
     string,
     { source: LabelSource; iris: Set<string> }
   >();
-  const add = (fieldName: string, iri: string): void => {
-    const source = sources.get(fieldName);
-    if (source === undefined) {
-      return;
-    }
+  const add = (source: LabelSource, iri: string): void => {
     let group = irisByCollection.get(source.collection);
     if (group === undefined) {
       group = { source, iris: new Set() };
@@ -428,23 +438,31 @@ function labelLookupGroups(
     group.iris.add(iri);
   };
   for (const response of responses) {
+    // Hits only carry labels for OUTPUT reference fields (reconstructDocument
+    // skips non-output fields); `outputSources` pairs each with its resolved
+    // source, precomputed per type.
     for (const hit of response.hits ?? []) {
-      for (const name of outputReferenceFields) {
+      for (const { name, source } of outputSources) {
         const raw = hit.document[name];
         if (Array.isArray(raw)) {
           for (const value of raw) {
-            add(name, String(value));
+            add(source, String(value));
           }
         } else if (typeof raw === 'string') {
-          add(name, raw);
+          add(source, raw);
         }
       }
     }
     // Reference-facet bucket values are IRIs too (incl. facet-only references
-    // like `class`); resolve them in the same lookup.
+    // like `class`); resolve them in the same lookup. Skip a non-source facet
+    // (e.g. a keyword facet) in one check instead of probing every bucket.
     for (const facet of response.facet_counts ?? []) {
+      const source = sources.get(facet.field_name);
+      if (source === undefined) {
+        continue;
+      }
       for (const bucket of facet.counts) {
-        add(facet.field_name, bucket.value);
+        add(source, bucket.value);
       }
     }
   }

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -264,7 +264,7 @@ export function createTypesenseSearchEngine<
       return cachedLabelsPromise;
     }
     try {
-      return await fetchLabels(client, groups());
+      return await fetchLabels(client, groups(), options.onLabelError);
     } catch (error) {
       options.onLabelError?.(error);
       return new Map();
@@ -471,6 +471,7 @@ function labelLookupGroups(
 export async function fetchLabels(
   client: Pick<Client, 'multiSearch'>,
   groups: readonly LabelLookupGroup[],
+  onError?: (error: Error) => void,
 ): Promise<Map<string, LocalizedValue>> {
   const labels = new Map<string, LocalizedValue>();
   const searches = [];
@@ -495,15 +496,18 @@ export async function fetchLabels(
     results: readonly (TypesenseSearchResponse | TypesenseErrorEntry)[];
   };
   results.forEach((result, index) => {
-    // multi_search reports a failed entry inline instead of rejecting; throw
-    // so the caller's degradation path (onLabelError, id-only references)
-    // engages rather than mistaking the failure for absent labels.
+    // multi_search reports a failed entry inline instead of rejecting. Isolate
+    // it: report the failed source and skip its entry so the other sources'
+    // labels still land, instead of blanking the whole page to id-only – its
+    // own references fall back to id-only as their IRIs stay absent.
     if ('error' in result) {
-      throw new Error(
+      const failure = new Error(
         `Typesense label lookup in “${groupPerSearch[index].source.collection}” failed${
           result.code !== undefined ? ` (${result.code})` : ''
         }: ${result.error}`,
       );
+      onError?.(failure);
+      return;
     }
     for (const hit of result.hits ?? []) {
       const label = labelValue(
@@ -595,8 +599,13 @@ export function parseSearchResponse(
   }));
   // Reference facets are IRI-keyed; their buckets carry a resolved data label.
   // Plain facets (tokens, free strings) carry no label — the consumer owns display.
+  // Only reference facets with a label source get bucket labels; an id-only
+  // reference facet stays id-only even when a cached full-collection map holds
+  // its IRIs.
   const referenceFacets = new Set(
-    referenceFields(searchType).map((field) => field.name),
+    referenceFields(searchType)
+      .filter((field) => field.labelSource !== undefined)
+      .map((field) => field.name),
   );
   const facets: Record<string, FacetBucket[]> = {};
   for (const facet of response.facet_counts ?? []) {
@@ -695,7 +704,10 @@ function referenceValue(
   }
   const iris = Array.isArray(raw) ? (raw as string[]) : [String(raw)];
   const references: Reference[] = iris.map((iri) => {
-    const label = labels.get(iri);
+    // A reference without a label source is id-only by declaration; never
+    // attach a label, even if the (cached, full-collection) map happens to
+    // hold this IRI from another source.
+    const label = field.labelSource === undefined ? undefined : labels.get(iri);
     return label === undefined ? { id: iri } : { id: iri, label };
   });
   return field.array === true ? references : references[0];

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -21,6 +21,7 @@ import {
   assertValidQuery,
   fieldNamed,
   isRangeFacet,
+  labelFieldOf,
   outputFields,
   physicalFields,
   referenceFields,
@@ -114,8 +115,8 @@ export function createTypesenseSearchEngine<
     }),
   );
   // Resolve every reference field's label source ONCE at construction. The
-  // schema already guarantees the named type exists and declares a suitable
-  // `label` field (`searchSchema`), and `collections` is exhaustive per type.
+  // schema already guarantees the named type exists and serves labels
+  // (`searchSchema`/`labelFieldOf`), and `collections` is exhaustive per type.
   const typesByName = new Map(
     [...schema.values()].map((searchType) => [searchType.name, searchType]),
   );
@@ -127,7 +128,7 @@ export function createTypesenseSearchEngine<
           .filter((field) => field.labelSource !== undefined)
           .map((field) => {
             const source = typesByName.get(field.labelSource!) as SearchType;
-            const labelField = fieldNamed(source, 'label') as TextField;
+            const labelField = labelFieldOf(source) as TextField;
             return [
               field.name,
               {
@@ -138,6 +139,18 @@ export function createTypesenseSearchEngine<
             ];
           }),
       ),
+    ]),
+  );
+  // The distinct source collections per type, for the cached path – fixed at
+  // construction, so no per-search dedup dance.
+  const distinctLabelSources = new Map<string, readonly LabelSource[]>(
+    [...labelSources].map(([type, sources]) => [
+      type,
+      [
+        ...new Map(
+          [...sources.values()].map((source) => [source.collection, source]),
+        ).values(),
+      ],
     ]),
   );
 
@@ -185,6 +198,34 @@ export function createTypesenseSearchEngine<
     return load;
   }
 
+  // The merged per-type view over the cached per-collection maps, reused
+  // until any constituent map reloads (same instances = still valid), so a
+  // multi-source type does not pay an O(all labels) merge per search.
+  const mergedCache = new Map<
+    string,
+    {
+      parts: readonly ReadonlyMap<string, LocalizedValue>[];
+      merged: ReadonlyMap<string, LocalizedValue>;
+    }
+  >();
+
+  function mergeCachedLabels(
+    typeIri: string,
+    parts: readonly ReadonlyMap<string, LocalizedValue>[],
+  ): ReadonlyMap<string, LocalizedValue> {
+    const cached = mergedCache.get(typeIri);
+    if (
+      cached !== undefined &&
+      cached.parts.length === parts.length &&
+      cached.parts.every((part, index) => part === parts[index])
+    ) {
+      return cached.merged;
+    }
+    const merged = mergeLabels(parts);
+    mergedCache.set(typeIri, { parts, merged });
+    return merged;
+  }
+
   // Cached path: the once-loaded full collections serve labels by in-memory
   // lookup (no per-search round-trip). The load does not depend on the
   // response, so it is started BEFORE awaiting the search and runs alongside
@@ -194,23 +235,18 @@ export function createTypesenseSearchEngine<
   function startCachedLabels(
     searchType: SearchType,
   ): Promise<ReadonlyMap<string, LocalizedValue>> | undefined {
-    const sources = labelSources.get(searchType.type);
+    const sources = distinctLabelSources.get(searchType.type);
     if (
       options.labelCacheTtlMs === undefined ||
       sources === undefined ||
-      sources.size === 0
+      sources.length === 0
     ) {
       return undefined;
     }
     const ttlMs = options.labelCacheTtlMs;
-    const distinct = [
-      ...new Map(
-        [...sources.values()].map((source) => [source.collection, source]),
-      ).values(),
-    ];
     return Promise.all(
-      distinct.map((source) => cachedAllLabels(source, ttlMs)),
-    ).then((maps) => mergeLabels(maps));
+      sources.map((source) => cachedAllLabels(source, ttlMs)),
+    ).then((maps) => mergeCachedLabels(searchType.type, maps));
   }
 
   // Labels are supplementary: a failed lookup (e.g. a label-source collection
@@ -488,18 +524,12 @@ function labelValue(
   document: Record<string, unknown>,
   labelField: TextField,
 ): LocalizedValue {
-  const map: Record<string, readonly string[]> = {};
-  const display = physicalFields(labelField).display;
-  labelField.locales.forEach((locale, index) => {
-    const value = document[display[index]];
-    if (typeof value === 'string') {
-      map[locale] = [value];
-    }
-  });
-  if (Object.keys(map).length === 0 && typeof document.label === 'string') {
-    map.und = [document.label];
+  const localized = localizedValue(document, labelField);
+  if (localized !== undefined) {
+    return localized;
   }
-  return map;
+  const untagged = document[labelField.name];
+  return typeof untagged === 'string' ? { und: [untagged] } : {};
 }
 
 /** Merge per-collection label maps into one IRI-keyed map (URI identity). */

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -31,45 +31,56 @@ import {
   type BuildSearchParamsOptions,
 } from './query-compiler.js';
 
-/** Where the engine reads documents and (optionally) reference labels — plus
- *  every query-compiler knob ({@link BuildSearchParamsOptions}), declared once
- *  there and forwarded wholesale into each search. `TypeName` is the union of
- *  the schema’s type names, so a literal schema makes the `collections` map
- *  exhaustive at compile time. */
+/** Where the engine reads documents — plus every query-compiler knob
+ *  ({@link BuildSearchParamsOptions}), declared once there and forwarded
+ *  wholesale into each search. `TypeName` is the union of the schema’s type
+ *  names, so a literal schema makes the `collections` map exhaustive at
+ *  compile time. Reference labels resolve per field from the collection of
+ *  the SearchType its `labelSource` names — a label source is just another
+ *  entry in `collections`. */
 export interface TypesenseSearchEngineOptions<
   TypeName extends string = string,
 > extends BuildSearchParamsOptions {
   /** The collection (or alias) per search type, keyed by the type’s `name` —
    *  with a literal schema, omitting a type is a compile error. */
   readonly collections: Readonly<Record<TypeName, string>>;
-  /** The sidecar `labels` collection (IRI → label); omit for id-only references. */
-  readonly labelsCollection?: string;
   /**
    * Called when reference-label resolution fails; the search then degrades to
    * id-only references rather than failing. Optional — omit to swallow silently.
    */
   readonly onLabelError?: (error: unknown) => void;
   /**
-   * Opt-in in-memory label cache. When set (and {@link labelsCollection} is
-   * set), the FULL sidecar `labels` collection is loaded once via the documents
-   * export endpoint and held in a process-lifetime cache for this many
-   * milliseconds; each `search` then resolves its reference labels by in-memory
-   * lookup instead of a per-search `multi_search` round-trip. Omit to keep the
-   * per-search {@link fetchLabels} behaviour unchanged.
+   * Opt-in in-memory label cache. When set, each label-source collection is
+   * loaded in FULL once via the documents export endpoint and held in a
+   * process-lifetime cache for this many milliseconds; each `search` then
+   * resolves its reference labels by in-memory lookup instead of a per-search
+   * `multi_search` round-trip. Omit to keep the per-search
+   * {@link fetchLabels} behaviour unchanged.
    */
   readonly labelCacheTtlMs?: number;
 }
 
 /**
+ * One reference field’s resolved label source: the collection it reads, the
+ * source type’s `label` declaration (for reconstructing localized labels) and
+ * the physical field a label search queries.
+ */
+export interface LabelSource {
+  readonly collection: string;
+  readonly labelField: TextField;
+  readonly queryBy: string;
+}
+
+/**
  * A Typesense-backed {@link SearchEngine}, bound to the whole
  * {@link SearchSchema} at construction — like every other schema consumer.
- * Each type’s collection comes from `options.collections`; the label sidecar
- * and its cache are shared across all types. `search` compiles the query
- * ({@link buildSearchParams}), runs it against the type’s collection,
- * resolves the reference labels for the page of hits from the sidecar
- * `labels` collection in one lookup, and reconstructs the engine-neutral
+ * Each type’s collection comes from `options.collections`. `search` compiles
+ * the query ({@link buildSearchParams}), runs it against the type’s
+ * collection, resolves the reference labels for the page of hits — each
+ * reference field from its own label source’s collection, all sources bundled
+ * into one lookup — and reconstructs the engine-neutral
  * {@link SearchResult} ({@link parseSearchResponse}). `searchFacets` answers
- * a whole facet batch (e.g. a sidebar’s skip-own-filter query variants) as a
+ * a whole facet batch (e.g. a faceted listing’s skip-own-filter query variants) as a
  * single `multi_search` round-trip with one shared label lookup; a failed
  * entry is reported in place as a per-query outcome, so it never discards
  * its siblings’ facets. Every engine specific stays here; consumers see only
@@ -102,25 +113,63 @@ export function createTypesenseSearchEngine<
       return [searchType.type, collection];
     }),
   );
-  // Process-lifetime cache for the FULL `labels` collection, held in the engine
-  // closure. Populated lazily on the first cached search; `loadAll` is the
-  // single-flight in-flight promise so concurrent first-loads share one export.
-  let cachedLabels: ReadonlyMap<string, LocalizedValue> | undefined;
-  let cacheExpiresAt = 0;
-  let inFlightLoad: Promise<ReadonlyMap<string, LocalizedValue>> | undefined;
+  // Resolve every reference field's label source ONCE at construction. The
+  // schema already guarantees the named type exists and declares a suitable
+  // `label` field (`searchSchema`), and `collections` is exhaustive per type.
+  const typesByName = new Map(
+    [...schema.values()].map((searchType) => [searchType.name, searchType]),
+  );
+  const labelSources = new Map<string, ReadonlyMap<string, LabelSource>>(
+    [...schema.values()].map((searchType) => [
+      searchType.type,
+      new Map(
+        referenceFields(searchType)
+          .filter((field) => field.labelSource !== undefined)
+          .map((field) => {
+            const source = typesByName.get(field.labelSource!) as SearchType;
+            const labelField = fieldNamed(source, 'label') as TextField;
+            return [
+              field.name,
+              {
+                collection: collections.get(source.type) as string,
+                labelField,
+                queryBy: physicalFields(labelField).search[0],
+              },
+            ];
+          }),
+      ),
+    ]),
+  );
+
+  // Process-lifetime cache per label-source collection, held in the engine
+  // closure. Populated lazily on the first cached search; `inFlightLoads` is
+  // the single-flight promise per collection so concurrent first-loads share
+  // one export each.
+  const cachedLabels = new Map<
+    string,
+    { labels: ReadonlyMap<string, LocalizedValue>; expiresAt: number }
+  >();
+  const inFlightLoads = new Map<
+    string,
+    Promise<ReadonlyMap<string, LocalizedValue>>
+  >();
 
   function cachedAllLabels(
-    labelsCollection: string,
+    source: LabelSource,
     ttlMs: number,
   ): Promise<ReadonlyMap<string, LocalizedValue>> {
-    if (cachedLabels !== undefined && Date.now() < cacheExpiresAt) {
-      return Promise.resolve(cachedLabels);
+    const cached = cachedLabels.get(source.collection);
+    if (cached !== undefined && Date.now() < cached.expiresAt) {
+      return Promise.resolve(cached.labels);
     }
     // Single-flight: a load already running serves every concurrent caller.
-    inFlightLoad ??= loadAllLabels(client, labelsCollection)
+    let load = inFlightLoads.get(source.collection);
+    load ??= loadAllLabels(client, source)
       .then((loaded) => {
-        cachedLabels = loaded;
-        cacheExpiresAt = Date.now() + ttlMs;
+        cachedLabels.set(source.collection, {
+          labels: loaded,
+          expiresAt: Date.now() + ttlMs,
+        });
         return loaded;
       })
       // A failed load degrades to id-only references and is NOT cached, so the
@@ -130,44 +179,55 @@ export function createTypesenseSearchEngine<
         return new Map<string, LocalizedValue>();
       })
       .finally(() => {
-        inFlightLoad = undefined;
+        inFlightLoads.delete(source.collection);
       });
-    return inFlightLoad;
+    inFlightLoads.set(source.collection, load);
+    return load;
   }
 
-  // Cached path: the once-loaded full collection serves labels by in-memory
+  // Cached path: the once-loaded full collections serve labels by in-memory
   // lookup (no per-search round-trip). The load does not depend on the
   // response, so it is started BEFORE awaiting the search and runs alongside
   // it; it never rejects (a failed load degrades to an empty map), so it
   // cannot leave an unhandled rejection behind if the search itself fails.
-  // `undefined` when the cache (or the sidecar) is not configured.
-  function startCachedLabels():
-    | Promise<ReadonlyMap<string, LocalizedValue>>
-    | undefined {
-    return options.labelsCollection !== undefined &&
-      options.labelCacheTtlMs !== undefined
-      ? cachedAllLabels(options.labelsCollection, options.labelCacheTtlMs)
-      : undefined;
+  // `undefined` when the cache is off or the type has no label sources.
+  function startCachedLabels(
+    searchType: SearchType,
+  ): Promise<ReadonlyMap<string, LocalizedValue>> | undefined {
+    const sources = labelSources.get(searchType.type);
+    if (
+      options.labelCacheTtlMs === undefined ||
+      sources === undefined ||
+      sources.size === 0
+    ) {
+      return undefined;
+    }
+    const ttlMs = options.labelCacheTtlMs;
+    const distinct = [
+      ...new Map(
+        [...sources.values()].map((source) => [source.collection, source]),
+      ).values(),
+    ];
+    return Promise.all(
+      distinct.map((source) => cachedAllLabels(source, ttlMs)),
+    ).then((maps) => mergeLabels(maps));
   }
 
-  // Labels are supplementary: a failed lookup (e.g. the sidecar collection
+  // Labels are supplementary: a failed lookup (e.g. a label-source collection
   // mid-rebuild) degrades to id-only references rather than failing the whole
-  // search, so the listing still renders with bare IRIs. `iris` is a thunk so
-  // the cached and no-sidecar paths never pay for collecting them.
+  // search, so the listing still renders with bare IRIs. `groups` is a thunk
+  // so the cached and source-less paths never pay for collecting the IRIs.
   async function resolveLabels(
     cachedLabelsPromise:
       | Promise<ReadonlyMap<string, LocalizedValue>>
       | undefined,
-    iris: () => readonly string[],
+    groups: () => readonly LabelLookupGroup[],
   ): Promise<ReadonlyMap<string, LocalizedValue>> {
     if (cachedLabelsPromise !== undefined) {
       return cachedLabelsPromise;
     }
-    if (options.labelsCollection === undefined) {
-      return new Map();
-    }
     try {
-      return await fetchLabels(client, options.labelsCollection, iris());
+      return await fetchLabels(client, groups());
     } catch (error) {
       options.onLabelError?.(error);
       return new Map();
@@ -186,13 +246,17 @@ export function createTypesenseSearchEngine<
       assertTypeInSchema(schema, searchType);
       assertValidQuery(query, searchType);
       const params = buildSearchParams(query, searchType, options);
-      const cachedLabelsPromise = startCachedLabels();
+      const cachedLabelsPromise = startCachedLabels(searchType);
       const response = (await client
         .collections(collections.get(searchType.type) as string)
         .documents()
         .search(params)) as TypesenseSearchResponse;
       const labels = await resolveLabels(cachedLabelsPromise, () =>
-        referenceIris(response, searchType),
+        labelLookupGroups(
+          [response],
+          searchType,
+          labelSources.get(searchType.type),
+        ),
       );
       return parseSearchResponse(response, searchType, labels);
     },
@@ -208,7 +272,7 @@ export function createTypesenseSearchEngine<
         return [];
       }
       const collection = collections.get(searchType.type) as string;
-      const cachedLabelsPromise = startCachedLabels();
+      const cachedLabelsPromise = startCachedLabels(searchType);
       // The whole batch travels as ONE multi_search round-trip. Each query
       // compiles as facet-only regardless of what it carries: no hits
       // (per_page 0) and no ordering – nothing is transferred or sorted that
@@ -229,11 +293,13 @@ export function createTypesenseSearchEngine<
       const responses = results.filter(
         (result): result is TypesenseSearchResponse => !('error' in result),
       );
-      const labels = await resolveLabels(cachedLabelsPromise, () => [
-        ...new Set(
-          responses.flatMap((response) => referenceIris(response, searchType)),
+      const labels = await resolveLabels(cachedLabelsPromise, () =>
+        labelLookupGroups(
+          responses,
+          searchType,
+          labelSources.get(searchType.type),
         ),
-      ]);
+      );
       // multi_search reports a failed entry inline instead of rejecting the
       // call; pass that through as a per-query outcome – naming the facets,
       // not the position, since the batch order is the caller's internal –
@@ -255,118 +321,157 @@ export function createTypesenseSearchEngine<
   return engine as SearchEngine<Types>;
 }
 
+/** One label lookup: a source and the distinct IRIs to resolve against it. */
+export interface LabelLookupGroup {
+  readonly source: LabelSource;
+  readonly iris: readonly string[];
+}
+
 /**
- * Load the FULL `labels` collection into a label map via the documents export
- * endpoint, which streams every document as JSONL (one JSON object per line).
- * Each line is reconstructed by {@link labelToLocalizedValue}, exactly as the
+ * Load a FULL label-source collection into a label map via the documents
+ * export endpoint, which streams every document as JSONL (one JSON object per
+ * line). Each line is reconstructed by {@link labelValue}, exactly as the
  * per-search {@link fetchLabels} path does for its `multi_search` hits.
  */
 async function loadAllLabels(
   client: Pick<Client, 'collections'>,
-  collection: string,
+  source: LabelSource,
 ): Promise<ReadonlyMap<string, LocalizedValue>> {
-  const jsonl = await client.collections(collection).documents().export();
+  const jsonl = await client
+    .collections(source.collection)
+    .documents()
+    .export();
   const labels = new Map<string, LocalizedValue>();
   for (const line of jsonl.split('\n')) {
     if (line.length === 0) {
       continue;
     }
     const document = JSON.parse(line) as Record<string, unknown>;
-    labels.set(String(document.id), labelToLocalizedValue(document));
+    labels.set(String(document.id), labelValue(document, source.labelField));
   }
   return labels;
 }
 
-/** Every distinct reference IRI whose label the result will actually use. */
-function referenceIris(
-  response: TypesenseSearchResponse,
+/**
+ * Group every reference IRI the result will actually use by its field’s label
+ * source, one group per source collection. Fields without a `labelSource`
+ * stay id-only, so their IRIs never travel.
+ */
+function labelLookupGroups(
+  responses: readonly TypesenseSearchResponse[],
   searchType: SearchType,
-): string[] {
-  const referenceFieldSet = new Set(
-    referenceFields(searchType).map((field) => field.name),
-  );
+  sources: ReadonlyMap<string, LabelSource> | undefined,
+): LabelLookupGroup[] {
+  if (sources === undefined || sources.size === 0) {
+    return [];
+  }
   // Hits only carry labels for OUTPUT reference fields: reconstructDocument skips
   // non-output fields, so resolving a non-output reference's hit labels (e.g. a
   // facet-only `class` with dozens of IRIs per hit) is pure waste.
   const outputReferenceFields = referenceFields(searchType)
-    .filter((field) => field.output === true)
+    .filter((field) => field.output === true && sources.has(field.name))
     .map((field) => field.name);
-  const iris = new Set<string>();
-  for (const hit of response.hits ?? []) {
-    for (const name of outputReferenceFields) {
-      const raw = hit.document[name];
-      if (Array.isArray(raw)) {
-        for (const value of raw) {
-          iris.add(String(value));
+  const irisByCollection = new Map<
+    string,
+    { source: LabelSource; iris: Set<string> }
+  >();
+  const add = (fieldName: string, iri: string): void => {
+    const source = sources.get(fieldName);
+    if (source === undefined) {
+      return;
+    }
+    let group = irisByCollection.get(source.collection);
+    if (group === undefined) {
+      group = { source, iris: new Set() };
+      irisByCollection.set(source.collection, group);
+    }
+    group.iris.add(iri);
+  };
+  for (const response of responses) {
+    for (const hit of response.hits ?? []) {
+      for (const name of outputReferenceFields) {
+        const raw = hit.document[name];
+        if (Array.isArray(raw)) {
+          for (const value of raw) {
+            add(name, String(value));
+          }
+        } else if (typeof raw === 'string') {
+          add(name, raw);
         }
-      } else if (typeof raw === 'string') {
-        iris.add(raw);
       }
     }
-  }
-  // Reference-facet bucket values are IRIs too (incl. facet-only references like
-  // `class`); resolve them in the same lookup.
-  for (const facet of response.facet_counts ?? []) {
-    if (referenceFieldSet.has(facet.field_name)) {
+    // Reference-facet bucket values are IRIs too (incl. facet-only references
+    // like `class`); resolve them in the same lookup.
+    for (const facet of response.facet_counts ?? []) {
       for (const bucket of facet.counts) {
-        iris.add(bucket.value);
+        add(facet.field_name, bucket.value);
       }
     }
   }
-  return [...iris];
+  return [...irisByCollection.values()].map(({ source, iris }) => ({
+    source,
+    iris: [...iris],
+  }));
 }
 
 /**
- * Resolve labels for `iris` from the sidecar `labels` collection. Each
- * `label_${locale}` becomes a language-map entry; the default `label` is the
- * untagged (`und`) fallback when no locale variant exists.
+ * Resolve labels from each group’s label-source collection. Localized labels
+ * are reconstructed from the source type’s `label` declaration; a bare
+ * untagged `label` value is the `und` fallback when no locale variant exists.
  *
- * Sent as one `multi_search` (POST) call, the id-list split over per-search
- * batches: the id-list of a page or facet carrying many references — e.g. a
- * dataset with dozens of classes — would overflow Typesense’s GET query-string
- * limit (4000 chars, and IRIs URL-encode to several times their length) if it
- * travelled in the URL. POST puts it in the body; each batch stays under
- * Typesense’s `per_page` cap, and bundling the batches keeps it one round-trip
- * regardless of IRI count. Exported for unit testing against a fake client.
+ * All groups travel as ONE `multi_search` (POST) call, each group’s id-list
+ * split over per-search batches: the id-list of a page or facet carrying many
+ * references — e.g. a dataset with dozens of classes — would overflow
+ * Typesense’s GET query-string limit (4000 chars, and IRIs URL-encode to
+ * several times their length) if it travelled in the URL. POST puts it in the
+ * body; each batch stays under Typesense’s `per_page` cap, and bundling the
+ * batches keeps it one round-trip regardless of IRI or source count. Exported
+ * for unit testing against a fake client.
  */
 export async function fetchLabels(
   client: Pick<Client, 'multiSearch'>,
-  collection: string,
-  iris: readonly string[],
+  groups: readonly LabelLookupGroup[],
 ): Promise<Map<string, LocalizedValue>> {
   const labels = new Map<string, LocalizedValue>();
-  if (iris.length === 0) {
-    return labels;
-  }
   const searches = [];
-  for (let start = 0; start < iris.length; start += LABEL_BATCH_SIZE) {
-    const batch = iris.slice(start, start + LABEL_BATCH_SIZE);
-    searches.push({
-      collection,
-      q: '*',
-      query_by: 'label',
-      filter_by: `id:[${batch.map(escapeFilterValue).join(',')}]`,
-      per_page: batch.length,
-    });
+  const groupPerSearch: LabelLookupGroup[] = [];
+  for (const group of groups) {
+    for (let start = 0; start < group.iris.length; start += LABEL_BATCH_SIZE) {
+      const batch = group.iris.slice(start, start + LABEL_BATCH_SIZE);
+      searches.push({
+        collection: group.source.collection,
+        q: '*',
+        query_by: group.source.queryBy,
+        filter_by: `id:[${batch.map(escapeFilterValue).join(',')}]`,
+        per_page: batch.length,
+      });
+      groupPerSearch.push(group);
+    }
+  }
+  if (searches.length === 0) {
+    return labels;
   }
   const { results } = (await client.multiSearch.perform({ searches })) as {
     results: readonly (TypesenseSearchResponse | TypesenseErrorEntry)[];
   };
-  for (const result of results) {
+  results.forEach((result, index) => {
     // multi_search reports a failed entry inline instead of rejecting; throw
     // so the caller's degradation path (onLabelError, id-only references)
     // engages rather than mistaking the failure for absent labels.
     if ('error' in result) {
       throw new Error(
-        `Typesense label lookup failed${
+        `Typesense label lookup in “${groupPerSearch[index].source.collection}” failed${
           result.code !== undefined ? ` (${result.code})` : ''
         }: ${result.error}`,
       );
     }
     for (const hit of result.hits ?? []) {
-      labels.set(String(hit.document.id), labelToLocalizedValue(hit.document));
+      labels.set(
+        String(hit.document.id),
+        labelValue(hit.document, groupPerSearch[index].source.labelField),
+      );
     }
-  }
+  });
   return labels;
 }
 
@@ -374,20 +479,43 @@ export async function fetchLabels(
  *  id-list comfortably, so resolve references in batches of this size. */
 const LABEL_BATCH_SIZE = 200;
 
-/** Turn a `labels` document into a language map (`label_${locale}` → locale). */
-function labelToLocalizedValue(
+/**
+ * Reconstruct a label document into a language map via the source type’s
+ * `label` declaration (its per-locale display fields), with a bare untagged
+ * `label` value as the `und` fallback when no locale variant exists.
+ */
+function labelValue(
   document: Record<string, unknown>,
+  labelField: TextField,
 ): LocalizedValue {
   const map: Record<string, readonly string[]> = {};
-  for (const [key, value] of Object.entries(document)) {
-    if (key.startsWith('label_') && typeof value === 'string') {
-      map[key.slice('label_'.length)] = [value];
+  const display = physicalFields(labelField).display;
+  labelField.locales.forEach((locale, index) => {
+    const value = document[display[index]];
+    if (typeof value === 'string') {
+      map[locale] = [value];
     }
-  }
+  });
   if (Object.keys(map).length === 0 && typeof document.label === 'string') {
     map.und = [document.label];
   }
   return map;
+}
+
+/** Merge per-collection label maps into one IRI-keyed map (URI identity). */
+function mergeLabels(
+  maps: readonly ReadonlyMap<string, LocalizedValue>[],
+): ReadonlyMap<string, LocalizedValue> {
+  if (maps.length === 1) {
+    return maps[0];
+  }
+  const merged = new Map<string, LocalizedValue>();
+  for (const map of maps) {
+    for (const [iri, label] of map) {
+      merged.set(iri, label);
+    }
+  }
+  return merged;
 }
 
 /** A failed entry in a `multi_search` response: Typesense reports a
@@ -414,7 +542,7 @@ export interface TypesenseSearchResponse {
  * Reconstruct a Typesense response into the engine-neutral {@link SearchResult}:
  * the flat, fanned-out document is turned back into a logical one (per-locale
  * display fields → a language map, reference IRIs → labelled references via the
- * sidecar `labels` lookup, scalars passed through). `labels` maps a reference IRI
+ * label-source lookup, scalars passed through). `labels` maps a reference IRI
  * to its resolved label; an IRI absent from it yields an id-only reference.
  */
 export function parseSearchResponse(

--- a/packages/search-typesense/test/fake-typesense-client.ts
+++ b/packages/search-typesense/test/fake-typesense-client.ts
@@ -22,8 +22,8 @@ export function labelLookup(
 export interface FakeTypesenseClientOptions {
   /** Answer for `collections().documents().search()`. */
   readonly searchResponse?: Record<string, unknown>;
-  /** The labels-collection export endpoint (JSONL); calls are counted. */
-  readonly exportJsonl?: () => Promise<string>;
+  /** The documents export endpoint (JSONL) per collection; calls are counted. */
+  readonly exportJsonl?: (collection: string) => Promise<string>;
   /** Answers one `multi_search` entry (an inline `{ error }` entry included);
    *  a throw rejects the whole perform. */
   readonly multiSearch?: (
@@ -54,7 +54,7 @@ export function fakeTypesenseClient(
   const performs: (readonly Record<string, unknown>[])[] = [];
   let exportCalls = 0;
   const client = {
-    collections: () => ({
+    collections: (name?: string) => ({
       documents: () => ({
         search: () =>
           Promise.resolve(options.searchResponse ?? { found: 0, hits: [] }),
@@ -62,7 +62,7 @@ export function fakeTypesenseClient(
           exportCalls += 1;
           return options.exportJsonl === undefined
             ? Promise.reject(new Error('No exportJsonl configured.'))
-            : options.exportJsonl();
+            : options.exportJsonl(String(name));
         },
       }),
     }),

--- a/packages/search-typesense/test/label-sources.test.ts
+++ b/packages/search-typesense/test/label-sources.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from 'vitest';
+import { searchSchema, type SearchQuery, type SearchType } from '@lde/search';
+import { createTypesenseSearchEngine } from '../src/search.js';
+import {
+  fakeTypesenseClient,
+  filterByIds,
+  labelLookup,
+} from './fake-typesense-client.js';
+
+// Per-reference label sources: each reference field resolves its labels from
+// the collection of the SearchType its `labelSource` names.
+
+const organization: SearchType = {
+  name: 'Organization',
+  type: 'https://example.org/Organization',
+  fields: [
+    {
+      name: 'label',
+      kind: 'text',
+      locales: ['und', 'nl'],
+      output: true,
+      searchable: { weight: 1 },
+    },
+  ],
+};
+
+const term: SearchType = {
+  name: 'Term',
+  type: 'https://example.org/Term',
+  fields: [
+    {
+      name: 'label',
+      kind: 'text',
+      locales: ['und'],
+      output: true,
+      searchable: { weight: 1 },
+    },
+  ],
+};
+
+const dataset: SearchType = {
+  name: 'Dataset',
+  type: 'http://www.w3.org/ns/dcat#Dataset',
+  fields: [
+    {
+      name: 'publisher',
+      kind: 'reference',
+      array: true,
+      facetable: true,
+      output: true,
+      ref: { typeName: 'Agent', strategy: 'labelOnly' },
+      labelSource: 'Organization',
+    },
+    {
+      name: 'subject',
+      kind: 'reference',
+      array: true,
+      facetable: true,
+      output: true,
+      ref: { typeName: 'Concept', strategy: 'labelOnly' },
+      labelSource: 'Term',
+    },
+    // No labelSource: stays id-only, and no lookup is ever issued for it.
+    {
+      name: 'license',
+      kind: 'reference',
+      array: true,
+      output: true,
+      ref: { typeName: 'License', strategy: 'labelOnly' },
+    },
+  ],
+};
+
+const schema = searchSchema(organization, term, dataset);
+
+const collections = {
+  Organization: 'organizations',
+  Term: 'terms',
+  Dataset: 'datasets',
+};
+
+const baseQuery: SearchQuery = {
+  where: [],
+  orderBy: [],
+  limit: 10,
+  offset: 0,
+  facets: [],
+  locale: 'nl',
+};
+
+/** Answers label lookups per collection; other multi_search entries error. */
+function labelSourcesLookup(
+  perCollection: Record<string, Record<string, Record<string, unknown>>>,
+): (search: Record<string, unknown>) => Record<string, unknown> {
+  return (search) => {
+    const docs = perCollection[String(search.collection)];
+    if (docs === undefined) {
+      return { error: `Unknown collection ${String(search.collection)}` };
+    }
+    return labelLookup(docs)(search);
+  };
+}
+
+describe('per-reference label sources', () => {
+  it('resolves each reference field from its own label source collection', async () => {
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [
+          {
+            document: {
+              id: 'https://d/1',
+              publisher: ['https://org/1'],
+              subject: ['https://term/1'],
+              license: ['https://license/1'],
+            },
+          },
+        ],
+      },
+      multiSearch: labelSourcesLookup({
+        organizations: {
+          // As projected: one display field per declared locale.
+          'https://org/1': {
+            label_und: 'Het Archief',
+            label_nl: 'Het Archief',
+          },
+        },
+        terms: {
+          // A bare untagged `label` is the `und` fallback.
+          'https://term/1': { label: 'Cartography' },
+        },
+      }),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema, {
+      collections,
+    });
+
+    const result = await engine.search(dataset, baseQuery);
+
+    expect(result.hits[0].document.publisher).toEqual([
+      {
+        id: 'https://org/1',
+        label: { und: ['Het Archief'], nl: ['Het Archief'] },
+      },
+    ]);
+    expect(result.hits[0].document.subject).toEqual([
+      { id: 'https://term/1', label: { und: ['Cartography'] } },
+    ]);
+    // No label source: id-only, and its IRI never travelled in a lookup.
+    expect(result.hits[0].document.license).toEqual([
+      { id: 'https://license/1' },
+    ]);
+    const requestedIds = fake.performs
+      .flat()
+      .flatMap((search) => filterByIds(String(search.filter_by)));
+    expect(requestedIds).not.toContain('https://license/1');
+    // Each source was asked in its own collection, in ONE round-trip.
+    expect(fake.performs).toHaveLength(1);
+    const byCollection = new Map(
+      fake.performs.flat().map((search) => [String(search.collection), search]),
+    );
+    expect(
+      filterByIds(String(byCollection.get('organizations')?.filter_by)),
+    ).toEqual(['https://org/1']);
+    expect(filterByIds(String(byCollection.get('terms')?.filter_by))).toEqual([
+      'https://term/1',
+    ]);
+  });
+
+  it('degrades a dangling reference to id-only', async () => {
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [
+          {
+            document: {
+              id: 'https://d/1',
+              publisher: ['https://org/vanished'],
+            },
+          },
+        ],
+      },
+      multiSearch: labelSourcesLookup({ organizations: {}, terms: {} }),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema, {
+      collections,
+    });
+
+    const result = await engine.search(dataset, baseQuery);
+
+    expect(result.hits[0].document.publisher).toEqual([
+      { id: 'https://org/vanished' },
+    ]);
+  });
+
+  it('labels facet buckets from the facet field’s own source', async () => {
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 0,
+        hits: [],
+        facet_counts: [
+          {
+            field_name: 'publisher',
+            counts: [{ value: 'https://org/1', count: 2 }],
+          },
+          {
+            field_name: 'subject',
+            counts: [{ value: 'https://term/1', count: 5 }],
+          },
+        ],
+      },
+      multiSearch: labelSourcesLookup({
+        organizations: {
+          'https://org/1': { label_nl: 'Het Archief' },
+        },
+        terms: {
+          'https://term/1': { label: 'Cartography' },
+        },
+      }),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema, {
+      collections,
+    });
+
+    const result = await engine.search(dataset, {
+      ...baseQuery,
+      facets: ['publisher', 'subject'],
+    });
+
+    expect(result.facets.publisher).toEqual([
+      { value: 'https://org/1', count: 2, label: { nl: ['Het Archief'] } },
+    ]);
+    expect(result.facets.subject).toEqual([
+      { value: 'https://term/1', count: 5, label: { und: ['Cartography'] } },
+    ]);
+  });
+
+  it('splits many ids into batches per source, still one round-trip', async () => {
+    const iris = Array.from(
+      { length: 401 },
+      (_, index) => `https://org/${index}`,
+    );
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [{ document: { id: 'https://d/1', publisher: iris } }],
+      },
+      multiSearch: labelSourcesLookup({ organizations: {}, terms: {} }),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema, {
+      collections,
+    });
+
+    await engine.search(dataset, baseQuery);
+
+    expect(fake.performs).toHaveLength(1);
+    const batches = fake.performs[0];
+    expect(batches).toHaveLength(3); // 401 ids in batches of 200
+    expect(
+      batches.every((search) => search.collection === 'organizations'),
+    ).toBe(true);
+  });
+
+  it('serves cached labels merged across both source collections', async () => {
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [
+          {
+            document: {
+              id: 'https://d/1',
+              publisher: ['https://org/1'],
+              subject: ['https://term/1'],
+            },
+          },
+        ],
+      },
+      // Trailing newline: the export stream ends on a line boundary.
+      exportJsonl: (collection) =>
+        Promise.resolve(
+          collection === 'organizations'
+            ? `${JSON.stringify({ id: 'https://org/1', label_nl: 'Het Archief' })}\n`
+            : `${JSON.stringify({ id: 'https://term/1', label_und: 'Cartography' })}\n`,
+        ),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema, {
+      collections,
+      labelCacheTtlMs: 60_000,
+    });
+
+    const result = await engine.search(dataset, baseQuery);
+
+    // Both collections were exported once; no per-search lookup travelled.
+    expect(fake.exportCalls()).toBe(2);
+    expect(fake.performs).toHaveLength(0);
+    expect(result.hits[0].document.publisher).toEqual([
+      { id: 'https://org/1', label: { nl: ['Het Archief'] } },
+    ]);
+    expect(result.hits[0].document.subject).toEqual([
+      { id: 'https://term/1', label: { und: ['Cartography'] } },
+    ]);
+  });
+
+  it('issues no lookup at all for a schema without label sources', async () => {
+    const bare = searchSchema({
+      name: 'Dataset',
+      type: 'http://www.w3.org/ns/dcat#Dataset',
+      fields: [
+        {
+          name: 'license',
+          kind: 'reference',
+          array: true,
+          output: true,
+          ref: { typeName: 'License', strategy: 'labelOnly' },
+        },
+      ],
+    });
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [{ document: { id: 'https://d/1', license: ['https://l/1'] } }],
+      },
+    });
+    const engine = createTypesenseSearchEngine(fake.client, bare, {
+      collections: { Dataset: 'datasets' },
+    });
+
+    const result = await engine.search(bare.get(dataset.type)!, baseQuery);
+
+    expect(result.hits[0].document.license).toEqual([{ id: 'https://l/1' }]);
+    expect(fake.performs).toHaveLength(0);
+  });
+});

--- a/packages/search-typesense/test/label-sources.test.ts
+++ b/packages/search-typesense/test/label-sources.test.ts
@@ -355,6 +355,81 @@ describe('per-reference label sources', () => {
     ]);
   });
 
+  it('isolates a failing label source and keeps the healthy ones', async () => {
+    const errors: unknown[] = [];
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [
+          {
+            document: {
+              id: 'https://d/1',
+              publisher: ['https://org/1'],
+              subject: ['https://term/1'],
+            },
+          },
+        ],
+      },
+      // The organizations lookup fails inline (e.g. mid-rebuild); terms answers.
+      multiSearch: (search) =>
+        String(search.collection) === 'organizations'
+          ? { error: 'Collection is being rebuilt', code: 503 }
+          : labelLookup({ 'https://term/1': { label: 'Cartography' } })(search),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema, {
+      collections,
+      onLabelError: (error) => errors.push(error),
+    });
+
+    const result = await engine.search(dataset, baseQuery);
+
+    // The failed source degrades only its own references to id-only …
+    expect(result.hits[0].document.publisher).toEqual([
+      { id: 'https://org/1' },
+    ]);
+    // … while the healthy source still lands its labels.
+    expect(result.hits[0].document.subject).toEqual([
+      { id: 'https://term/1', label: { und: ['Cartography'] } },
+    ]);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('keeps an id-only reference id-only even when a cached map holds its IRI', async () => {
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [
+          {
+            document: {
+              id: 'https://d/1',
+              // The same IRI is a labelled publisher and an id-only license.
+              publisher: ['https://org/1'],
+              license: ['https://org/1'],
+            },
+          },
+        ],
+      },
+      exportJsonl: (collection) =>
+        Promise.resolve(
+          collection === 'organizations'
+            ? `${JSON.stringify({ id: 'https://org/1', label_nl: 'Het Archief' })}\n`
+            : '',
+        ),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema, {
+      collections,
+      labelCacheTtlMs: 60_000,
+    });
+
+    const result = await engine.search(dataset, baseQuery);
+
+    expect(result.hits[0].document.publisher).toEqual([
+      { id: 'https://org/1', label: { nl: ['Het Archief'] } },
+    ]);
+    // license has no labelSource: id-only, despite org/1 being in the cache.
+    expect(result.hits[0].document.license).toEqual([{ id: 'https://org/1' }]);
+  });
+
   it('issues no lookup at all for a schema without label sources', async () => {
     const bare = searchSchema({
       name: 'Dataset',

--- a/packages/search-typesense/test/label-sources.test.ts
+++ b/packages/search-typesense/test/label-sources.test.ts
@@ -65,6 +65,7 @@ const dataset: SearchType = {
       name: 'license',
       kind: 'reference',
       array: true,
+      facetable: true,
       output: true,
       ref: { typeName: 'License', strategy: 'labelOnly' },
     },
@@ -261,6 +262,12 @@ describe('per-reference label sources', () => {
             field_name: 'subject',
             counts: [{ value: 'https://term/1', count: 5 }],
           },
+          // A reference facet with no labelSource stays id-only and triggers
+          // no lookup: labelLookupGroups skips it in one check.
+          {
+            field_name: 'license',
+            counts: [{ value: 'https://license/1', count: 3 }],
+          },
         ],
       },
       multiSearch: labelSourcesLookup({
@@ -278,7 +285,7 @@ describe('per-reference label sources', () => {
 
     const result = await engine.search(dataset, {
       ...baseQuery,
-      facets: ['publisher', 'subject'],
+      facets: ['publisher', 'subject', 'license'],
     });
 
     expect(result.facets.publisher).toEqual([
@@ -286,6 +293,10 @@ describe('per-reference label sources', () => {
     ]);
     expect(result.facets.subject).toEqual([
       { value: 'https://term/1', count: 5, label: { und: ['Cartography'] } },
+    ]);
+    // license has no labelSource: buckets stay id-only, no label attached.
+    expect(result.facets.license).toEqual([
+      { value: 'https://license/1', count: 3 },
     ]);
   });
 

--- a/packages/search-typesense/test/label-sources.test.ts
+++ b/packages/search-typesense/test/label-sources.test.ts
@@ -193,6 +193,60 @@ describe('per-reference label sources', () => {
     ]);
   });
 
+  it('keeps a reference id-only when its label document has no usable label', async () => {
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [
+          { document: { id: 'https://d/1', publisher: ['https://org/1'] } },
+        ],
+      },
+      // The label doc exists but carries no `label_*` display column and no
+      // bare `label`, so there is nothing to reconstruct – stay id-only rather
+      // than emit an empty `label: {}`.
+      multiSearch: labelSourcesLookup({
+        organizations: { 'https://org/1': {} },
+        terms: {},
+      }),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema, {
+      collections,
+    });
+
+    const result = await engine.search(dataset, baseQuery);
+
+    expect(result.hits[0].document.publisher).toEqual([
+      { id: 'https://org/1' },
+    ]);
+  });
+
+  it('queries every locale of a label source, not just the first', async () => {
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [
+          { document: { id: 'https://d/1', publisher: ['https://org/1'] } },
+        ],
+      },
+      multiSearch: labelSourcesLookup({
+        organizations: { 'https://org/1': { label_und: 'Het Archief' } },
+        terms: {},
+      }),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema, {
+      collections,
+    });
+
+    await engine.search(dataset, baseQuery);
+
+    const orgSearch = fake.performs
+      .flat()
+      .find((search) => String(search.collection) === 'organizations');
+    // Organization declares locales ['und', 'nl']; the lookup must query both
+    // folded search fields so typeahead can match a label in either locale.
+    expect(orgSearch?.query_by).toBe('label_search_und,label_search_nl');
+  });
+
   it('labels facet buckets from the facet field’s own source', async () => {
     const fake = fakeTypesenseClient({
       searchResponse: {

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -681,24 +681,51 @@ describe('fetchLabels', () => {
     expect(performs).toHaveLength(0);
   });
 
-  it('throws on an inline multi_search error entry instead of returning no labels', async () => {
-    // multi_search reports a failed entry inline (the call still resolves);
-    // fetchLabels must throw so the engine's degradation path (onLabelError,
-    // id-only references) engages instead of silently missing every label.
+  it('reports an inline multi_search error via onError, skipping only that source', async () => {
+    // multi_search reports a failed entry inline (the call still resolves).
+    // fetchLabels reports it via onError and skips that source, so healthy
+    // sources still resolve and the failed source falls back to id-only.
+    const termsSource = {
+      collection: 'terms',
+      labelField: organization.fields[0] as TextField,
+      queryBy: 'label_search_und',
+    };
+    const errors: Error[] = [];
     const { client } = fakeTypesenseClient({
-      multiSearch: () => ({ code: 503, error: 'lookup failed' }),
+      multiSearch: (search) =>
+        String(search.collection) === 'labels'
+          ? { code: 503, error: 'lookup failed' }
+          : labelLookup({ 'https://term/1': { label: 'Cartography' } })(search),
     });
-    await expect(fetchLabels(client, group(['https://org/1']))).rejects.toThrow(
-      /label lookup in “labels” failed \(503\): lookup failed/,
+
+    const labels = await fetchLabels(
+      client,
+      [
+        { source: labelsSource, iris: ['https://org/1'] },
+        { source: termsSource, iris: ['https://term/1'] },
+      ],
+      (error) => errors.push(error),
     );
 
-    // An error entry without a status code still throws.
+    // The failed source contributes nothing; the healthy one resolves.
+    expect(labels.has('https://org/1')).toBe(false);
+    expect(labels.get('https://term/1')).toEqual({ und: ['Cartography'] });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(
+      /label lookup in .labels. failed \(503\): lookup failed/,
+    );
+
+    // An error entry without a status code is reported without a code suffix.
+    const noCode: Error[] = [];
     const { client: clientWithoutCode } = fakeTypesenseClient({
       multiSearch: () => ({ error: 'lookup failed' }),
     });
-    await expect(
-      fetchLabels(clientWithoutCode, group(['https://org/1'])),
-    ).rejects.toThrow(/label lookup in “labels” failed: lookup failed/);
+    await fetchLabels(clientWithoutCode, group(['https://org/1']), (error) =>
+      noCode.push(error),
+    );
+    expect(noCode[0].message).toMatch(
+      /label lookup in .labels. failed: lookup failed/,
+    );
   });
 });
 

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -4,6 +4,7 @@ import {
   type LocalizedValue,
   type SearchQuery,
   type SearchType,
+  type TextField,
 } from '@lde/search';
 import type { Client } from 'typesense';
 import {
@@ -24,6 +25,22 @@ const referenceHits = {
   hits: [
     { document: { id: 'https://d/1', publisher: ['https://org/1'] } },
     { document: { id: 'https://d/2', publisher: 'https://org/2' } },
+  ],
+};
+
+// The label source the `publisher` reference resolves against; its collection
+// is the `labels` entry in the engines' `collections` maps below.
+const organization: SearchType = {
+  name: 'Organization',
+  type: 'https://example.org/Organization',
+  fields: [
+    {
+      name: 'label',
+      kind: 'text',
+      locales: ['nl'],
+      output: true,
+      searchable: { weight: 1 },
+    },
   ],
 };
 
@@ -51,6 +68,7 @@ const schema: SearchType = {
       facetable: true,
       output: true,
       ref: { typeName: 'Agent', strategy: 'labelOnly' },
+      labelSource: 'Organization',
     },
     { name: 'size', kind: 'integer', output: true },
     { name: 'datePosted', kind: 'date', output: true },
@@ -59,6 +77,10 @@ const schema: SearchType = {
     { name: 'status', kind: 'keyword', facetable: true, filterable: true },
   ],
 };
+
+/** The engine-facing schema and collections wiring shared by the label tests. */
+const labelledSchema = () => searchSchema(organization, schema);
+const labelledCollections = { Dataset: 'datasets', Organization: 'labels' };
 
 const labels = new Map<string, LocalizedValue>([
   ['https://org/1', { nl: ['Het Utrechts Archief'] }],
@@ -235,9 +257,8 @@ describe('createTypesenseSearchEngine label degradation', () => {
         throw new Error('labels collection unavailable');
       },
     });
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
-      labelsCollection: 'labels',
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
       onLabelError: (error) => {
         capturedError = error;
       },
@@ -289,9 +310,8 @@ describe('createTypesenseSearchEngine label cache (labelCacheTtlMs)', () => {
     const { client, exportCalls } = fakeClient(() =>
       Promise.resolve(labelsJsonl),
     );
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
-      labelsCollection: 'labels',
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
       labelCacheTtlMs: 60_000,
     });
 
@@ -314,9 +334,8 @@ describe('createTypesenseSearchEngine label cache (labelCacheTtlMs)', () => {
     const { client, exportCalls } = fakeClient(() =>
       Promise.resolve(labelsJsonl),
     );
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
-      labelsCollection: 'labels',
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
       labelCacheTtlMs: 60_000,
     });
 
@@ -331,9 +350,8 @@ describe('createTypesenseSearchEngine label cache (labelCacheTtlMs)', () => {
     const { client, exportCalls } = fakeClient(() =>
       Promise.resolve(labelsJsonl),
     );
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
-      labelsCollection: 'labels',
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
       labelCacheTtlMs: 1000,
     });
 
@@ -360,9 +378,8 @@ describe('createTypesenseSearchEngine label cache (labelCacheTtlMs)', () => {
         ? Promise.reject(new Error('labels collection unavailable'))
         : Promise.resolve(labelsJsonl);
     });
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
-      labelsCollection: 'labels',
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
       labelCacheTtlMs: 60_000,
       onLabelError: (error) => {
         capturedError = error;
@@ -409,8 +426,8 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
         ],
       }),
     });
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
     });
 
     const outcomes = await engine.searchFacets(schema, [
@@ -444,8 +461,8 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     const { client, performs } = fakeTypesenseClient({
       multiSearch: () => ({ found: 0, hits: [] }),
     });
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
     });
     await expect(engine.searchFacets(schema, [])).resolves.toEqual([]);
     expect(performs).toHaveLength(0);
@@ -458,8 +475,8 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
           ? { code: 404, error: 'collection not found' }
           : { found: 0, hits: [], facet_counts: [] },
     });
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
     });
 
     const outcomes = await engine.searchFacets(schema, [
@@ -483,8 +500,8 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     const { client } = fakeTypesenseClient({
       multiSearch: () => ({ error: 'malformed query' }),
     });
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
     });
     const [outcome] = await engine.searchFacets(schema, [
       { ...facetBrowse, facets: ['keyword'] },
@@ -517,9 +534,8 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
         ],
       }),
     });
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
-      labelsCollection: 'labels',
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
       labelCacheTtlMs: 60_000,
     });
 
@@ -551,7 +567,7 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     };
     const { client, performs } = fakeTypesenseClient({
       multiSearch: (search, index) =>
-        search.query_by === 'label'
+        search.collection === 'labels'
           ? labelLookup(labelDocs)(search)
           : {
               found: 0,
@@ -569,9 +585,8 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
               ],
             },
     });
-    const engine = createTypesenseSearchEngine(client, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
-      labelsCollection: 'labels',
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
     });
 
     const outcomes = await engine.searchFacets(schema, [
@@ -611,6 +626,13 @@ describe('fetchLabels', () => {
   // Resolving via multi_search/POST avoids the GET query-string limit that a
   // large id-list would otherwise overflow; each POST's per-search id-lists
   // are recoverable from `performs` so batching is observable.
+  const labelsSource = {
+    collection: 'labels',
+    labelField: organization.fields[0] as TextField,
+    queryBy: 'label_search_nl',
+  };
+  const group = (iris: readonly string[]) => [{ source: labelsSource, iris }];
+
   it('resolves labels via multi_search, merging per-locale variants', async () => {
     const { client, performs } = fakeTypesenseClient({
       multiSearch: labelLookup({
@@ -619,11 +641,10 @@ describe('fetchLabels', () => {
         'https://org/3': { label: 'Untagged' },
       }),
     });
-    const labels = await fetchLabels(client, 'labels', [
-      'https://org/1',
-      'https://org/2',
-      'https://org/3',
-    ]);
+    const labels = await fetchLabels(
+      client,
+      group(['https://org/1', 'https://org/2', 'https://org/3']),
+    );
     expect(labels.get('https://org/1')).toEqual({ nl: ['KB'] });
     expect(labels.get('https://org/3')).toEqual({ und: ['Untagged'] });
     // An IRI absent from the collection yields no entry.
@@ -642,7 +663,7 @@ describe('fetchLabels', () => {
     const { client, performs } = fakeTypesenseClient({
       multiSearch: labelLookup(docsById),
     });
-    const labels = await fetchLabels(client, 'labels', ids);
+    const labels = await fetchLabels(client, group(ids));
     // 450 ids → batches of 200, 200, 50, bundled into one round-trip.
     expect(performs).toHaveLength(1);
     expect(
@@ -655,7 +676,7 @@ describe('fetchLabels', () => {
     const { client, performs } = fakeTypesenseClient({
       multiSearch: labelLookup({}),
     });
-    const labels = await fetchLabels(client, 'labels', []);
+    const labels = await fetchLabels(client, group([]));
     expect(labels.size).toBe(0);
     expect(performs).toHaveLength(0);
   });
@@ -667,17 +688,17 @@ describe('fetchLabels', () => {
     const { client } = fakeTypesenseClient({
       multiSearch: () => ({ code: 503, error: 'lookup failed' }),
     });
-    await expect(
-      fetchLabels(client, 'labels', ['https://org/1']),
-    ).rejects.toThrow(/label lookup failed \(503\): lookup failed/);
+    await expect(fetchLabels(client, group(['https://org/1']))).rejects.toThrow(
+      /label lookup in “labels” failed \(503\): lookup failed/,
+    );
 
     // An error entry without a status code still throws.
     const { client: clientWithoutCode } = fakeTypesenseClient({
       multiSearch: () => ({ error: 'lookup failed' }),
     });
     await expect(
-      fetchLabels(clientWithoutCode, 'labels', ['https://org/1']),
-    ).rejects.toThrow(/label lookup failed: lookup failed/);
+      fetchLabels(clientWithoutCode, group(['https://org/1'])),
+    ).rejects.toThrow(/label lookup in “labels” failed: lookup failed/);
   });
 });
 
@@ -739,8 +760,8 @@ describe('schema binding', () => {
       type: 'urn:example:Other',
       fields: [],
     };
-    const engine = createTypesenseSearchEngine(noClient, searchSchema(schema), {
-      collections: { Dataset: 'datasets' },
+    const engine = createTypesenseSearchEngine(noClient, labelledSchema(), {
+      collections: labelledCollections,
     });
     await expect(engine.search(foreign, browse)).rejects.toThrow(
       /not in this engine/,
@@ -756,10 +777,10 @@ describe('schema binding', () => {
     expect(() =>
       createTypesenseSearchEngine(
         noClient,
-        searchSchema(schema, other),
+        searchSchema(organization, schema, other),
         // The widened schema loses compile-time exhaustiveness; the
         // constructor still rejects the missing entry at startup.
-        { collections: { Dataset: 'datasets' } },
+        { collections: labelledCollections },
       ),
     ).toThrow(/No collection configured for search type “Other”/);
   });

--- a/packages/search-typesense/test/search-engine.test.ts
+++ b/packages/search-typesense/test/search-engine.test.ts
@@ -11,6 +11,22 @@ import { buildCollectionSchema } from '../src/collection-schema.js';
 import { createTypesenseSearchEngine } from '../src/search.js';
 import { TypesenseContainer } from './typesense-container.js';
 
+// The label source `publisher` resolves against: a first-class search type
+// whose collection is built from the same declaration.
+const organizationSchema: SearchType = {
+  name: 'Organization',
+  type: 'https://example.org/Organization',
+  fields: [
+    {
+      name: 'label',
+      kind: 'text',
+      locales: ['nl', 'en'],
+      output: true,
+      searchable: { weight: 1 },
+    },
+  ],
+};
+
 const datasetSchema: SearchType = {
   name: 'Dataset',
   type: 'http://www.w3.org/ns/dcat#Dataset',
@@ -39,6 +55,7 @@ const datasetSchema: SearchType = {
       facetable: true,
       output: true,
       ref: { typeName: 'Agent', strategy: 'labelOnly' },
+      labelSource: 'Organization',
     },
     { name: 'status', kind: 'keyword', facetable: true, filterable: true },
     { name: 'statusRank', kind: 'integer', sortable: true },
@@ -85,19 +102,20 @@ const documents = [
   },
 ];
 
+// Organization documents in projected shape (per-locale display + folded
+// search fields), as @lde/search's projection would emit them.
 const labelDocuments = [
   {
     id: 'https://org/1',
-    label: 'Het Utrechts Archief',
     label_nl: 'Het Utrechts Archief',
-    type: 'organization',
+    label_search_nl: 'het utrechts archief',
   },
   {
     id: 'https://org/2',
-    label: 'Rijksmuseum',
     label_nl: 'Rijksmuseum',
     label_en: 'Rijksmuseum',
-    type: 'organization',
+    label_search_nl: 'rijksmuseum',
+    label_search_en: 'rijksmuseum',
   },
 ];
 
@@ -125,15 +143,10 @@ describe('createTypesenseSearchEngine (integration)', () => {
         defaultLocale: 'nl',
       }),
     );
-    await client.collections().create({
-      name: 'labels',
-      fields: [
-        { name: 'label', type: 'string' },
-        { name: 'label_nl', type: 'string', optional: true, index: false },
-        { name: 'label_en', type: 'string', optional: true, index: false },
-        { name: 'type', type: 'string', facet: true },
-      ],
-    });
+    // The label source's collection comes from the same declarative source.
+    await client
+      .collections()
+      .create(buildCollectionSchema(organizationSchema, { name: 'labels' }));
     await client
       .collections('datasets')
       .documents()
@@ -143,10 +156,13 @@ describe('createTypesenseSearchEngine (integration)', () => {
       .documents()
       .import(labelDocuments, { action: 'create' });
 
-    engine = createTypesenseSearchEngine(client, searchSchema(datasetSchema), {
-      collections: { Dataset: 'datasets' },
-      labelsCollection: 'labels',
-    });
+    engine = createTypesenseSearchEngine(
+      client,
+      searchSchema(organizationSchema, datasetSchema),
+      {
+        collections: { Dataset: 'datasets', Organization: 'labels' },
+      },
+    );
   }, 120_000);
 
   afterAll(async () => {
@@ -297,9 +313,9 @@ describe('createTypesenseSearchEngine (integration)', () => {
     const ignored: unknown[] = [];
     const reporting = createTypesenseSearchEngine(
       client,
-      searchSchema(datasetSchema),
+      searchSchema(organizationSchema, datasetSchema),
       {
-        collections: { Dataset: 'datasets' },
+        collections: { Dataset: 'datasets', Organization: 'labels' },
         onIgnoredFilter: (filter) => ignored.push(filter),
       },
     );

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these — see AGENTS.md.
-          functions: 98.47,
-          lines: 98.2,
+          functions: 98.38,
+          lines: 98.16,
           branches: 92.62,
-          statements: 98.23,
+          statements: 98.2,
         },
       },
     },

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -203,6 +203,12 @@ A `reference` carries `labelOnly` today (id + display label); the `idOnly` and
 day one so that `inline` can later **add** fields to a reference type without
 breaking clients.
 
+A reference resolves its label from a **label source**: `labelSource` names
+the `SearchType` whose collection holds the referenced entities. The named
+type must declare an `output`, `searchable` text field called `label` –
+`searchSchema` validates this schema-wide, so a dangling or unsuitable label
+source fails at startup. A reference without a `labelSource` stays id-only.
+
 ## Projection
 
 `projectGraph` is fully streaming: subjects are grouped and framed one at a time
@@ -286,7 +292,7 @@ await engine.search(OTHER_TYPE, query); // compile error: not in this schema
 ```
 
 `searchFacets(type, queries)` is the port’s **batch entry point**: several
-facet-only queries – e.g. a faceted sidebar’s skip-own-filter variants –
+facet-only queries – e.g. a faceted listing’s skip-own-filter variants –
 answered in one engine round-trip (Typesense: a single `multi_search`), one
 outcome per query, positionally aligned – its facet map, or an in-place error,
 so one failed query never discards its siblings’ facets. The same schema

--- a/packages/search/src/adapter.ts
+++ b/packages/search/src/adapter.ts
@@ -16,6 +16,7 @@ export {
   outputFields,
   referenceFields,
   fieldNamed,
+  labelFieldOf,
   isRangeFacet,
   isoToUnixSeconds,
   unixSecondsToIso,

--- a/packages/search/src/engine.ts
+++ b/packages/search/src/engine.ts
@@ -46,7 +46,7 @@ export interface SearchEngine<
    * in a single engine round-trip (where the engine supports one, e.g.
    * Typesense `multi_search`), returning one {@link FacetsOutcome} per query,
    * positionally aligned with `queries`. This is what keeps a faceted
-   * sidebar – one skip-own-filter query variant per filtered facet – from
+   * listing – one skip-own-filter query variant per filtered facet – from
    * fanning out into per-facet engine calls. Only facet buckets come back: an
    * engine answers every query in the batch facet-only (as if `limit: 0` and
    * without ordering, whatever the query carries), so hits are never

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -158,6 +158,15 @@ export interface ReferenceField extends SearchFieldBase, Searchable {
   /** Projection-time value transform. */
   readonly transform?: (value: string) => string;
   readonly facetRanges?: never;
+  /**
+   * The `name` of the {@link SearchType} whose collection resolves this
+   * reference’s labels – its ‘label source’. The named type must declare an
+   * `output`, `searchable` text field called `label` (validated by
+   * {@link searchSchema}), so an engine can both reconstruct the label and
+   * search it (typeahead). Omit for an id-only reference: no label
+   * resolution.
+   */
+  readonly labelSource?: string;
   /** The referenced entity’s shape and how much of it to carry. Required when
    *  the field is `output` (the API surfaces need the reference type name);
    *  optional for a facet- or filter-only reference. */
@@ -301,10 +310,47 @@ export function searchSchema<const Types extends readonly SearchType[]>(
     typeIris.add(searchType.type);
     names.add(searchType.name);
   }
+  assertResolvableLabelSources(types);
   // The one blessed cast: only this validated constructor mints the brand.
   return new Map(
     types.map((searchType) => [searchType.type, searchType]),
   ) as unknown as SearchSchema<Types>;
+}
+
+/**
+ * Every {@link ReferenceField.labelSource} must name a declared type that can
+ * actually serve labels: an `output` (something to reconstruct a label from),
+ * `searchable` (something to type ahead against) text field called `label`.
+ * Checked schema-wide, because a single declaration cannot see its siblings.
+ */
+function assertResolvableLabelSources(types: readonly SearchType[]): void {
+  const byName = new Map(
+    types.map((searchType) => [searchType.name, searchType]),
+  );
+  for (const searchType of types) {
+    for (const field of searchType.fields) {
+      if (field.kind !== 'reference' || field.labelSource === undefined) {
+        continue;
+      }
+      const source = byName.get(field.labelSource);
+      if (source === undefined) {
+        throw new Error(
+          `Reference “${searchType.name}.${field.name}” names unknown label source “${field.labelSource}”; declare a SearchType with that name.`,
+        );
+      }
+      const labelField = fieldNamed(source, 'label');
+      if (
+        labelField === undefined ||
+        labelField.kind !== 'text' ||
+        labelField.output !== true ||
+        labelField.searchable === undefined
+      ) {
+        throw new Error(
+          `Reference “${searchType.name}.${field.name}” uses label source “${field.labelSource}”, which must declare an output, searchable text field “label”.`,
+        );
+      }
+    }
+  }
 }
 
 /**
@@ -534,7 +580,7 @@ export function outputFields(searchType: SearchType): readonly SearchField[] {
 /** Fields of kind `reference` (IRI-valued, label-resolved), in declaration order. */
 export function referenceFields(
   searchType: SearchType,
-): readonly SearchField[] {
+): readonly ReferenceField[] {
   return searchType.fields.filter((field) => field.kind === 'reference');
 }
 

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -346,10 +346,17 @@ function assertResolvableLabelSources(types: readonly SearchType[]): void {
   );
   for (const searchType of types) {
     for (const field of searchType.fields) {
-      if (field.kind !== 'reference' || field.labelSource === undefined) {
+      const labelSource = (field as { readonly labelSource?: string })
+        .labelSource;
+      if (labelSource === undefined) {
         continue;
       }
-      const source = byName.get(field.labelSource);
+      if (field.kind !== 'reference') {
+        throw new Error(
+          `Field “${searchType.name}.${field.name}” declares a label source but is a ${field.kind} field; only reference fields resolve labels from a source.`,
+        );
+      }
+      const source = byName.get(labelSource);
       if (source === undefined) {
         throw new Error(
           `Reference “${searchType.name}.${field.name}” names unknown label source “${field.labelSource}”; declare a SearchType with that name.`,

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -318,10 +318,27 @@ export function searchSchema<const Types extends readonly SearchType[]>(
 }
 
 /**
- * Every {@link ReferenceField.labelSource} must name a declared type that can
- * actually serve labels: an `output` (something to reconstruct a label from),
+ * The text field a label source serves labels from – the ‘label’ convention
+ * in one place: an `output` (something to reconstruct a label from),
  * `searchable` (something to type ahead against) text field called `label`.
- * Checked schema-wide, because a single declaration cannot see its siblings.
+ * Returns `undefined` when the type declares no such field; a schema built by
+ * {@link searchSchema} guarantees it for every type named as a
+ * {@link ReferenceField.labelSource}.
+ */
+export function labelFieldOf(searchType: SearchType): TextField | undefined {
+  const field = fieldNamed(searchType, 'label');
+  return field !== undefined &&
+    field.kind === 'text' &&
+    field.output === true &&
+    field.searchable !== undefined
+    ? field
+    : undefined;
+}
+
+/**
+ * Every {@link ReferenceField.labelSource} must name a declared type that can
+ * actually serve labels ({@link labelFieldOf}). Checked schema-wide, because
+ * a single declaration cannot see its siblings.
  */
 function assertResolvableLabelSources(types: readonly SearchType[]): void {
   const byName = new Map(
@@ -338,13 +355,7 @@ function assertResolvableLabelSources(types: readonly SearchType[]): void {
           `Reference “${searchType.name}.${field.name}” names unknown label source “${field.labelSource}”; declare a SearchType with that name.`,
         );
       }
-      const labelField = fieldNamed(source, 'label');
-      if (
-        labelField === undefined ||
-        labelField.kind !== 'text' ||
-        labelField.output !== true ||
-        labelField.searchable === undefined
-      ) {
+      if (labelFieldOf(source) === undefined) {
         throw new Error(
           `Reference “${searchType.name}.${field.name}” uses label source “${field.labelSource}”, which must declare an output, searchable text field “label”.`,
         );

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -415,6 +415,107 @@ describe('searchSchema validation', () => {
       ),
     ).toThrow(/Duplicate search type name/);
   });
+
+  describe('reference label sources', () => {
+    const organization = {
+      name: 'Organization',
+      type: 'https://example.org/Organization',
+      fields: [
+        {
+          name: 'label',
+          kind: 'text',
+          locales: ['und', 'nl'],
+          output: true,
+          searchable: { weight: 1 },
+        },
+      ],
+    } as const;
+
+    it('accepts a reference whose labelSource names a type with a resolvable label', () => {
+      expect(() =>
+        searchSchema(organization, {
+          name: 'Dataset',
+          type: DATASET,
+          fields: [
+            {
+              name: 'publisher',
+              kind: 'reference',
+              facetable: true,
+              labelSource: 'Organization',
+            },
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it('rejects a labelSource that names no declared type', () => {
+      expect(() =>
+        searchSchema({
+          name: 'Dataset',
+          type: DATASET,
+          fields: [
+            {
+              name: 'publisher',
+              kind: 'reference',
+              labelSource: 'Organization',
+            },
+          ],
+        }),
+      ).toThrow(/label source “Organization”/);
+    });
+
+    it('rejects a label source without an output, searchable text “label” field', () => {
+      const withLabelField = (label: Record<string, unknown>) => () =>
+        searchSchema(
+          {
+            name: 'Organization',
+            type: 'https://example.org/Organization',
+            fields: [{ name: 'label', kind: 'text', ...label } as never],
+          },
+          {
+            name: 'Dataset',
+            type: DATASET,
+            fields: [
+              {
+                name: 'publisher',
+                kind: 'reference',
+                labelSource: 'Organization',
+              },
+            ],
+          },
+        );
+
+      // Not output: nothing to reconstruct a label from.
+      expect(
+        withLabelField({ locales: ['und'], searchable: { weight: 1 } }),
+      ).toThrow(/label source/);
+      // Not searchable: nothing to type ahead against, and no query_by.
+      expect(withLabelField({ locales: ['und'], output: true })).toThrow(
+        /label source/,
+      );
+      // No `label` field at all.
+      expect(() =>
+        searchSchema(
+          {
+            name: 'Organization',
+            type: 'https://example.org/Organization',
+            fields: [],
+          },
+          {
+            name: 'Dataset',
+            type: DATASET,
+            fields: [
+              {
+                name: 'publisher',
+                kind: 'reference',
+                labelSource: 'Organization',
+              },
+            ],
+          },
+        ),
+      ).toThrow(/label source/);
+    });
+  });
 });
 
 describe('date storage codec', () => {

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -515,6 +515,22 @@ describe('searchSchema validation', () => {
         ),
       ).toThrow(/label source/);
     });
+
+    it('rejects a labelSource on a non-reference field', () => {
+      expect(() =>
+        searchSchema(organization, {
+          name: 'Dataset',
+          type: DATASET,
+          fields: [
+            {
+              name: 'theme',
+              kind: 'keyword',
+              labelSource: 'Organization',
+            } as never,
+          ],
+        }),
+      ).toThrow(/declares a label source but is a keyword field/);
+    });
   });
 });
 

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 96.9,
+          branches: 96.93,
           statements: 100,
         },
       },

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 96.7,
+          branches: 96.9,
           statements: 100,
         },
       },


### PR DESCRIPTION
Slice 4 of #534, stacked on #565: per-reference label sources, replacing the single global sidecar `labels` collection. Design captured in [ADR 7](docs/decisions/0007-resolve-reference-labels-from-per-reference-label-sources.md).

## Schema (`@lde/search`)

`ReferenceField.labelSource` names the `SearchType` whose collection resolves the reference’s labels. The named type must declare an `output`, `searchable` text field called `label` – something to reconstruct a label from, and something to type ahead against (the future facet-by-name entry point). `searchSchema` validates this schema-wide, so a dangling or unsuitable source fails at startup. A reference without a `labelSource` stays id-only: its IRIs never travel in a lookup.

Resolving open decision 1 of #534 as decided: the global labels collection is **dropped**, not kept as a typeless fallback – a typed entity collection and a ‘labels collection’ are the same kind of thing (one entry in `collections`).

## Engine (`@lde/search-typesense`)

- Each reference field resolves from its own source’s collection; all sources’ id-lists are bundled into the single `multi_search` the engine already used (per-source batches of 200).
- Labels reconstruct from the source type’s `label` declaration (per-locale display fields), with a bare untagged `label` value as the `und` fallback – so existing sidecar-shaped documents keep working during migration.
- The opt-in in-memory cache (`labelCacheTtlMs`) now caches per source collection, single-flight per collection.
- Reference facet buckets are labelled from the facet field’s own source, exactly as hit references are.

Covered by the issue’s resolver spec: labels resolve batched per source, fields without a source are pruned from lookups, dangling references degrade to id-only; plus the migrated container-backed integration suite, where the label collection is now built from the same `SearchType` declaration via `buildCollectionSchema`.

## Also

Degeneralizes UI-specific “sidebar” wording in ADR 5, the READMEs and JSDoc to “a faceted listing” – the sidebar is a consumer (Dataset Register) notion, not LDE’s.

## Breaking changes

`TypesenseSearchEngineOptions.labelsCollection` is removed. Migration: declare each label source as a `SearchType`, add its collection to `options.collections`, set `labelSource` on each reference field, and rebuild label collections via `buildCollectionSchema` so the physical label fields exist. `fetchLabels` now takes label-lookup groups instead of `(collection, iris)`.

Part of #534 (slice 4; the facet-by-name two-step itself follows separately with #533’s value-query IR).
