### PR TITLE
feat(pipeline-void): merge namespace-alias variants into one VoID partition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Each package uses conditional exports with a `development` condition for local d
 - Test files use `.test.ts` suffix in `test/` directory
 - Fixtures in `test/fixtures/`
 - HTTP mocking with Nock
-- Tests that start a local SPARQL endpoint (`@lde/local-sparql-endpoint`) must use unique ports across packages to avoid conflicts when Nx runs tests in parallel. Current port allocations: `dataset-registry-client` (3002), `pipeline` sparqlQuery (3001), `pipeline` executor (3003), `pipeline` provenance store (3004)
+- Tests that start a local SPARQL endpoint (`@lde/local-sparql-endpoint`) must use unique ports across packages to avoid conflicts when Nx runs tests in parallel. Current port allocations: `dataset-registry-client` (3002), `pipeline` sparqlQuery (3001), `pipeline` executor (3003), `pipeline` provenance store (3004), `pipeline-void` namespace-normalization (3005–3006)
 
 ### Key Dependencies
 

--- a/docs/decisions/0007-merge-namespace-alias-partitions.md
+++ b/docs/decisions/0007-merge-namespace-alias-partitions.md
@@ -1,0 +1,88 @@
+# 7. Merge namespace-alias VoID partitions after aggregation
+
+Date: 2026-07-08
+
+## Status
+
+Proposed
+
+Extends the VoID analysis of
+[ADR 2 (Unify pipeline extension on quad transforms)](./0002-unify-pipeline-extension-on-quad-transforms.md).
+
+## Context
+
+Some vocabularies publish under both an `http://` and an `https://`
+variant of the same namespace — notably schema.org — and datasets mix
+them. The VoID analysis keys each partition on an opaque
+`MD5(class[, property[, …]])` IRI, so a dataset with both
+`http://schema.org/CreativeWork` and `https://schema.org/CreativeWork`
+produces **two** `void:classPartition` nodes that, once the class IRI is
+normalized, describe the same class. Downstream consumers that group by
+class URI do not expect two partitions for one class; the Dataset Register
+browser crashed on the duplicate.
+
+The consuming side cannot fix this from the published summary: merging two
+pre-aggregated `void:entities` counts is only correct if the underlying
+subject sets are disjoint, and merging two `void:distinctObjects` counts is
+never correct from the counts alone (the object sets can overlap). Only the
+analysis, which still has the raw data, can produce correct merged numbers.
+
+Two placements were considered:
+
+- **Normalize inside every query, before `GROUP BY`.** Correct without any
+  assumptions, but weaves a per-row `BIND(IF(STRSTARTS…))` into all six
+  partition queries and groups on a computed value rather than an indexed
+  one.
+- **Normalize once, after aggregation.** Keeps the queries plain and puts
+  normalization in one testable place, at the cost of correctness
+  assumptions where a distinct-count cannot be reconstructed by summing.
+
+## Decision
+
+Normalize after aggregation with a single **partition-merge transform**,
+except for the one measure that cannot be summed.
+
+- A per-stage `QuadTransform` (`mergeNamespaceVariants`) buffers a stage’s
+  VoID output, re-mints every partition IRI from its **canonical** key
+  components (replicating the queries’ `MD5(CONCAT(STR(…)))`), collapses the
+  duplicate partition nodes, and **sums** `void:entities` / `void:triples`.
+  The class selector canonicalizes and de-duplicates its bindings and the
+  reader expands each canonical class back to its namespace variants, so a
+  class’s variants are co-located in one batch — the merge is therefore
+  self-contained per stage.
+- The `void-ext` queries (`datatype`, `object-class`, `language`) emit their
+  parent `cp → pp` chain (`void:class`, `void:property`) so the transform can
+  re-key them from an otherwise opaque hash.
+- `class-properties-objects.rq` keeps query-time normalization: its
+  `void:distinctObjects` is a distinct-count over object _values_, which
+  overlap across namespace variants even when subjects are disjoint, so
+  summing would over-count. It is deduped in the query and never reaches the
+  transform.
+
+### Assumptions of record
+
+Summing pre-aggregated counts is exact only under:
+
+- **Subject/class disjointness** — no resource is typed under two namespace
+  variants of the same class. Guards the class-partition `void:entities` sum
+  and every `void:triples` sum.
+- **Predicate-namespace disjointness** — no subject uses two namespace
+  variants of the same property. Guards the property-partition
+  `void:entities` sum.
+
+Both hold in practice for the schema.org datasets that motivate this (the
+variants appear as disjoint subsets of the data). A resource typed under
+both variants over-counts its class entities; this is pinned by a test and
+documented on the transform.
+
+## Consequences
+
+- The six analysis queries return to plain, index-friendly SPARQL (only
+  `class-properties-objects.rq` normalizes, because it must).
+- Normalization lives in one unit-tested transform, applied uniformly to
+  dump-loaded and remote-endpoint datasets alike — no dependence on being
+  able to rewrite the source.
+- The correctness of the summed measures is now assumption-bound rather than
+  exact; the assumptions are documented and the known violation is tested.
+- `namespaceAliases` is a stage option; with none configured the transform
+  is a no-op and the behaviour is unchanged.

--- a/docs/decisions/0007-merge-namespace-alias-partitions.md
+++ b/docs/decisions/0007-merge-namespace-alias-partitions.md
@@ -21,11 +21,15 @@ normalized, describe the same class. Downstream consumers that group by
 class URI do not expect two partitions for one class; the Dataset Register
 browser crashed on the duplicate.
 
-The consuming side cannot fix this from the published summary: merging two
-pre-aggregated `void:entities` counts is only correct if the underlying
-subject sets are disjoint, and merging two `void:distinctObjects` counts is
-never correct from the counts alone (the object sets can overlap). Only the
-analysis, which still has the raw data, can produce correct merged numbers.
+The consuming side cannot cleanly fix this from the published summary.
+Merging two `void:distinctObjects` counts is never correct from the counts
+alone — the object sets can overlap — so only the analysis, which still has
+the raw object values, can dedupe them. Merging two `void:entities` counts
+_can_ be done by summing, but only under a subject-disjointness assumption
+(see [Assumptions of record](#assumptions-of-record)); doing that sum in the
+analysis is no more correct than a consumer doing it, it just keeps the
+normalization in one place and stops the duplicate partition nodes — which
+crashed the browser — from being published at all.
 
 Two placements were considered:
 

--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -1,8 +1,10 @@
 import {
+  aliasVariants,
   Stage,
   SparqlConstructReader,
   SparqlItemSelector,
   type ItemSelector,
+  type NamespaceAlias,
   type StageOptions,
   type ValidationReport,
   type ValidationResult,
@@ -17,29 +19,7 @@ const { namedNode, quad } = DataFactory;
 
 type OnInvalid = NonNullable<StageOptions['validation']>['onInvalid'];
 
-/**
- * Declares that two namespaces should be treated as equivalent when
- * sampling and validating, working around vocabularies that publish under
- * both HTTP and HTTPS variants of the same IRI (notably schema.org).
- *
- * The sampler accepts subjects typed under the {@link alias} namespace in
- * addition to the SHACL `sh:targetClass` IRI under {@link canonical}, and
- * rewrites alias-namespace IRIs to canonical ones in the sampled quads
- * before validation so SHACL `sh:targetClass` and `sh:path` patterns
- * match.
- */
-export interface NamespaceAlias {
-  /**
-   * The namespace declared in the SHACL shapes file (e.g.
-   * `https://schema.org/`).
-   */
-  canonical: string;
-  /**
-   * The equivalent namespace that may appear in source data (e.g.
-   * `http://schema.org/`).
-   */
-  alias: string;
-}
+export type { NamespaceAlias } from '@lde/pipeline';
 
 /** Options for {@link shaclSampleStages}. */
 export interface ShaclSampleStagesOptions {
@@ -237,16 +217,7 @@ function expandTargetClass(
   targetClass: NamedNode,
   namespaceAliases: NamespaceAlias[],
 ): string[] {
-  const iri = targetClass.value;
-  for (const { canonical, alias } of namespaceAliases) {
-    if (iri.startsWith(canonical)) {
-      return [iri, alias + iri.slice(canonical.length)];
-    }
-    if (iri.startsWith(alias)) {
-      return [iri, canonical + iri.slice(alias.length)];
-    }
-  }
-  return [iri];
+  return aliasVariants(targetClass.value, namespaceAliases);
 }
 
 export function buildSampleQuery(shape: TargetShape): string {

--- a/packages/pipeline-shacl-sampler/vite.config.ts
+++ b/packages/pipeline-shacl-sampler/vite.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 96.77,
-          lines: 97.26,
-          branches: 89.87,
-          statements: 94.96,
+          lines: 97.14,
+          branches: 89.33,
+          statements: 94.77,
         },
       },
     },

--- a/packages/pipeline-void/README.md
+++ b/packages/pipeline-void/README.md
@@ -10,14 +10,15 @@ Returns all VoID stages in their recommended execution order. The ordering is op
 
 Accepts an optional `VoidStagesOptions` object:
 
-| Option           | Default | Description                                                                                                     |
-| ---------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
-| `batchSize`      | 10      | Maximum class bindings per reader call (per-class stages only)                                                  |
-| `maxConcurrency` | 10      | Maximum concurrent in-flight reader batches (per-class stages only)                                             |
-| `perClass`       | —       | Override per-class iteration for all five per-class stages                                                      |
-| `uriSpaces`      | —       | When provided, includes the object URI space stage                                                              |
-| `vocabularies`   | —       | Additional vocabulary namespace URIs to detect beyond the built-in defaults                                     |
-| `transforms`     | —       | Transforms to attach to bundled stages, keyed by `VOID_STAGE_NAMES` (see [Stage transforms](#stage-transforms)) |
+| Option             | Default | Description                                                                                                     |
+| ------------------ | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `batchSize`        | 10      | Maximum class bindings per reader call (per-class stages only)                                                  |
+| `maxConcurrency`   | 10      | Maximum concurrent in-flight reader batches (per-class stages only)                                             |
+| `perClass`         | —       | Override per-class iteration for all five per-class stages                                                      |
+| `uriSpaces`        | —       | When provided, includes the object URI space stage                                                              |
+| `vocabularies`     | —       | Additional vocabulary namespace URIs to detect beyond the built-in defaults                                     |
+| `transforms`       | —       | Transforms to attach to bundled stages, keyed by `VOID_STAGE_NAMES` (see [Stage transforms](#stage-transforms)) |
+| `namespaceAliases` | —       | Namespace pairs to treat as equivalent when partitioning (see [Namespace aliases](#namespace-aliases))          |
 
 Per-request timeouts are configured at the `Pipeline` level via `PipelineOptions.timeout`, not per VoID stage.
 
@@ -71,6 +72,29 @@ Global and domain-specific factories accept `VoidStageOptions` (`transform`) and
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `detectVocabularies()`   | [`entity-properties.rq`](queries/entity-properties.rq) — Entity properties with automatic `void:vocabulary` detection. Accepts `DetectVocabulariesOptions` with an optional `vocabularies` array to extend the built-in defaults. |
 | `uriSpaces(uriSpaceMap)` | [`object-uri-space.rq`](queries/object-uri-space.rq) — Object URI namespace linksets, aggregated against a provided URI space map                                                                                                 |
+
+## Namespace aliases
+
+Some vocabularies publish under both HTTP and HTTPS variants of the same namespace (notably schema.org), and datasets mix them. Without normalization, each variant gets its own `void:classPartition`/`void:propertyPartition`, so consumers see two partitions for what is semantically one class.
+
+Pass `namespaceAliases` to merge the variants into one partition per canonical class/property:
+
+```typescript
+const stages = await voidStages({
+  namespaceAliases: [
+    { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+  ],
+});
+```
+
+Merging happens **after** aggregation, in a single partition-merge transform (`mergeNamespaceVariants`) attached to the class and property partition stages: it re-mints each partition IRI from its canonical key components, collapses the duplicates, and sums `void:entities` / `void:triples`. The analysis queries stay plain — except `class-properties-objects.rq`, which normalizes at query time because its `void:distinctObjects` is a distinct-count over object values that overlap across variants and so cannot be recovered by summing. See [ADR 7](../../docs/decisions/0007-merge-namespace-alias-partitions.md).
+
+Summing pre-aggregated counts is exact only under two assumptions, both of which hold for the schema.org datasets that motivate this (the variants appear as disjoint subsets):
+
+- **Subject/class disjointness** — no resource is typed under both namespace variants of a class (guards the class-partition and triple-count sums).
+- **Predicate-namespace disjointness** — no subject uses both variants of the same property (guards the property-partition entity sum).
+
+A resource typed under both variants over-counts its class entities. With no aliases configured the transform is a no-op. The top-level property partitions from `entity-properties.rq` and `void:vocabulary` detection keep the source namespaces, so consumers can still see which namespace the dataset actually uses.
 
 ## Stage transforms
 

--- a/packages/pipeline-void/queries/class-properties-objects.rq
+++ b/packages/pipeline-void/queries/class-properties-objects.rq
@@ -5,17 +5,27 @@ CONSTRUCT {
 }
 WHERE {
     # Object counts only. Subject counts in class-properties-subjects.rq.
+    #
+    # Unlike the other per-class queries, this one normalizes the class and
+    # property to their canonical namespace *before* the COUNT(DISTINCT ?o):
+    # merging distinct-object counts by summing would over-count objects shared
+    # between namespace variants (e.g. the same name under http:name and
+    # https:name), so the dedup must happen here rather than in the
+    # partition-merge transform. `?class` is bound per namespace variant by the
+    # injected VALUES clause; `?property` is discovered.
     {
-        SELECT ?class ?p (COUNT(DISTINCT ?o) AS ?objects) {
+        SELECT ?canonicalClass ?canonicalProperty (COUNT(DISTINCT ?o) AS ?objects) {
             {
-                SELECT ?class ?p ?o {
+                SELECT ?canonicalClass ?canonicalProperty ?o {
                     #subjectFilter#
-                    ?s a ?class ; ?p ?o .
+                    ?s a ?class ; ?property ?o .
+                    BIND(#normalized:class# AS ?canonicalClass)
+                    BIND(#normalized:property# AS ?canonicalProperty)
                 }
             }
         }
-        GROUP BY ?class ?p
+        GROUP BY ?canonicalClass ?canonicalProperty
     }
-    BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(?class), STR(?p))))) AS ?propertyPartition)
+    BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(?canonicalClass), STR(?canonicalProperty))))) AS ?propertyPartition)
 }
 LIMIT 100000

--- a/packages/pipeline-void/queries/class-property-datatypes.rq
+++ b/packages/pipeline-void/queries/class-property-datatypes.rq
@@ -3,7 +3,12 @@ PREFIX void-ext: <http://ldf.fi/void-ext#>
 
 CONSTRUCT {
   # Self-describing parent chain so the namespace-merge transform can re-key
-  # this partition from its (class, property) components.
+  # this partition from its (class, property) components. The
+  # `?dataset void:classPartition ?classPartition` link is what gives the class
+  # partition an incoming edge, so the transform re-keys it too (without it, the
+  # alias-variant class partition leaks unmerged).
+  ?dataset a void:Dataset ;
+      void:classPartition ?classPartition .
   ?classPartition void:class ?class ;
       void:propertyPartition ?propertyPartition .
   ?propertyPartition void:property ?p ;

--- a/packages/pipeline-void/queries/class-property-datatypes.rq
+++ b/packages/pipeline-void/queries/class-property-datatypes.rq
@@ -2,7 +2,12 @@ PREFIX void: <http://rdfs.org/ns/void#>
 PREFIX void-ext: <http://ldf.fi/void-ext#>
 
 CONSTRUCT {
-  ?propertyPartition void-ext:datatypePartition ?datatypePartition .
+  # Self-describing parent chain so the namespace-merge transform can re-key
+  # this partition from its (class, property) components.
+  ?classPartition void:class ?class ;
+      void:propertyPartition ?propertyPartition .
+  ?propertyPartition void:property ?p ;
+      void-ext:datatypePartition ?datatypePartition .
   ?datatypePartition
       void-ext:datatype ?dt ;
       void:triples ?count .
@@ -22,6 +27,7 @@ WHERE {
     }
     GROUP BY ?class ?p ?dt
   }
+  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-", MD5(STR(?class)))) AS ?classPartition)
   BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(?class), STR(?p))))) AS ?propertyPartition)
   BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#datatype-", MD5(CONCAT(STR(?class), STR(?p), STR(?dt))))) AS ?datatypePartition)
 }

