### PR TITLE
docs(search-typesense): document the index:false RAM lever

### DIFF
--- a/packages/search-typesense/README.md
+++ b/packages/search-typesense/README.md
@@ -17,6 +17,15 @@ type comes from each field’s `kind`, and the physical fanout (per-locale
 search/sort keys) matches what the projection writes, via
 `@lde/search`’s `physicalFields`, so the index and the documents cannot drift.
 
+**Memory lever.** Typesense keeps the index in RAM (with a raw copy of each
+document on disk), so RAM tracks the _indexed_ surface – roughly 2–3× the size
+of the fields you search, facet or sort on – not the full document.
+`buildCollectionSchema` keeps that surface minimal: the `output` display labels
+fan out to `index: false` fields, stored on disk and fetched only for a hit, so
+they cost no RAM; only the folded `*_search_${locale}`, facet/reference and
+`*_sort_${locale}` companions are indexed. Keeping retrieval-only fields
+un-indexed is the lever for holding a large index’s RAM down.
+
 `createTypesenseSearchEngine(client, { collection, labelsCollection })` is the
 `SearchEngine` implementation. Each search:
 

--- a/packages/search-typesense/src/collection-schema.ts
+++ b/packages/search-typesense/src/collection-schema.ts
@@ -29,6 +29,15 @@ export interface CollectionSchemaOptions {
  * untagged `und` locale (and any searchable keyword/reference companion)
  * stems in `defaultLocale` when one is set, and is left unstemmed (folded
  * only) otherwise.
+ *
+ * Memory lever: Typesense holds the index in RAM (with a raw copy of each
+ * document on disk), so RAM tracks the *indexed* surface – roughly 2–3× the
+ * size of the fields you search, facet or sort on – not the whole document.
+ * This builder keeps that surface minimal: the `output` display labels fan out
+ * to `index: false` fields, kept on disk and read back only for a hit, so they
+ * cost no RAM; only the folded `*_search_${locale}`, facet/reference and
+ * `*_sort_${locale}` companions are indexed. Keeping retrieval-only fields
+ * un-indexed is the lever for holding a large index’s RAM down.
  */
 export function buildCollectionSchema(
   searchType: SearchType,
@@ -60,8 +69,10 @@ function typesenseFields(
   if (field.kind === 'text') {
     const locales = field.locales;
     return [
-      // Display labels: stored, not indexed for search (search uses the folded
-      // companions), accents preserved.
+      // Display labels: stored but NOT indexed (`index: false`) – search hits
+      // the folded `*_search` companions, so the display copy stays on disk and
+      // off RAM (fetched only for a hit), accents preserved. This is the memory
+      // lever: RAM tracks the search surface, not the display text.
       ...names.display.map(
         (name): CollectionFieldSchema => ({
           name,


### PR DESCRIPTION
Documents the existing RAM lever in `buildCollectionSchema`: Typesense holds the search index in RAM, so RAM tracks the *indexed* surface (~2-3x the fields you search, facet or sort on); the `output` display labels are already emitted as `index: false` fields (stored on disk, off RAM). Adds this rationale to the JSDoc, the inline comment, and the package README.

Doc-only change; package typecheck/lint/build/test all green. Context: the engine RAM-scaling discussion and #572 (OpenSearch adapter for large object indexes).