### PR TITLE
ci(distribution-probe): pin coverage thresholds below the flaky ceiling

### DIFF
--- a/packages/distribution-probe/vite.config.ts
+++ b/packages/distribution-probe/vite.config.ts
@@ -10,11 +10,17 @@ export default mergeConfig(
     test: {
       coverage: {
         thresholds: {
-          autoUpdate: true,
-          lines: 100,
-          functions: 100,
-          branches: 96.72,
-          statements: 99.64,
+          // autoUpdate off: coverage of probe.ts is timing-dependent (small
+          // arrow callbacks in content-type matching run only under certain
+          // response orderings), so a lucky run must not ratchet the
+          // thresholds above the deterministic floor – that made CI fail
+          // nondeterministically on unrelated PRs (observed floor: functions
+          // 98.36, statements 99.28 on unlucky runs).
+          autoUpdate: false,
+          lines: 99,
+          functions: 98.3,
+          branches: 96.5,
+          statements: 99.2,
         },
       },
     },


### PR DESCRIPTION
`probe.ts` coverage is timing-dependent: small arrow callbacks in the content-type matching (the `.some`/`.find` predicates and their `?? false` fallbacks) only execute under certain response orderings, and v8 counts each arrow as a function. The auto-updated 100% functions threshold therefore made CI fail nondeterministically on PRs that never touch this package – twice today alone (#565 first run and its rerun, observed floor: functions 98.36, statements 99.28), passing minutes later on identical code (#560, #566).

This pins the thresholds at the deterministic floor and disables `autoUpdate` for this package only, so a lucky run can’t ratchet them back above it (the base config’s `autoUpdate: true` would otherwise reinstate the flake on the next local full run someone commits).

A nicer follow-up would deflake the tests – pin the uncovered orderings with explicit cases – and restore the ratchet; this unblocks CI first.