--- a/packages/pipeline-void/queries/class-property-languages.rq
+++ b/packages/pipeline-void/queries/class-property-languages.rq
@@ -2,7 +2,12 @@ PREFIX void: <http://rdfs.org/ns/void#>
 PREFIX void-ext: <http://ldf.fi/void-ext#>
 
 CONSTRUCT {
-  ?propertyPartition void-ext:languagePartition ?languagePartition .
+  # Self-describing parent chain so the namespace-merge transform can re-key
+  # this partition from its (class, property) components.
+  ?classPartition void:class ?class ;
+      void:propertyPartition ?propertyPartition .
+  ?propertyPartition void:property ?p ;
+      void-ext:languagePartition ?languagePartition .
   ?languagePartition
     void-ext:language ?lang ;
     void:triples ?count .
@@ -24,6 +29,7 @@ WHERE {
     }
     GROUP BY ?class ?p ?lang
   }
+  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-", MD5(STR(?class)))) AS ?classPartition)
   BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(?class), STR(?p))))) AS ?propertyPartition)
   BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#language-", MD5(CONCAT(STR(?class), STR(?p), ?lang)))) AS ?languagePartition)
 }

--- a/packages/pipeline-void/queries/class-property-languages.rq
+++ b/packages/pipeline-void/queries/class-property-languages.rq
@@ -3,7 +3,12 @@ PREFIX void-ext: <http://ldf.fi/void-ext#>
 
 CONSTRUCT {
   # Self-describing parent chain so the namespace-merge transform can re-key
-  # this partition from its (class, property) components.
+  # this partition from its (class, property) components. The
+  # `?dataset void:classPartition ?classPartition` link is what gives the class
+  # partition an incoming edge, so the transform re-keys it too (without it, the
+  # alias-variant class partition leaks unmerged).
+  ?dataset a void:Dataset ;
+      void:classPartition ?classPartition .
   ?classPartition void:class ?class ;
       void:propertyPartition ?propertyPartition .
   ?propertyPartition void:property ?p ;

--- a/packages/pipeline-void/queries/class-property-object-classes.rq
+++ b/packages/pipeline-void/queries/class-property-object-classes.rq
@@ -3,7 +3,12 @@ PREFIX void-ext: <http://ldf.fi/void-ext#>
 
 CONSTRUCT {
   # Self-describing parent chain so the namespace-merge transform can re-key
-  # this partition from its (class, property) components.
+  # this partition from its (class, property) components. The
+  # `?dataset void:classPartition ?classPartition` link is what gives the class
+  # partition an incoming edge, so the transform re-keys it too (without it, the
+  # alias-variant class partition leaks unmerged).
+  ?dataset a void:Dataset ;
+      void:classPartition ?classPartition .
   ?classPartition void:class ?class ;
       void:propertyPartition ?propertyPartition .
   ?propertyPartition void:property ?p ;

--- a/packages/pipeline-void/queries/class-property-object-classes.rq
+++ b/packages/pipeline-void/queries/class-property-object-classes.rq
@@ -2,7 +2,12 @@ PREFIX void: <http://rdfs.org/ns/void#>
 PREFIX void-ext: <http://ldf.fi/void-ext#>
 
 CONSTRUCT {
-  ?propertyPartition void-ext:objectClassPartition ?objectClassPartition .
+  # Self-describing parent chain so the namespace-merge transform can re-key
+  # this partition from its (class, property) components.
+  ?classPartition void:class ?class ;
+      void:propertyPartition ?propertyPartition .
+  ?propertyPartition void:property ?p ;
+      void-ext:objectClassPartition ?objectClassPartition .
   ?objectClassPartition
       void:class ?objectClass ;
       void:triples ?count .
@@ -22,6 +27,7 @@ WHERE {
     }
     GROUP BY ?class ?p ?objectClass
   }
+  BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-", MD5(STR(?class)))) AS ?classPartition)
   BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#class-property-", MD5(CONCAT(STR(?class), STR(?p))))) AS ?propertyPartition)
   BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#object-class-", MD5(CONCAT(STR(?class), STR(?p), STR(?objectClass))))) AS ?objectClassPartition)
 }

--- a/packages/pipeline-void/src/index.ts
+++ b/packages/pipeline-void/src/index.ts
@@ -1,9 +1,12 @@
 export { Stage, NotSupported } from '@lde/pipeline';
 export type {
   AttachedReader,
+  NamespaceAlias,
   ReaderContext,
   QuadTransform,
 } from '@lde/pipeline';
 export * from './stage.js';
+export * from './namespaceAliases.js';
+export * from './partitionMerge.js';
 export * from './vocabularyTransform.js';
 export * from './uriSpaceTransform.js';

--- a/packages/pipeline-void/src/namespaceAliases.ts
+++ b/packages/pipeline-void/src/namespaceAliases.ts
@@ -32,38 +32,6 @@ export function substituteNormalizationMarkers(
 }
 
 /**
- * SPARQL expression rewriting `?rawVariable` from any alias namespace to its
- * canonical namespace: nested `IF(STRSTARTS(...), IRI(CONCAT(...)), ...)`
- * per alias, or the bare variable when no aliases are configured.
- */
-function normalizedExpression(
-  rawVariable: string,
-  namespaceAliases: readonly NamespaceAlias[],
-): string {
-  let expression = `?${rawVariable}`;
-  // Build from the inside out so the first alias is the outermost check.
-  for (const { canonical, alias } of [...namespaceAliases].reverse()) {
-    assertSafeSparqlString(canonical);
-    assertSafeSparqlString(alias);
-    expression = `IF(STRSTARTS(STR(?${rawVariable}), "${alias}"), IRI(CONCAT("${canonical}", STRAFTER(STR(?${rawVariable}), "${alias}"))), ${expression})`;
-  }
-  return expression;
-}
-
-/**
- * Namespaces are interpolated into double-quoted SPARQL string literals, so
- * beyond {@link assertSafeIri} they must not contain quotes or backslashes.
- */
-function assertSafeSparqlString(namespace: string): void {
-  assertSafeIri(namespace);
-  if (namespace.includes('"') || namespace.includes('\\')) {
-    throw new Error(
-      `Namespace contains unsafe characters and cannot be interpolated into SPARQL: ${namespace}`,
-    );
-  }
-}
-
-/**
  * Canonicalize and deduplicate the `?class` bindings a class selector
  * yields, so every namespace-alias variant of a class becomes one item and
  * its variants are queried together in one batch (split across batches,
@@ -104,4 +72,36 @@ export function withAliasVariantBindings(
       return inner.read(dataset, distribution, { ...options, bindings });
     },
   };
+}
+
+/**
+ * SPARQL expression rewriting `?rawVariable` from any alias namespace to its
+ * canonical namespace: nested `IF(STRSTARTS(...), IRI(CONCAT(...)), ...)`
+ * per alias, or the bare variable when no aliases are configured.
+ */
+function normalizedExpression(
+  rawVariable: string,
+  namespaceAliases: readonly NamespaceAlias[],
+): string {
+  let expression = `?${rawVariable}`;
+  // Build from the inside out so the first alias is the outermost check.
+  for (const { canonical, alias } of [...namespaceAliases].reverse()) {
+    assertSafeSparqlString(canonical);
+    assertSafeSparqlString(alias);
+    expression = `IF(STRSTARTS(STR(?${rawVariable}), "${alias}"), IRI(CONCAT("${canonical}", STRAFTER(STR(?${rawVariable}), "${alias}"))), ${expression})`;
+  }
+  return expression;
+}
+
+/**
+ * Namespaces are interpolated into double-quoted SPARQL string literals, so
+ * beyond {@link assertSafeIri} they must not contain quotes or backslashes.
+ */
+function assertSafeSparqlString(namespace: string): void {
+  assertSafeIri(namespace);
+  if (namespace.includes('"') || namespace.includes('\\')) {
+    throw new Error(
+      `Namespace contains unsafe characters and cannot be interpolated into SPARQL: ${namespace}`,
+    );
+  }
 }

--- a/packages/pipeline-void/src/namespaceAliases.ts
+++ b/packages/pipeline-void/src/namespaceAliases.ts
@@ -1,0 +1,107 @@
+import {
+  aliasVariants,
+  canonicalizeIri,
+  type NamespaceAlias,
+  type Reader,
+  type VariableBindings,
+} from '@lde/pipeline';
+import { assertSafeIri } from '@lde/dataset';
+import { DataFactory } from 'n3';
+
+const { namedNode } = DataFactory;
+
+/**
+ * Marker in a VoID query template that expands to a SPARQL expression
+ * normalizing the named raw variable to its canonical namespace, e.g.
+ * `BIND(#normalized:rawClass# AS ?class)`. With no aliases configured the
+ * marker expands to the raw variable itself.
+ */
+const NORMALIZATION_MARKER = /#normalized:([A-Za-z][A-Za-z0-9]*)#/g;
+
+/**
+ * Replace every {@link NORMALIZATION_MARKER} in a query template with the
+ * normalization expression for its raw variable.
+ */
+export function substituteNormalizationMarkers(
+  query: string,
+  namespaceAliases: readonly NamespaceAlias[],
+): string {
+  return query.replace(NORMALIZATION_MARKER, (_match, rawVariable: string) =>
+    normalizedExpression(rawVariable, namespaceAliases),
+  );
+}
+
+/**
+ * SPARQL expression rewriting `?rawVariable` from any alias namespace to its
+ * canonical namespace: nested `IF(STRSTARTS(...), IRI(CONCAT(...)), ...)`
+ * per alias, or the bare variable when no aliases are configured.
+ */
+function normalizedExpression(
+  rawVariable: string,
+  namespaceAliases: readonly NamespaceAlias[],
+): string {
+  let expression = `?${rawVariable}`;
+  // Build from the inside out so the first alias is the outermost check.
+  for (const { canonical, alias } of [...namespaceAliases].reverse()) {
+    assertSafeSparqlString(canonical);
+    assertSafeSparqlString(alias);
+    expression = `IF(STRSTARTS(STR(?${rawVariable}), "${alias}"), IRI(CONCAT("${canonical}", STRAFTER(STR(?${rawVariable}), "${alias}"))), ${expression})`;
+  }
+  return expression;
+}
+
+/**
+ * Namespaces are interpolated into double-quoted SPARQL string literals, so
+ * beyond {@link assertSafeIri} they must not contain quotes or backslashes.
+ */
+function assertSafeSparqlString(namespace: string): void {
+  assertSafeIri(namespace);
+  if (namespace.includes('"') || namespace.includes('\\')) {
+    throw new Error(
+      `Namespace contains unsafe characters and cannot be interpolated into SPARQL: ${namespace}`,
+    );
+  }
+}
+
+/**
+ * Canonicalize and deduplicate the `?class` bindings a class selector
+ * yields, so every namespace-alias variant of a class becomes one item and
+ * its variants are queried together in one batch (split across batches,
+ * each batch would emit its own partial counts for the same partition IRI).
+ */
+export async function* canonicalizeClassBindings(
+  rows: AsyncIterable<VariableBindings>,
+  namespaceAliases: readonly NamespaceAlias[],
+): AsyncIterable<VariableBindings> {
+  const seen = new Set<string>();
+  for await (const row of rows) {
+    const canonical = canonicalizeIri(row.class.value, namespaceAliases);
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    yield { class: namedNode(canonical) };
+  }
+}
+
+/**
+ * Decorate a {@link Reader} so each canonical `?class` binding is expanded to
+ * one `?class` binding per namespace-alias variant. The per-class VoID queries
+ * match `?s a ?class`, so this makes them pick up instances typed under either
+ * namespace; the partition-merge transform then collapses the variants. The
+ * expansion happens within one executor call, so the variants of a class are
+ * co-located in a single batch — a prerequisite for the per-stage merge.
+ */
+export function withAliasVariantBindings(
+  inner: Reader,
+  namespaceAliases: readonly NamespaceAlias[],
+): Reader {
+  return {
+    read(dataset, distribution, options) {
+      const bindings = options?.bindings?.flatMap((row) =>
+        aliasVariants(row.class.value, namespaceAliases).map((iri) => ({
+          class: namedNode(iri),
+        })),
+      );
+      return inner.read(dataset, distribution, { ...options, bindings });
+    },
+  };
+}

--- a/packages/pipeline-void/src/partitionMerge.ts
+++ b/packages/pipeline-void/src/partitionMerge.ts
@@ -18,7 +18,6 @@ const VOID_CLASS = `${VOID}class`;
 const VOID_PROPERTY = `${VOID}property`;
 const VOID_ENTITIES = `${VOID}entities`;
 const VOID_TRIPLES = `${VOID}triples`;
-const VOID_DISTINCT_OBJECTS = `${VOID}distinctObjects`;
 const VOID_CLASS_PARTITION = `${VOID}classPartition`;
 const VOID_PROPERTY_PARTITION = `${VOID}propertyPartition`;
 const VOIDEXT_DATATYPE = `${VOID_EXT}datatype`;
@@ -27,12 +26,11 @@ const VOIDEXT_DATATYPE_PARTITION = `${VOID_EXT}datatypePartition`;
 const VOIDEXT_OBJECTCLASS_PARTITION = `${VOID_EXT}objectClassPartition`;
 const VOIDEXT_LANGUAGE_PARTITION = `${VOID_EXT}languagePartition`;
 
-/** Predicates whose integer-literal objects are summed across merged partitions. */
-const NUMERIC_MEASURES = new Set([
-  VOID_ENTITIES,
-  VOID_TRIPLES,
-  VOID_DISTINCT_OBJECTS,
-]);
+// Predicates whose integer-literal objects are summed across merged partitions.
+// `void:distinctObjects` is deliberately excluded: distinct-object sets overlap
+// across namespace variants, so summing would over-count. It is normalized at
+// query time in `class-properties-objects.rq` and never reaches this transform.
+const NUMERIC_MEASURES = new Set([VOID_ENTITIES, VOID_TRIPLES]);
 
 /** Structural links whose object is a child partition node. */
 const CHILD_LINKS = new Set([
@@ -316,7 +314,7 @@ function canonicalizeObject<T extends Term>(
 }
 
 function accumulateMeasure(sums: Map<string, MeasureSum>, measure: Quad): void {
-  const key = `${measure.subject.value} ${measure.predicate.value}`;
+  const key = `${measure.subject.value} ${measure.predicate.value} ${measure.graph.value}`;
   const existing = sums.get(key);
   if (existing === undefined) {
     sums.set(key, {
@@ -365,5 +363,3 @@ function termKey(term: Term): string {
   }
   return term.value;
 }
-
-export { XSD_INTEGER };

--- a/packages/pipeline-void/src/partitionMerge.ts
+++ b/packages/pipeline-void/src/partitionMerge.ts
@@ -1,0 +1,369 @@
+import {
+  canonicalizeIri,
+  type NamespaceAlias,
+  type QuadTransform,
+  type ReaderContext,
+} from '@lde/pipeline';
+import type { Quad, Term } from '@rdfjs/types';
+import { DataFactory } from 'n3';
+import { createHash } from 'node:crypto';
+
+const { namedNode, literal, quad } = DataFactory;
+
+const VOID = 'http://rdfs.org/ns/void#';
+const VOID_EXT = 'http://ldf.fi/void-ext#';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+
+const VOID_CLASS = `${VOID}class`;
+const VOID_PROPERTY = `${VOID}property`;
+const VOID_ENTITIES = `${VOID}entities`;
+const VOID_TRIPLES = `${VOID}triples`;
+const VOID_DISTINCT_OBJECTS = `${VOID}distinctObjects`;
+const VOID_CLASS_PARTITION = `${VOID}classPartition`;
+const VOID_PROPERTY_PARTITION = `${VOID}propertyPartition`;
+const VOIDEXT_DATATYPE = `${VOID_EXT}datatype`;
+const VOIDEXT_LANGUAGE = `${VOID_EXT}language`;
+const VOIDEXT_DATATYPE_PARTITION = `${VOID_EXT}datatypePartition`;
+const VOIDEXT_OBJECTCLASS_PARTITION = `${VOID_EXT}objectClassPartition`;
+const VOIDEXT_LANGUAGE_PARTITION = `${VOID_EXT}languagePartition`;
+
+/** Predicates whose integer-literal objects are summed across merged partitions. */
+const NUMERIC_MEASURES = new Set([
+  VOID_ENTITIES,
+  VOID_TRIPLES,
+  VOID_DISTINCT_OBJECTS,
+]);
+
+/** Structural links whose object is a child partition node. */
+const CHILD_LINKS = new Set([
+  VOID_CLASS_PARTITION,
+  VOID_PROPERTY_PARTITION,
+  VOIDEXT_DATATYPE_PARTITION,
+  VOIDEXT_OBJECTCLASS_PARTITION,
+  VOIDEXT_LANGUAGE_PARTITION,
+]);
+
+/** `void:class` / `void:property` objects are IRIs subject to canonicalization. */
+const CANONICALIZED_OBJECT_PREDICATES = new Set([VOID_CLASS, VOID_PROPERTY]);
+
+/**
+ * A {@link QuadTransform} that merges the `void:classPartition` /
+ * `void:propertyPartition` subtrees of namespace-alias variants (e.g.
+ * `http://schema.org/CreativeWork` and `https://schema.org/CreativeWork`) into
+ * a single partition per canonical class/property.
+ *
+ * VoID partitions are keyed by an opaque `MD5(class[, property[, …]])` IRI, so
+ * two namespace variants yield two partition nodes that both, after
+ * canonicalization, describe the same class. This transform re-mints every
+ * partition IRI from its **canonical** key components (replicating the queries’
+ * SPARQL `MD5(CONCAT(STR(…)))`), collapses the duplicates, and **sums** their
+ * numeric measures (`void:entities`, `void:triples`).
+ *
+ * ## Correctness assumptions
+ *
+ * Summing pre-aggregated counts is exact only under these assumptions; the
+ * queries whose measures cannot be safely summed keep their normalization at
+ * query time instead (notably `class-properties-objects.rq`’s
+ * `void:distinctObjects`, which this transform never sees):
+ *
+ * - **Subject/class disjointness** — no resource is typed under two namespace
+ *   variants of the same class. Guards the `void:entities` sum on class
+ *   partitions and every `void:triples` sum (a doubly-typed resource’s triples
+ *   would otherwise count under both variants).
+ * - **Predicate-namespace disjointness** — no subject uses two namespace
+ *   variants of the same property (e.g. both `http://schema.org/name` and
+ *   `https://schema.org/name`). Guards the `void:entities` sum on property
+ *   partitions.
+ *
+ * With no aliases configured the transform is a no-op.
+ *
+ * @see substituteNormalizationMarkers for the query-time normalization used
+ *   where summing is not safe.
+ */
+export function mergeNamespaceVariants(
+  namespaceAliases: readonly NamespaceAlias[],
+): QuadTransform<ReaderContext> {
+  if (namespaceAliases.length === 0) {
+    return (quads) => quads;
+  }
+  return async function* (quads, { dataset }) {
+    const datasetIri = dataset.iri.toString();
+    const buffered: Quad[] = [];
+    for await (const q of quads) {
+      buffered.push(q);
+    }
+    yield* mergeBuffered(buffered, datasetIri, namespaceAliases);
+  };
+}
+
+/** One node’s describing quads, indexed for component lookup. */
+interface NodeIndex {
+  /** For a partition node: the structural predicate linking its parent to it. */
+  incomingLink?: { predicate: string; parent: string };
+  values: Map<string, Term>;
+}
+
+/** A running sum of one numeric measure, keyed by (subject, predicate). */
+interface MeasureSum {
+  subject: Quad['subject'];
+  predicate: Quad['predicate'];
+  graph: Quad['graph'];
+  datatype: string;
+  total: bigint;
+}
+
+function* mergeBuffered(
+  buffered: readonly Quad[],
+  datasetIri: string,
+  namespaceAliases: readonly NamespaceAlias[],
+): Iterable<Quad> {
+  const nodes = indexNodes(buffered);
+  const remap = buildRemap(nodes, datasetIri, namespaceAliases);
+
+  const measureSums = new Map<string, MeasureSum>();
+  const emitted = new Set<string>();
+  const structural: Quad[] = [];
+
+  for (const original of buffered) {
+    const subject = remapTerm(original.subject, remap);
+    const object = canonicalizeObject(
+      remapTerm(original.object, remap),
+      original.predicate.value,
+      namespaceAliases,
+    );
+    const rewritten = quad(subject, original.predicate, object, original.graph);
+
+    if (NUMERIC_MEASURES.has(original.predicate.value)) {
+      accumulateMeasure(measureSums, rewritten);
+      continue;
+    }
+
+    const key = quadKey(rewritten);
+    if (!emitted.has(key)) {
+      emitted.add(key);
+      structural.push(rewritten);
+    }
+  }
+
+  yield* structural;
+  for (const sum of measureSums.values()) {
+    yield reconstructMeasure(sum);
+  }
+}
+
+function indexNodes(buffered: readonly Quad[]): Map<string, NodeIndex> {
+  const nodes = new Map<string, NodeIndex>();
+  const nodeOf = (value: string): NodeIndex => {
+    let node = nodes.get(value);
+    if (!node) {
+      node = { values: new Map() };
+      nodes.set(value, node);
+    }
+    return node;
+  };
+
+  for (const q of buffered) {
+    if (
+      CHILD_LINKS.has(q.predicate.value) &&
+      q.object.termType === 'NamedNode'
+    ) {
+      nodeOf(q.object.value).incomingLink = {
+        predicate: q.predicate.value,
+        parent: q.subject.value,
+      };
+    } else {
+      nodeOf(q.subject.value).values.set(q.predicate.value, q.object);
+    }
+  }
+  return nodes;
+}
+
+/**
+ * Build a raw-IRI → canonical-IRI map for every partition node whose canonical
+ * key differs from its current IRI.
+ */
+function buildRemap(
+  nodes: Map<string, NodeIndex>,
+  datasetIri: string,
+  namespaceAliases: readonly NamespaceAlias[],
+): Map<string, string> {
+  const remap = new Map<string, string>();
+  for (const [iri, node] of nodes) {
+    const canonicalIri = canonicalPartitionIri(
+      node,
+      nodes,
+      datasetIri,
+      namespaceAliases,
+    );
+    if (canonicalIri !== undefined && canonicalIri !== iri) {
+      remap.set(iri, canonicalIri);
+    }
+  }
+  return remap;
+}
+
+/**
+ * The canonical partition IRI for a node, or `undefined` if the node is not a
+ * partition (no incoming structural link). Replicates the queries’ minting:
+ * `<dataset>/.well-known/void#<prefix>-<MD5(STR(component)…)>`.
+ */
+function canonicalPartitionIri(
+  node: NodeIndex,
+  nodes: Map<string, NodeIndex>,
+  datasetIri: string,
+  namespaceAliases: readonly NamespaceAlias[],
+): string | undefined {
+  const link = node.incomingLink;
+  if (link === undefined) return undefined;
+  const canon = (value: string) => canonicalizeIri(value, namespaceAliases);
+  const classOf = (partition: string) =>
+    nodes.get(partition)?.values.get(VOID_CLASS)?.value;
+
+  switch (link.predicate) {
+    case VOID_CLASS_PARTITION: {
+      const klass = node.values.get(VOID_CLASS)?.value;
+      return klass ? mint(datasetIri, 'class', [canon(klass)]) : undefined;
+    }
+    case VOID_PROPERTY_PARTITION: {
+      const klass = classOf(link.parent);
+      const property = node.values.get(VOID_PROPERTY)?.value;
+      return klass && property
+        ? mint(datasetIri, 'class-property', [canon(klass), canon(property)])
+        : undefined;
+    }
+    case VOIDEXT_DATATYPE_PARTITION: {
+      const [klass, property] = classProperty(link.parent, nodes);
+      const datatype = node.values.get(VOIDEXT_DATATYPE)?.value;
+      return klass && property && datatype
+        ? mint(datasetIri, 'datatype', [
+            canon(klass),
+            canon(property),
+            datatype,
+          ])
+        : undefined;
+    }
+    case VOIDEXT_OBJECTCLASS_PARTITION: {
+      const [klass, property] = classProperty(link.parent, nodes);
+      const objectClass = node.values.get(VOID_CLASS)?.value;
+      return klass && property && objectClass
+        ? mint(datasetIri, 'object-class', [
+            canon(klass),
+            canon(property),
+            canon(objectClass),
+          ])
+        : undefined;
+    }
+    case VOIDEXT_LANGUAGE_PARTITION: {
+      const [klass, property] = classProperty(link.parent, nodes);
+      const language = node.values.get(VOIDEXT_LANGUAGE)?.value;
+      return klass && property && language !== undefined
+        ? mint(datasetIri, 'language', [
+            canon(klass),
+            canon(property),
+            language,
+          ])
+        : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+/** The (class, property) of a property partition, following it up to its class partition. */
+function classProperty(
+  propertyPartition: string,
+  nodes: Map<string, NodeIndex>,
+): [string | undefined, string | undefined] {
+  const node = nodes.get(propertyPartition);
+  const property = node?.values.get(VOID_PROPERTY)?.value;
+  const classPartition = node?.incomingLink?.parent;
+  const klass = classPartition
+    ? nodes.get(classPartition)?.values.get(VOID_CLASS)?.value
+    : undefined;
+  return [klass, property];
+}
+
+function mint(
+  datasetIri: string,
+  prefix: string,
+  components: string[],
+): string {
+  const hash = createHash('md5').update(components.join('')).digest('hex');
+  return `${datasetIri}/.well-known/void#${prefix}-${hash}`;
+}
+
+function remapTerm<T extends Term>(term: T, remap: Map<string, string>): T {
+  if (term.termType === 'NamedNode') {
+    const canonical = remap.get(term.value);
+    if (canonical !== undefined) return namedNode(canonical) as unknown as T;
+  }
+  return term;
+}
+
+function canonicalizeObject<T extends Term>(
+  object: T,
+  predicate: string,
+  namespaceAliases: readonly NamespaceAlias[],
+): T {
+  if (
+    CANONICALIZED_OBJECT_PREDICATES.has(predicate) &&
+    object.termType === 'NamedNode'
+  ) {
+    const canonical = canonicalizeIri(object.value, namespaceAliases);
+    if (canonical !== object.value) return namedNode(canonical) as unknown as T;
+  }
+  return object;
+}
+
+function accumulateMeasure(sums: Map<string, MeasureSum>, measure: Quad): void {
+  const key = `${measure.subject.value} ${measure.predicate.value}`;
+  const existing = sums.get(key);
+  if (existing === undefined) {
+    sums.set(key, {
+      subject: measure.subject,
+      predicate: measure.predicate,
+      graph: measure.graph,
+      datatype:
+        measure.object.termType === 'Literal'
+          ? measure.object.datatype.value
+          : XSD_INTEGER,
+      total: parseInteger(measure.object),
+    });
+  } else {
+    existing.total += parseInteger(measure.object);
+  }
+}
+
+function parseInteger(object: Term): bigint {
+  if (object.termType === 'Literal' && /^[+-]?\d+$/.test(object.value)) {
+    return BigInt(object.value);
+  }
+  return 0n;
+}
+
+function reconstructMeasure(sum: MeasureSum): Quad {
+  return quad(
+    sum.subject,
+    sum.predicate,
+    literal(sum.total.toString(), namedNode(sum.datatype)),
+    sum.graph,
+  );
+}
+
+function quadKey(q: Quad): string {
+  return [
+    q.subject.value,
+    q.predicate.value,
+    termKey(q.object),
+    q.graph.value,
+  ].join(' ');
+}
+
+function termKey(term: Term): string {
+  if (term.termType === 'Literal') {
+    return `"${term.value}"^^${term.datatype.value}@${term.language}`;
+  }
+  return term.value;
+}
+
+export { XSD_INTEGER };

--- a/packages/pipeline-void/src/stage.ts
+++ b/packages/pipeline-void/src/stage.ts
@@ -6,6 +6,7 @@ import {
   type AttachedReader,
   type ReaderContext,
   type ItemSelector,
+  type NamespaceAlias,
   type QuadTransform,
 } from '@lde/pipeline';
 import { assertSafeIri } from '@lde/dataset';
@@ -17,6 +18,12 @@ import {
   defaultVocabularies,
 } from './vocabularyTransform.js';
 import { withUriSpaces } from './uriSpaceTransform.js';
+import {
+  canonicalizeClassBindings,
+  substituteNormalizationMarkers,
+  withAliasVariantBindings,
+} from './namespaceAliases.js';
+import { mergeNamespaceVariants } from './partitionMerge.js';
 
 const queriesDir = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -76,6 +83,27 @@ export interface VoidStageOptions {
    * with these, built-in first.
    */
   transform?: VoidStageTransform;
+  /**
+   * Namespace pairs to treat as equivalent when partitioning by class and
+   * property, so alias variants (e.g. `http://schema.org/CreativeWork` and
+   * `https://schema.org/CreativeWork`) merge into a single partition instead
+   * of two that both claim the canonical `void:class`.
+   *
+   * Merging happens after aggregation, in the {@link mergeNamespaceVariants}
+   * transform, which sums `void:entities` / `void:triples`; only
+   * `class-properties-objects.rq` normalizes at query time (its
+   * `void:distinctObjects` cannot be recovered by summing). Correct under the
+   * subject/class- and predicate-namespace-disjointness assumptions documented
+   * on {@link mergeNamespaceVariants}. The top-level property partitions
+   * ({@link detectVocabularies}’s `entity-properties.rq`) and `void:vocabulary`
+   * detection keep the source namespaces, so consumers can still see which
+   * namespace the dataset actually uses.
+   *
+   * Defaults to no aliases. To cover schema.org datasets that publish under
+   * both `http://schema.org/` and `https://schema.org/`, pass
+   * `[{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }]`.
+   */
+  namespaceAliases?: readonly NamespaceAlias[];
 }
 
 /**
@@ -123,22 +151,42 @@ async function createVoidStage(
   filename: VoidStageName,
   options?: {
     transform?: VoidStageTransform;
+    namespaceAliases?: readonly NamespaceAlias[];
+    mergePartitions?: boolean;
     perClass?: boolean;
     batchSize?: number;
     maxConcurrency?: number;
     expectsOutput?: boolean;
   },
 ): Promise<Stage> {
-  const query = await readQueryFile(resolve(queriesDir, filename));
+  const namespaceAliases = options?.namespaceAliases ?? [];
+  const query = substituteNormalizationMarkers(
+    await readQueryFile(resolve(queriesDir, filename)),
+    namespaceAliases,
+  );
+  const constructReader = new SparqlConstructReader({ query });
+  // Partition stages merge their namespace-alias variants (e.g. http:// and
+  // https://schema.org/) into one partition per canonical class/property.
+  // Runs first, so any consumer transform sees the already-merged output.
+  const mergeTransform =
+    options?.mergePartitions && namespaceAliases.length > 0
+      ? [mergeNamespaceVariants(namespaceAliases)]
+      : [];
   const reader: AttachedReader = {
-    reader: new SparqlConstructReader({ query }),
-    transform: options?.transform,
+    // Per-class stages receive canonical `?class` bindings from the
+    // selector; expand each to its alias variants as `?rawClass` bindings.
+    reader: options?.perClass
+      ? withAliasVariantBindings(constructReader, namespaceAliases)
+      : constructReader,
+    transform: [...mergeTransform, ...asTransforms(options?.transform)],
   };
 
   return new Stage({
     name: filename,
     readers: reader,
-    itemSelector: options?.perClass ? classSelector() : undefined,
+    itemSelector: options?.perClass
+      ? classSelector(namespaceAliases)
+      : undefined,
     batchSize: options?.batchSize,
     maxConcurrency: options?.maxConcurrency,
     expectsOutput: options?.expectsOutput,
@@ -153,7 +201,9 @@ function asTransforms(
   return Array.isArray(transform) ? [...transform] : [transform];
 }
 
-function classSelector(): ItemSelector {
+function classSelector(
+  namespaceAliases: readonly NamespaceAlias[],
+): ItemSelector {
   return {
     // Forward `options` so the Pipeline’s per-dataset TimeoutPolicy
     // reaches the inner SparqlItemSelector — without this the adaptive
@@ -172,9 +222,10 @@ function classSelector(): ItemSelector {
         'LIMIT 1000',
       ].join('\n');
 
-      return new SparqlItemSelector({
+      const rows = new SparqlItemSelector({
         query: selectorQuery,
       }).select(distribution, batchSize, options);
+      return canonicalizeClassBindings(rows, namespaceAliases);
     },
   };
 }
@@ -186,7 +237,10 @@ export function subjectUriSpaces(options?: VoidStageOptions): Promise<Stage> {
 }
 
 export function classPartitions(options?: VoidStageOptions): Promise<Stage> {
-  return createVoidStage(VOID_STAGE_NAMES.classPartitions, options);
+  return createVoidStage(VOID_STAGE_NAMES.classPartitions, {
+    ...options,
+    mergePartitions: true,
+  });
 }
 
 // Scalar-aggregate counts: each query is a single COUNT with no GROUP BY/HAVING,
@@ -237,6 +291,7 @@ export function classPropertySubjects(
   return createVoidStage(VOID_STAGE_NAMES.classPropertySubjects, {
     ...options,
     perClass: options?.perClass ?? true,
+    mergePartitions: true,
   });
 }
 
@@ -268,6 +323,7 @@ export function perClassObjectClasses(
   return createVoidStage(VOID_STAGE_NAMES.perClassObjectClasses, {
     ...options,
     perClass: options?.perClass ?? true,
+    mergePartitions: true,
   });
 }
 
@@ -277,6 +333,7 @@ export function perClassDatatypes(
   return createVoidStage(VOID_STAGE_NAMES.perClassDatatypes, {
     ...options,
     perClass: options?.perClass ?? true,
+    mergePartitions: true,
   });
 }
 
@@ -286,6 +343,7 @@ export function perClassLanguages(
   return createVoidStage(VOID_STAGE_NAMES.perClassLanguages, {
     ...options,
     perClass: options?.perClass ?? true,
+    mergePartitions: true,
   });
 }
 

--- a/packages/pipeline-void/src/stage.ts
+++ b/packages/pipeline-void/src/stage.ts
@@ -173,8 +173,9 @@ async function createVoidStage(
       ? [mergeNamespaceVariants(namespaceAliases)]
       : [];
   const reader: AttachedReader = {
-    // Per-class stages receive canonical `?class` bindings from the
-    // selector; expand each to its alias variants as `?rawClass` bindings.
+    // Per-class stages receive canonical `?class` bindings from the selector;
+    // expand each into one `?class` binding per alias variant so the query
+    // (`?s a ?class`) matches instances under either namespace.
     reader: options?.perClass
       ? withAliasVariantBindings(constructReader, namespaceAliases)
       : constructReader,

--- a/packages/pipeline-void/test/fixtures/dualTypedNamespaces.ttl
+++ b/packages/pipeline-void/test/fixtures/dualTypedNamespaces.ttl
@@ -1,0 +1,8 @@
+@prefix schema: <https://schema.org/> .
+@prefix schemahttp: <http://schema.org/> .
+
+# A single resource typed under BOTH namespace variants of the same class —
+# violating the merge transform’s subject/class-disjointness assumption. Used
+# to pin the documented consequence: its class-partition entities over-count
+# (summed as 1 + 1 = 2 rather than the exact distinct count of 1).
+<http://example.org/thing> a schemahttp:CreativeWork, schema:CreativeWork .

--- a/packages/pipeline-void/test/fixtures/mixedNamespaces.ttl
+++ b/packages/pipeline-void/test/fixtures/mixedNamespaces.ttl
@@ -1,0 +1,25 @@
+@prefix schema: <https://schema.org/> .
+@prefix schemahttp: <http://schema.org/> .
+
+# Two disjoint subsets of schema:CreativeWork instances — one typed under the
+# http:// namespace, one under https:// — as seen in netwerk-digitaal-erfgoed/
+# dataset-knowledge-graph#334. Subjects are disjoint across the two namespaces
+# (the merge transform’s disjointness assumption).
+
+# http-namespace subset
+<http://example.org/work1> a schemahttp:CreativeWork ;
+  schemahttp:name "A" .
+
+<http://example.org/work2> a schemahttp:CreativeWork ;
+  schemahttp:name "Shared" .
+
+# https-namespace subset
+<http://example.org/work3> a schema:CreativeWork ;
+  schema:name "Shared" ;              # same object value as work2’s http:name
+  schema:description "Werk 3"@nl ;    # exercises the language partition
+  schema:author <http://example.org/person1> .  # exercises the object-class partition
+
+<http://example.org/work4> a schema:CreativeWork ;
+  schema:name "B" .
+
+<http://example.org/person1> a schema:Person .

--- a/packages/pipeline-void/test/namespaceAliases.test.ts
+++ b/packages/pipeline-void/test/namespaceAliases.test.ts
@@ -1,0 +1,123 @@
+import {
+  canonicalizeClassBindings,
+  substituteNormalizationMarkers,
+  withAliasVariantBindings,
+} from '../src/index.js';
+import type { NamespaceAlias } from '../src/index.js';
+import type { Reader, VariableBindings } from '@lde/pipeline';
+import { Dataset, Distribution } from '@lde/dataset';
+import type { Quad } from '@rdfjs/types';
+import { DataFactory } from 'n3';
+import { describe, it, expect, vi } from 'vitest';
+
+const { namedNode } = DataFactory;
+
+async function* noQuads() {
+  yield* [] as Quad[];
+}
+
+const schemaOrgAlias: NamespaceAlias = {
+  canonical: 'https://schema.org/',
+  alias: 'http://schema.org/',
+};
+
+describe('substituteNormalizationMarkers', () => {
+  it('expands a marker to the bare variable without aliases', () => {
+    expect(
+      substituteNormalizationMarkers('BIND(#normalized:rawType# AS ?type)', []),
+    ).toBe('BIND(?rawType AS ?type)');
+  });
+
+  it('expands a marker to a rewrite expression per alias', () => {
+    expect(
+      substituteNormalizationMarkers('BIND(#normalized:rawType# AS ?type)', [
+        schemaOrgAlias,
+      ]),
+    ).toBe(
+      'BIND(IF(STRSTARTS(STR(?rawType), "http://schema.org/"), IRI(CONCAT("https://schema.org/", STRAFTER(STR(?rawType), "http://schema.org/"))), ?rawType) AS ?type)',
+    );
+  });
+
+  it('replaces every marker in the query', () => {
+    const substituted = substituteNormalizationMarkers(
+      'BIND(#normalized:rawClass# AS ?class) BIND(#normalized:rawProperty# AS ?p)',
+      [],
+    );
+    expect(substituted).toBe(
+      'BIND(?rawClass AS ?class) BIND(?rawProperty AS ?p)',
+    );
+  });
+
+  it('rejects namespaces that cannot be interpolated safely', () => {
+    expect(() =>
+      substituteNormalizationMarkers('#normalized:rawType#', [
+        { canonical: 'https://schema.org/', alias: 'http://schema.org/"' },
+      ]),
+    ).toThrow('unsafe characters');
+  });
+});
+
+describe('canonicalizeClassBindings', () => {
+  it('canonicalizes alias-namespace classes and deduplicates variants', async () => {
+    const rows = (async function* () {
+      yield { class: namedNode('http://schema.org/CreativeWork') };
+      yield { class: namedNode('https://schema.org/CreativeWork') };
+      yield { class: namedNode('http://example.org/Other') };
+    })();
+
+    const result: VariableBindings[] = [];
+    for await (const row of canonicalizeClassBindings(rows, [schemaOrgAlias])) {
+      result.push(row);
+    }
+
+    expect(result).toEqual([
+      { class: namedNode('https://schema.org/CreativeWork') },
+      { class: namedNode('http://example.org/Other') },
+    ]);
+  });
+});
+
+describe('withAliasVariantBindings', () => {
+  const dataset = new Dataset({
+    iri: new URL('http://example.org/dataset'),
+    distributions: [],
+  });
+  const distribution = Distribution.sparql(
+    new URL('http://example.org/sparql'),
+  );
+
+  it('expands each canonical class to one class binding per variant', async () => {
+    const inner: Reader = {
+      read: vi.fn(async () => noQuads()),
+    };
+    const reader = withAliasVariantBindings(inner, [schemaOrgAlias]);
+
+    await reader.read(dataset, distribution, {
+      bindings: [
+        { class: namedNode('https://schema.org/CreativeWork') },
+        { class: namedNode('http://example.org/Other') },
+      ],
+    });
+
+    expect(inner.read).toHaveBeenCalledWith(dataset, distribution, {
+      bindings: [
+        { class: namedNode('https://schema.org/CreativeWork') },
+        { class: namedNode('http://schema.org/CreativeWork') },
+        { class: namedNode('http://example.org/Other') },
+      ],
+    });
+  });
+
+  it('passes through calls without bindings', async () => {
+    const inner: Reader = {
+      read: vi.fn(async () => noQuads()),
+    };
+    const reader = withAliasVariantBindings(inner, [schemaOrgAlias]);
+
+    await reader.read(dataset, distribution);
+
+    expect(inner.read).toHaveBeenCalledWith(dataset, distribution, {
+      bindings: undefined,
+    });
+  });
+});

--- a/packages/pipeline-void/test/namespaceNormalization.integration.test.ts
+++ b/packages/pipeline-void/test/namespaceNormalization.integration.test.ts
@@ -175,6 +175,20 @@ describe('namespace-alias normalization (end to end)', () => {
       )
       .map((q) => q.object.value);
     expect(objectClasses).toEqual(['https://schema.org/Person']);
+
+    // The self-describe chain must not leak a duplicate class partition: the
+    // http- and https-variant class partitions these stages emit have to
+    // collapse to a single node, or the duplicate this feature removes returns.
+    const creativeWorkClassPartitions = new Set(
+      quads
+        .filter(
+          (q) =>
+            q.predicate.value === `${VOID}class` &&
+            q.object.value === CREATIVE_WORK,
+        )
+        .map((q) => q.subject.value),
+    );
+    expect(creativeWorkClassPartitions.size).toBe(1);
   }, 30_000);
 
   it('emits two class partitions when no aliases are configured', async () => {

--- a/packages/pipeline-void/test/namespaceNormalization.integration.test.ts
+++ b/packages/pipeline-void/test/namespaceNormalization.integration.test.ts
@@ -1,0 +1,227 @@
+import {
+  classPartitions,
+  classPropertyObjects,
+  classPropertySubjects,
+  perClassDatatypes,
+  perClassLanguages,
+  perClassObjectClasses,
+  Stage,
+} from '../src/index.js';
+import type { NamespaceAlias } from '../src/index.js';
+import { Dataset, Distribution } from '@lde/dataset';
+import type { DatasetWriter } from '@lde/pipeline';
+import {
+  startSparqlEndpoint,
+  teardownSparqlEndpoint,
+} from '@lde/local-sparql-endpoint';
+import type { Quad } from '@rdfjs/types';
+import { fetch as undiciFetch, setGlobalDispatcher, Agent } from 'undici';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+const fixture = (name: string) =>
+  fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url));
+
+// The @lde/pipeline import chain pulls in a package copy of undici (via
+// rdf-parse → @comunica/actor-http-fetch) whose module init registers its
+// global dispatcher under the symbol Node’s built-in fetch also reads. Mixing
+// Node’s fetch with a foreign-version dispatcher fails on some Node versions
+// (“invalid content-length header”), so pin fetch and dispatcher to one and
+// the same undici copy for this endpoint-backed test.
+setGlobalDispatcher(new Agent());
+globalThis.fetch = undiciFetch as unknown as typeof globalThis.fetch;
+
+const namespaceAliases: NamespaceAlias[] = [
+  { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+];
+
+const VOID = 'http://rdfs.org/ns/void#';
+const VOID_EXT = 'http://ldf.fi/void-ext#';
+const CREATIVE_WORK = 'https://schema.org/CreativeWork';
+
+const dataset = new Dataset({
+  iri: new URL('http://example.org/dataset'),
+  distributions: [],
+});
+
+function collectingWriter(): DatasetWriter & { quads: Quad[] } {
+  const quads: Quad[] = [];
+  return {
+    quads,
+    async write(_dataset, data) {
+      for await (const quad of data) quads.push(quad);
+    },
+  };
+}
+
+async function runAll(
+  stages: Stage[],
+  distribution: Distribution,
+): Promise<Quad[]> {
+  const writer = collectingWriter();
+  for (const stage of stages) {
+    await stage.run(dataset, distribution, writer);
+  }
+  return writer.quads;
+}
+
+function objectsOf(quads: Quad[], subject: string, predicate: string) {
+  return quads
+    .filter(
+      (q) => q.subject.value === subject && q.predicate.value === predicate,
+    )
+    .map((q) => q.object.value);
+}
+
+/** The single value of `subject predicate ?o`, expected to be unique. */
+function only(quads: Quad[], subject: string, predicate: string): string {
+  const values = objectsOf(quads, subject, predicate);
+  expect(values).toHaveLength(1);
+  return values[0];
+}
+
+describe('namespace-alias normalization (end to end)', () => {
+  const port = 3005;
+  const distribution = () =>
+    Distribution.sparql(new URL(`http://localhost:${port}/sparql`));
+
+  beforeAll(async () => {
+    await startSparqlEndpoint(port, fixture('mixedNamespaces.ttl'));
+  }, 60_000);
+
+  afterAll(async () => {
+    await teardownSparqlEndpoint();
+  }, 30_000);
+
+  it('merges the class partition and sums entities over disjoint variants', async () => {
+    const quads = await runAll(
+      [await classPartitions({ namespaceAliases })],
+      distribution(),
+    );
+
+    const creativeWorkPartitions = quads.filter(
+      (q) =>
+        q.predicate.value === `${VOID}class` &&
+        q.object.value === CREATIVE_WORK,
+    );
+    expect(creativeWorkPartitions).toHaveLength(1);
+    // work1,work2 (http) + work3,work4 (https), disjoint → 4.
+    expect(
+      only(quads, creativeWorkPartitions[0].subject.value, `${VOID}entities`),
+    ).toBe('4');
+  }, 30_000);
+
+  it('merges the property partition and keeps distinctObjects exact', async () => {
+    const quads = await runAll(
+      [
+        await classPropertySubjects({ namespaceAliases, batchSize: 1 }),
+        await classPropertyObjects({ namespaceAliases, batchSize: 1 }),
+      ],
+      distribution(),
+    );
+
+    const nameProperties = quads.filter(
+      (q) =>
+        q.predicate.value === `${VOID}property` &&
+        q.object.value === 'https://schema.org/name',
+    );
+    expect(nameProperties).toHaveLength(1);
+    const namePartition = nameProperties[0].subject.value;
+
+    // Subjects with name: work1..work4, summed across variants (predicate-disjoint) → 4.
+    expect(only(quads, namePartition, `${VOID}entities`)).toBe('4');
+
+    // distinctObjects stays exact: {"A","Shared","B"} = 3 — work2’s http:name
+    // "Shared" and work3’s https:name "Shared" collapse. A naive sum would be 4.
+    expect(only(quads, namePartition, `${VOID}distinctObjects`)).toBe('3');
+  }, 30_000);
+
+  it('merges the void-ext partitions (datatype, language, object class)', async () => {
+    const quads = await runAll(
+      [
+        await perClassDatatypes({ namespaceAliases, batchSize: 1 }),
+        await perClassLanguages({ namespaceAliases, batchSize: 1 }),
+        await perClassObjectClasses({ namespaceAliases, batchSize: 1 }),
+      ],
+      distribution(),
+    );
+
+    // One datatype partition for (CreativeWork, name, xsd:string): 4 name
+    // triples across both namespace variants (the @nl description literal
+    // makes a separate rdf:langString partition, excluded here).
+    const stringDatatypePartitions = quads.filter(
+      (q) =>
+        q.predicate.value === `${VOID_EXT}datatype` &&
+        q.object.value === 'http://www.w3.org/2001/XMLSchema#string',
+    );
+    expect(stringDatatypePartitions).toHaveLength(1);
+    expect(
+      only(quads, stringDatatypePartitions[0].subject.value, `${VOID}triples`),
+    ).toBe('4');
+
+    // Language partition for (CreativeWork, description, nl): work3 only.
+    const languagePartitions = quads.filter(
+      (q) => q.predicate.value === `${VOID_EXT}language`,
+    );
+    expect(languagePartitions).toHaveLength(1);
+    expect(languagePartitions[0].object.value).toBe('nl');
+
+    // Object-class partition for (CreativeWork, author, Person): canonicalized.
+    const objectClasses = quads
+      .filter(
+        (q) =>
+          q.predicate.value === `${VOID}class` &&
+          q.object.value.endsWith('/Person'),
+      )
+      .map((q) => q.object.value);
+    expect(objectClasses).toEqual(['https://schema.org/Person']);
+  }, 30_000);
+
+  it('emits two class partitions when no aliases are configured', async () => {
+    const quads = await runAll([await classPartitions()], distribution());
+    const creativeWorkVariants = quads
+      .filter(
+        (q) =>
+          q.predicate.value === `${VOID}class` &&
+          q.object.value.includes('CreativeWork'),
+      )
+      .map((q) => q.object.value)
+      .sort();
+    expect(creativeWorkVariants).toEqual([
+      'http://schema.org/CreativeWork',
+      'https://schema.org/CreativeWork',
+    ]);
+  }, 30_000);
+});
+
+describe('namespace-alias normalization (disjointness violation)', () => {
+  const port = 3006;
+  const distribution = () =>
+    Distribution.sparql(new URL(`http://localhost:${port}/sparql`));
+
+  beforeAll(async () => {
+    await startSparqlEndpoint(port, fixture('dualTypedNamespaces.ttl'));
+  }, 60_000);
+
+  afterAll(async () => {
+    await teardownSparqlEndpoint();
+  }, 30_000);
+
+  it('over-counts entities for a resource typed under both namespace variants', async () => {
+    const quads = await runAll(
+      [await classPartitions({ namespaceAliases })],
+      distribution(),
+    );
+    const creativeWorkPartitions = quads.filter(
+      (q) =>
+        q.predicate.value === `${VOID}class` &&
+        q.object.value === CREATIVE_WORK,
+    );
+    expect(creativeWorkPartitions).toHaveLength(1);
+    // Documented limitation: the doubly-typed resource is summed 1 + 1 = 2,
+    // not deduped to 1. The transform assumes this case does not occur.
+    expect(
+      only(quads, creativeWorkPartitions[0].subject.value, `${VOID}entities`),
+    ).toBe('2');
+  }, 30_000);
+});

--- a/packages/pipeline-void/test/partitionMerge.test.ts
+++ b/packages/pipeline-void/test/partitionMerge.test.ts
@@ -125,12 +125,15 @@ describe('mergeNamespaceVariants', () => {
   });
 
   it('merges a datatype-partition subtree via the cp→pp→dp chain', async () => {
-    // Two full chains, http and https, over the same canonical class+property+datatype.
+    // Two full chains, http and https, with DISTINCT class-partition IRIs (as
+    // the real per-class query mints them) and the `dataset void:classPartition`
+    // link that lets the transform re-key the class partition too.
     const chain = (classIri: string, propIri: string) => {
-      const cpNode = namedNode(`${DATASET}/#cp`); // placeholder IRIs; transform re-keys by components
+      const cpNode = namedNode(`${DATASET}/#cp-${classIri}`);
       const ppNode = namedNode(`${DATASET}/#pp-${classIri}-${propIri}`);
       const dpNode = namedNode(`${DATASET}/#dp-${classIri}-${propIri}`);
       return [
+        quad(namedNode(DATASET), v('classPartition'), cpNode),
         quad(cpNode, v('class'), namedNode(classIri)),
         quad(cpNode, v('propertyPartition'), ppNode),
         quad(ppNode, v('property'), namedNode(propIri)),
@@ -156,6 +159,13 @@ describe('mergeNamespaceVariants', () => {
       .filter((q) => q.predicate.value === `${VOID}property`)
       .map((q) => q.object.value);
     expect(new Set(properties)).toEqual(new Set(['https://schema.org/name']));
+    // The class partition collapses to a single node (no leaked alias variant).
+    const classPartitions = new Set(
+      out
+        .filter((q) => q.predicate.value === `${VOID}class`)
+        .map((q) => q.subject.value),
+    );
+    expect(classPartitions.size).toBe(1);
   });
 
   it('merges object-class partitions, canonicalizing the object class', async () => {

--- a/packages/pipeline-void/test/partitionMerge.test.ts
+++ b/packages/pipeline-void/test/partitionMerge.test.ts
@@ -1,0 +1,313 @@
+import { mergeNamespaceVariants } from '../src/index.js';
+import type { NamespaceAlias } from '../src/index.js';
+import { Dataset, Distribution } from '@lde/dataset';
+import type { Quad } from '@rdfjs/types';
+import { DataFactory } from 'n3';
+import { describe, it, expect } from 'vitest';
+
+const { namedNode, literal, quad } = DataFactory;
+
+const schemaOrg: NamespaceAlias[] = [
+  { canonical: 'https://schema.org/', alias: 'http://schema.org/' },
+];
+
+const DATASET = 'http://example.org/dataset';
+const VOID = 'http://rdfs.org/ns/void#';
+const VOID_EXT = 'http://ldf.fi/void-ext#';
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
+
+// MD5s produced by the queries’ SPARQL `MD5(STR(?type))`, verified against the
+// live endpoint (issue #334): the two CreativeWork partition hashes.
+const HTTP_CW_HASH = '243a6fef650ffe66d349d33dab497039';
+const HTTPS_CW_HASH = 'abb86c011bcc584d50e50bf8f079120a';
+
+const cp = (hash: string) => `${DATASET}/.well-known/void#class-${hash}`;
+
+function v(local: string) {
+  return namedNode(`${VOID}${local}`);
+}
+function ve(local: string) {
+  return namedNode(`${VOID_EXT}${local}`);
+}
+function integer(value: number) {
+  return literal(String(value), namedNode(`${XSD}integer`));
+}
+
+const context = {
+  dataset: new Dataset({ iri: new URL(DATASET), distributions: [] }),
+  distribution: Distribution.sparql(new URL('http://example.org/sparql')),
+  stage: 'test',
+};
+
+async function run(
+  input: Quad[],
+  aliases: NamespaceAlias[] = schemaOrg,
+): Promise<Quad[]> {
+  const transform = mergeNamespaceVariants(aliases);
+  const source = (async function* () {
+    yield* input;
+  })();
+  const out: Quad[] = [];
+  for await (const q of transform(source, context)) out.push(q);
+  return out;
+}
+
+function objectsOf(quads: Quad[], subject: string, predicate: string) {
+  return quads
+    .filter(
+      (q) => q.subject.value === subject && q.predicate.value === predicate,
+    )
+    .map((q) => q.object.value);
+}
+
+describe('mergeNamespaceVariants', () => {
+  it('mints the canonical class-partition IRI matching the SPARQL MD5', async () => {
+    const input = [
+      quad(
+        namedNode(cp(HTTP_CW_HASH)),
+        v('class'),
+        namedNode('http://schema.org/CreativeWork'),
+      ),
+      quad(
+        namedNode(DATASET),
+        v('classPartition'),
+        namedNode(cp(HTTP_CW_HASH)),
+      ),
+      quad(namedNode(cp(HTTP_CW_HASH)), v('entities'), integer(3278)),
+    ];
+    const out = await run(input);
+
+    // The http variant is re-keyed onto the canonical https hash.
+    const partitions = objectsOf(out, DATASET, `${VOID}classPartition`);
+    expect(partitions).toEqual([cp(HTTPS_CW_HASH)]);
+  });
+
+  it('merges the two CreativeWork class partitions into one, summing entities', async () => {
+    const input = [
+      quad(
+        namedNode(DATASET),
+        namedNode(`${XSD}../1999/02/22-rdf-syntax-ns#type`),
+        v('Dataset'),
+      ),
+      quad(
+        namedNode(DATASET),
+        v('classPartition'),
+        namedNode(cp(HTTP_CW_HASH)),
+      ),
+      quad(
+        namedNode(cp(HTTP_CW_HASH)),
+        v('class'),
+        namedNode('http://schema.org/CreativeWork'),
+      ),
+      quad(namedNode(cp(HTTP_CW_HASH)), v('entities'), integer(3278)),
+      quad(
+        namedNode(DATASET),
+        v('classPartition'),
+        namedNode(cp(HTTPS_CW_HASH)),
+      ),
+      quad(
+        namedNode(cp(HTTPS_CW_HASH)),
+        v('class'),
+        namedNode('https://schema.org/CreativeWork'),
+      ),
+      quad(namedNode(cp(HTTPS_CW_HASH)), v('entities'), integer(511)),
+    ];
+    const out = await run(input);
+
+    const partitions = objectsOf(out, DATASET, `${VOID}classPartition`);
+    expect(partitions).toEqual([cp(HTTPS_CW_HASH)]);
+    expect(objectsOf(out, cp(HTTPS_CW_HASH), `${VOID}class`)).toEqual([
+      'https://schema.org/CreativeWork',
+    ]);
+    expect(objectsOf(out, cp(HTTPS_CW_HASH), `${VOID}entities`)).toEqual([
+      '3789',
+    ]);
+  });
+
+  it('merges a datatype-partition subtree via the cp→pp→dp chain', async () => {
+    // Two full chains, http and https, over the same canonical class+property+datatype.
+    const chain = (classIri: string, propIri: string) => {
+      const cpNode = namedNode(`${DATASET}/#cp`); // placeholder IRIs; transform re-keys by components
+      const ppNode = namedNode(`${DATASET}/#pp-${classIri}-${propIri}`);
+      const dpNode = namedNode(`${DATASET}/#dp-${classIri}-${propIri}`);
+      return [
+        quad(cpNode, v('class'), namedNode(classIri)),
+        quad(cpNode, v('propertyPartition'), ppNode),
+        quad(ppNode, v('property'), namedNode(propIri)),
+        quad(ppNode, ve('datatypePartition'), dpNode),
+        quad(dpNode, ve('datatype'), namedNode(`${XSD}string`)),
+        quad(dpNode, v('triples'), integer(3)),
+      ];
+    };
+    const input = [
+      ...chain('http://schema.org/CreativeWork', 'http://schema.org/name'),
+      ...chain('https://schema.org/CreativeWork', 'https://schema.org/name'),
+    ];
+    const out = await run(input);
+
+    const datatypePartitions = out.filter(
+      (q) => q.predicate.value === `${VOID_EXT}datatype`,
+    );
+    expect(datatypePartitions).toHaveLength(1);
+    const dp = datatypePartitions[0].subject.value;
+    expect(objectsOf(out, dp, `${VOID}triples`)).toEqual(['6']);
+    // Class and property canonicalized to https.
+    const properties = out
+      .filter((q) => q.predicate.value === `${VOID}property`)
+      .map((q) => q.object.value);
+    expect(new Set(properties)).toEqual(new Set(['https://schema.org/name']));
+  });
+
+  it('merges object-class partitions, canonicalizing the object class', async () => {
+    const chain = (
+      classIri: string,
+      propIri: string,
+      objectClassIri: string,
+    ) => {
+      const cpNode = namedNode(`${DATASET}/#cp-${classIri}`);
+      const ppNode = namedNode(`${DATASET}/#pp-${classIri}-${propIri}`);
+      const ocpNode = namedNode(
+        `${DATASET}/#ocp-${classIri}-${propIri}-${objectClassIri}`,
+      );
+      return [
+        quad(cpNode, v('class'), namedNode(classIri)),
+        quad(cpNode, v('propertyPartition'), ppNode),
+        quad(ppNode, v('property'), namedNode(propIri)),
+        quad(ppNode, ve('objectClassPartition'), ocpNode),
+        quad(ocpNode, v('class'), namedNode(objectClassIri)),
+        quad(ocpNode, v('triples'), integer(2)),
+      ];
+    };
+    const input = [
+      ...chain(
+        'http://schema.org/CreativeWork',
+        'http://schema.org/author',
+        'http://schema.org/Person',
+      ),
+      ...chain(
+        'https://schema.org/CreativeWork',
+        'https://schema.org/author',
+        'https://schema.org/Person',
+      ),
+    ];
+    const out = await run(input);
+
+    const objectClassPartitions = out.filter(
+      (q) =>
+        q.predicate.value === `${VOID}class` &&
+        q.object.value.endsWith('/Person'),
+    );
+    expect(objectClassPartitions).toHaveLength(1);
+    expect(objectClassPartitions[0].object.value).toBe(
+      'https://schema.org/Person',
+    );
+    const ocp = objectClassPartitions[0].subject.value;
+    expect(objectsOf(out, ocp, `${VOID}triples`)).toEqual(['4']);
+  });
+
+  it('merges language partitions by (class, property, lang)', async () => {
+    const chain = (classIri: string, propIri: string) => {
+      const cpNode = namedNode(`${DATASET}/#cp-${classIri}`);
+      const ppNode = namedNode(`${DATASET}/#pp-${classIri}-${propIri}`);
+      const lpNode = namedNode(`${DATASET}/#lp-${classIri}-${propIri}`);
+      return [
+        quad(cpNode, v('class'), namedNode(classIri)),
+        quad(cpNode, v('propertyPartition'), ppNode),
+        quad(ppNode, v('property'), namedNode(propIri)),
+        quad(ppNode, ve('languagePartition'), lpNode),
+        quad(lpNode, ve('language'), literal('nl')),
+        quad(lpNode, v('triples'), integer(5)),
+      ];
+    };
+    const input = [
+      ...chain('http://schema.org/CreativeWork', 'http://schema.org/name'),
+      ...chain('https://schema.org/CreativeWork', 'https://schema.org/name'),
+    ];
+    const out = await run(input);
+
+    const languagePartitions = out.filter(
+      (q) => q.predicate.value === `${VOID_EXT}language`,
+    );
+    expect(languagePartitions).toHaveLength(1);
+    const lp = languagePartitions[0].subject.value;
+    expect(objectsOf(out, lp, `${VOID}triples`)).toEqual(['10']);
+  });
+
+  it('leaves a non-integer measure literal as a zero-summed passthrough', async () => {
+    const input = [
+      quad(
+        namedNode(DATASET),
+        v('classPartition'),
+        namedNode(cp(HTTP_CW_HASH)),
+      ),
+      quad(
+        namedNode(cp(HTTP_CW_HASH)),
+        v('class'),
+        namedNode('http://schema.org/CreativeWork'),
+      ),
+      quad(namedNode(cp(HTTP_CW_HASH)), v('entities'), literal('not-a-number')),
+    ];
+    const out = await run(input);
+    expect(objectsOf(out, cp(HTTPS_CW_HASH), `${VOID}entities`)).toEqual(['0']);
+  });
+
+  it('leaves a partition node missing its components unremapped', async () => {
+    // A class partition whose node carries no void:class, and a property
+    // partition whose parent class is absent: neither can be re-keyed, so both
+    // pass through untouched.
+    const orphanProperty = namedNode(`${DATASET}/#orphan-pp`);
+    const input = [
+      quad(
+        namedNode(DATASET),
+        v('classPartition'),
+        namedNode(cp(HTTP_CW_HASH)),
+      ),
+      // no void:class on the class partition
+      quad(namedNode(cp(HTTP_CW_HASH)), v('entities'), integer(3278)),
+      // property partition with no reachable parent class
+      quad(orphanProperty, v('property'), namedNode('http://schema.org/name')),
+      quad(orphanProperty, v('entities'), integer(1)),
+    ];
+    const out = await run(input);
+    // Neither node is re-keyed (both lack the components to mint a canonical
+    // IRI), so their subjects are unchanged.
+    expect(objectsOf(out, DATASET, `${VOID}classPartition`)).toEqual([
+      cp(HTTP_CW_HASH),
+    ]);
+    expect(objectsOf(out, orphanProperty.value, `${VOID}entities`)).toEqual([
+      '1',
+    ]);
+    // The void:property *object* is still canonicalized (that is unconditional).
+    expect(objectsOf(out, orphanProperty.value, `${VOID}property`)).toEqual([
+      'https://schema.org/name',
+    ]);
+  });
+
+  it('is a no-op with no aliases configured', async () => {
+    const input = [
+      quad(
+        namedNode(DATASET),
+        v('classPartition'),
+        namedNode(cp(HTTP_CW_HASH)),
+      ),
+      quad(
+        namedNode(cp(HTTP_CW_HASH)),
+        v('class'),
+        namedNode('http://schema.org/CreativeWork'),
+      ),
+      quad(namedNode(cp(HTTP_CW_HASH)), v('entities'), integer(3278)),
+    ];
+    const out = await run(input, []);
+    expect(out).toEqual(input);
+  });
+
+  it('passes non-partition quads through unchanged', async () => {
+    const unrelated = quad(
+      namedNode('http://example.org/thing'),
+      namedNode('http://purl.org/dc/terms/title'),
+      literal('Untitled'),
+    );
+    const out = await run([unrelated]);
+    expect(out).toEqual([unrelated]);
+  });
+});

--- a/packages/pipeline-void/tsconfig.lib.json
+++ b/packages/pipeline-void/tsconfig.lib.json
@@ -10,10 +10,13 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../dataset/tsconfig.lib.json"
+      "path": "../local-sparql-endpoint/tsconfig.lib.json"
     },
     {
       "path": "../pipeline/tsconfig.lib.json"
+    },
+    {
+      "path": "../dataset/tsconfig.lib.json"
     }
   ],
   "exclude": [

--- a/packages/pipeline-void/vite.config.ts
+++ b/packages/pipeline-void/vite.config.ts
@@ -10,10 +10,10 @@ export default mergeConfig(
     test: {
       coverage: {
         thresholds: {
-          functions: 96.66,
-          lines: 91.76,
-          branches: 88.37,
-          statements: 92.13,
+          functions: 100,
+          lines: 98.66,
+          branches: 93.54,
+          statements: 98.72,
         },
       },
     },

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -1,4 +1,5 @@
 export * from './validator.js';
+export * from './namespaceAlias.js';
 export * from './asyncQueue.js';
 export * from './batch.js';
 export * from './pipeline.js';

--- a/packages/pipeline/src/namespaceAlias.ts
+++ b/packages/pipeline/src/namespaceAlias.ts
@@ -1,0 +1,52 @@
+/**
+ * Declares that two namespaces should be treated as equivalent, working
+ * around vocabularies that publish under both HTTP and HTTPS variants of the
+ * same IRI (notably schema.org).
+ */
+export interface NamespaceAlias {
+  /**
+   * The namespace IRIs should be normalized to (e.g. `https://schema.org/`).
+   */
+  canonical: string;
+  /**
+   * The equivalent namespace that may appear in source data (e.g.
+   * `http://schema.org/`).
+   */
+  alias: string;
+}
+
+/**
+ * Rewrite an IRI in an alias namespace to its canonical form. IRIs outside
+ * every alias namespace are returned unchanged.
+ */
+export function canonicalizeIri(
+  iri: string,
+  namespaceAliases: readonly NamespaceAlias[],
+): string {
+  for (const { canonical, alias } of namespaceAliases) {
+    if (iri.startsWith(alias)) {
+      return canonical + iri.slice(alias.length);
+    }
+  }
+  return iri;
+}
+
+/**
+ * All equivalent forms of an IRI under the given aliases: the IRI itself
+ * plus, when it falls in a canonical or alias namespace, the counterpart in
+ * the other namespace.
+ */
+export function aliasVariants(
+  iri: string,
+  namespaceAliases: readonly NamespaceAlias[],
+): string[] {
+  for (const { canonical, alias } of namespaceAliases) {
+    if (iri.startsWith(canonical)) {
+      return [iri, alias + iri.slice(canonical.length)];
+    }
+    if (iri.startsWith(alias)) {
+      return [iri, canonical + iri.slice(alias.length)];
+    }
+  }
+  return [iri];
+}

--- a/packages/pipeline/test/namespaceAlias.test.ts
+++ b/packages/pipeline/test/namespaceAlias.test.ts
@@ -1,0 +1,54 @@
+import { aliasVariants, canonicalizeIri } from '../src/namespaceAlias.js';
+import type { NamespaceAlias } from '../src/namespaceAlias.js';
+import { describe, it, expect } from 'vitest';
+
+const schemaOrgAlias: NamespaceAlias = {
+  canonical: 'https://schema.org/',
+  alias: 'http://schema.org/',
+};
+
+describe('canonicalizeIri', () => {
+  it('rewrites an alias-namespace IRI to the canonical namespace', () => {
+    expect(
+      canonicalizeIri('http://schema.org/CreativeWork', [schemaOrgAlias]),
+    ).toBe('https://schema.org/CreativeWork');
+  });
+
+  it('keeps canonical-namespace IRIs unchanged', () => {
+    expect(
+      canonicalizeIri('https://schema.org/CreativeWork', [schemaOrgAlias]),
+    ).toBe('https://schema.org/CreativeWork');
+  });
+
+  it('keeps IRIs outside every alias namespace unchanged', () => {
+    expect(canonicalizeIri('http://example.org/Thing', [schemaOrgAlias])).toBe(
+      'http://example.org/Thing',
+    );
+  });
+});
+
+describe('aliasVariants', () => {
+  it('returns the alias variant for a canonical-namespace IRI', () => {
+    expect(
+      aliasVariants('https://schema.org/CreativeWork', [schemaOrgAlias]),
+    ).toEqual([
+      'https://schema.org/CreativeWork',
+      'http://schema.org/CreativeWork',
+    ]);
+  });
+
+  it('returns the canonical variant for an alias-namespace IRI', () => {
+    expect(
+      aliasVariants('http://schema.org/CreativeWork', [schemaOrgAlias]),
+    ).toEqual([
+      'http://schema.org/CreativeWork',
+      'https://schema.org/CreativeWork',
+    ]);
+  });
+
+  it('returns only the IRI itself outside every alias namespace', () => {
+    expect(aliasVariants('http://example.org/Thing', [schemaOrgAlias])).toEqual(
+      ['http://example.org/Thing'],
+    );
+  });
+});

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 97.13,
-          lines: 96.5,
-          branches: 91.54,
-          statements: 96.0,
+          functions: 97.15,
+          lines: 96.63,
+          branches: 91.63,
+          statements: 96.12,
         },
       },
     },


### PR DESCRIPTION
Adds a `namespaceAliases` option to the VoID stages that merges `http://` and `https://schema.org/` variants into a single partition per canonical class/property. Fixes the duplicate `void:classPartition` reported in netwerk-digitaal-erfgoed/dataset-knowledge-graph#334.

## Problem

Partitions are keyed on an opaque `MD5(class[, property[, …]])` IRI, so a dataset that types entities under both `http://schema.org/CreativeWork` and `https://schema.org/CreativeWork` produces **two** `void:classPartition` nodes that, once the class IRI is normalized, describe the same class. Consumers that group by class URI break on the duplicate (it blanked the Dataset Register browser's detail page). Consumers can't cleanly fix it from the published summary either: `void:distinctObjects` can never be merged from the counts alone (object sets overlap), and `void:entities` can only be summed under a subject-disjointness assumption. The analysis is the right place to normalize — it has the raw object values to dedupe `distinctObjects`, and it keeps the duplicate partition nodes from ever being published — but for the summed measures it makes the same disjointness assumption a consumer would.

## Approach

Merge **after** aggregation, keeping the analysis queries plain:

- **`mergeNamespaceVariants`** — a per-stage `QuadTransform` that buffers a stage's VoID output, re-mints each partition IRI from its **canonical** key components (replicating the queries' `MD5(CONCAT(STR(…)))`, pinned by a test against the real `#334` hashes), collapses the duplicate partition nodes, and sums `void:entities` / `void:triples`. Attached to the class and property partition stages.
- The class selector canonicalizes and de-duplicates its bindings, and the reader expands each canonical class back to its namespace variants, so a class's variants are **co-located in one batch** — the merge is self-contained per stage, no pipeline-core change needed.
- The three `void-ext` queries emit their `cp → pp` parent chain (`void:class`, `void:property`) so the transform can re-key them from an otherwise opaque hash.
- **`class-properties-objects.rq` keeps query-time normalization** — its `void:distinctObjects` is a distinct-count over object *values* that overlap across namespace variants (two works can share a name), so summing would over-count. It's deduped in the query and never reaches the transform. The integration test pins this: a shared object value gives `distinctObjects = 3` where a naive sum would give 4.
- `NamespaceAlias` moves to `@lde/pipeline` with shared `canonicalizeIri` / `aliasVariants` helpers; re-exported from `@lde/pipeline-shacl-sampler`.

## Assumptions

Summing pre-aggregated counts is exact only under **subject/class disjointness** (class-partition and triple sums) and **predicate-namespace disjointness** (property-partition entity sum). Both hold for the schema.org datasets that motivate this — the variants appear as disjoint subsets. A resource typed under both variants over-counts its class entities; this is documented on the transform, in [ADR 7](docs/decisions/0007-merge-namespace-alias-partitions.md), and pinned by a test. With no aliases configured the transform is a no-op and behaviour is unchanged.

## Verification

Unit tests for the transform (incl. the MD5-minting coupling and the malformed-input guards) plus an endpoint-backed integration test over the full VoID output of a mixed-namespace fixture: one merged class partition (4 entities), one property partition (4 entities, `distinctObjects` 3), merged datatype/language/object-class partitions, and the documented over-count under a disjointness violation.

Follow-up (dataset-knowledge-graph, separate repo): pass `namespaceAliases: [{ canonical: 'https://schema.org/', alias: 'http://schema.org/' }]` to `voidStages()` and drop the write-time `schemaOrgNormalizationPlugin` rewrite.
