### PR TITLE
fix(distribution-probe): attach parser error sink before tearing down on budget abort

### DIFF
--- a/packages/distribution-probe/src/probe.ts
+++ b/packages/distribution-probe/src/probe.ts
@@ -1059,12 +1059,12 @@ type RdfBodyOutcome =
  * Parse an RDF body just far enough to tell whether it carries any triples:
  * resolve on the first triple (presence is all we need, not a full count), on a
  * clean end with none ('empty'), or on a parse error. The parse is bounded by
- * `budgetSignal` – the caller's validation-budget {@link AbortController} –
+ * `budgetSignal` – the caller’s validation-budget {@link AbortController} –
  * because a JSON-LD `@context` is fetched from its origin, and a slow or hanging
  * context host would otherwise stall the probe past its budget; on abort – and
  * likewise when a remote `@context` is unreachable – the outcome is
  * 'inconclusive', so a valid distribution is never flagged faulty for a context
- * host's failure. Sharing the caller's single budget (rather than starting a
+ * host’s failure. Sharing the caller’s single budget (rather than starting a
  * second, identical timer) keeps that timeout deterministic: it fires once, when
  * the budget elapses, instead of leaving an orphan timer to settle on its own
  * schedule. `baseIRI` resolves any relative IRIs in the document.
@@ -1095,14 +1095,10 @@ function classifyRdfBody(
       quads.destroy();
       resolve(outcome);
     }
-    // The budget may already have elapsed while the body was being read; treat an
-    // already-aborted signal as an immediate expiry rather than waiting for an
-    // 'abort' event that will never come.
-    if (budgetSignal.aborted) {
-      onBudgetElapsed();
-      return;
-    }
-    budgetSignal.addEventListener('abort', onBudgetElapsed, { once: true });
+    // Attach the parser listeners before consulting the budget: settle() calls
+    // quads.destroy(), which can make the parser emit a late 'error', so the
+    // error sink must already be in place – including on the already-aborted
+    // path below – or that error goes unhandled and crashes the process.
     quads
       .on('data', () => settle({ type: 'hasTriples' }))
       .on('error', (error: Error) =>
@@ -1115,6 +1111,14 @@ function classifyRdfBody(
       .on('end', () =>
         settle(truncated ? { type: 'inconclusive' } : { type: 'empty' }),
       );
+    // The budget may already have elapsed while the body was being read; an
+    // already-aborted signal never emits another 'abort', so settle immediately
+    // rather than wait for an event that will not come.
+    if (budgetSignal.aborted) {
+      onBudgetElapsed();
+    } else {
+      budgetSignal.addEventListener('abort', onBudgetElapsed, { once: true });
+    }
   });
 }
 

--- a/packages/distribution-probe/test/probe.test.ts
+++ b/packages/distribution-probe/test/probe.test.ts
@@ -1049,6 +1049,51 @@ describe('probe', () => {
       expect((result as DataDumpProbeResult).isSuccess()).toBe(true);
       expect((result as DataDumpProbeResult).failureReason).toBeNull();
     });
+
+    it('does not crash when the budget aborts before a malformed body is parsed', async () => {
+      // The budget can elapse after the body has been read but before parsing
+      // starts, so the parser is torn down straight away. A malformed body then
+      // emits a late ‘error’ on the destroyed parser; that error must be handled,
+      // never left to surface as an uncaught exception – probe() never throws.
+      const malformed = 'this is not valid turtle <<<';
+      const slowBody = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // Deliver the body well after the 5 ms budget, so classifyRdfBody is
+          // reached with an already-aborted signal.
+          setTimeout(() => {
+            controller.enqueue(new TextEncoder().encode(malformed));
+            controller.close();
+          }, 80);
+        },
+      });
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(new Response('', { status: 200 })) // HEAD
+        .mockResolvedValueOnce(
+          new Response(slowBody, {
+            status: 200,
+            headers: { 'Content-Type': 'text/turtle' },
+          }),
+        ); // GET
+
+      const distribution = new Distribution(
+        new URL('http://example.org/data.ttl'),
+        'text/turtle',
+      );
+
+      const result = await probe(distribution, {
+        validateRdfContent: true,
+        rdfValidationBudgetMs: 5,
+      });
+
+      expect((result as DataDumpProbeResult).isSuccess()).toBe(true);
+      expect((result as DataDumpProbeResult).failureReason).toBeNull();
+
+      // probe() has already resolved via the budget; wait past the body delivery
+      // so the torn-down parser emits its error within this test. A regression
+      // (error sink attached too late) surfaces here as an uncaught exception
+      // instead of crashing an unrelated later test.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
   });
 
   describe('JSON-LD remote @context', () => {

--- a/packages/distribution-probe/vite.config.ts
+++ b/packages/distribution-probe/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 99.27,
+          lines: 100,
           functions: 100,
-          branches: 96.21,
-          statements: 98.94,
+          branches: 96.75,
+          statements: 99.64,
         },
       },
     },


### PR DESCRIPTION
## Follow-up to #570 — fixes a latent process crash it introduced

#570 (merged) made `classifyRdfBody`’s validation timeout deterministic by sharing the caller’s budget `AbortController`. A code review afterwards found that the new already-aborted early-return crashes the process on a reachable path.

## The bug

```js
function settle(outcome) {
  …
  quads.destroy();   // ← parser torn down
  resolve(outcome);
}
if (budgetSignal.aborted) {
  onBudgetElapsed();  // → settle() → quads.destroy()
  return;             // ← returns BEFORE the quads.on('error', …) chain below
}
budgetSignal.addEventListener('abort', onBudgetElapsed, { once: true });
quads.on('data', …).on('error', …).on('end', …);  // never reached on the aborted path
```

`rdf-parse` emits a late `'error'` on a destroyed parser – a malformed body, or JSON-LD with an unreachable remote `@context`. On the already-aborted path that `'error'` fires with **no listener attached**, so Node turns it into an `uncaughtException` and the whole process dies. `probe()` is documented to never throw, and `probeMany()` relies on that to isolate per-distribution failures – so one bad distribution could take down an entire batch.

**Reachable:** the budget elapses after the body has been read but before parsing starts. The gzip-decode step (`await gunzipPrefix`) gives the event loop a real window between “bytes in hand” and “parse begins”, and the abort lands there.

## The fix

Attach the parser `'data'`/`'error'`/`'end'` listeners **before** consulting the budget, so the `'error'` sink is in place on every path (including the already-aborted one), then settle immediately when the signal is already aborted.

## Test

A regression test drives the already-aborted branch: the budget (5 ms) elapses while a malformed Turtle body is still being delivered (80 ms), so `classifyRdfBody` is entered with an aborted signal; it asserts `probe()` resolves reachable/unvalidated and – crucially – that the torn-down parser’s late error surfaces no uncaught exception. Verified red/green: without the fix the test reports `Uncaught Exception: Unexpected "this" on line 1` from the N3 lexer; with the fix it passes.

Covering that branch deterministically also restores the thresholds to `lines`/`functions` 100 (`branches` 96.75, `statements` 99.64) — coverage stays deterministic across 20 repeated runs.
