### PR TITLE
docs(search-pipeline): sharpen the package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ await pipeline.run();
 <tr>
   <td><a href="packages/search">@lde/search</a></td>
   <td><a href="https://www.npmjs.com/package/@lde/search"><img src="https://img.shields.io/npm/v/@lde/search" alt="npm"></a></td>
-  <td>Project RDF into engine-agnostic search documents (framing + a declarative field spec)</td>
+  <td>The search core: projects RDF into engine-agnostic search documents (framing + a declarative field spec)</td>
 </tr>
 <tr>
   <td><a href="packages/search-api-graphql">@lde/search-api-graphql</a></td>
@@ -151,7 +151,7 @@ await pipeline.run();
 <tr>
   <td><a href="packages/search-pipeline">@lde/search-pipeline</a></td>
   <td><a href="https://www.npmjs.com/package/@lde/search-pipeline"><img src="https://img.shields.io/npm/v/@lde/search-pipeline" alt="npm"></a></td>
-  <td>Search indexing as an @lde/pipeline instance: projects extracted RDF into search documents and feeds them to a transactional engine writer</td>
+  <td>Applies the @lde/search projection inside an @lde/pipeline run, streaming the resulting documents to a transactional engine writer (owns no projection itself)</td>
 </tr>
 <tr>
   <td><a href="packages/search-typesense">@lde/search-typesense</a></td>

--- a/packages/search-pipeline/package.json
+++ b/packages/search-pipeline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lde/search-pipeline",
   "version": "0.1.1",
-  "description": "Search indexing as an @lde/pipeline Configurable Pipeline: projects extracted RDF into engine-agnostic search documents and feeds them to a transactional search-engine writer",
+  "description": "Search indexing as an @lde/pipeline instance: a Writer<Quad> that applies the @lde/search projection to extracted RDF and streams the documents to a transactional search-engine writer. Glue between the pipeline quad world and the search-engine document world; owns no projection or engine logic itself.",
   "repository": {
     "url": "git+https://github.com/ldelements/lde.git",
     "directory": "packages/search-pipeline"


### PR DESCRIPTION
The `@lde/search-pipeline` description read as if it *does* the projection ("projects extracted RDF into … search documents"), overlapping `@lde/search`, which owns projection. Rewords to "applies the @lde/search projection" plus a disclaimer that the package owns no projection or engine logic itself — so a workspace/registry view reads the split clearly.

Lands before the package's first npm publish so the registry never carries the confusing description. Doc-only.