### PR TITLE
docs: mark the shipped search and pipeline ADRs Accepted

### DIFF
--- a/docs/decisions/0003-search-api-core-query-model.md
+++ b/docs/decisions/0003-search-api-core-query-model.md
@@ -4,7 +4,7 @@ Date: 2026-06-25
 
 ## Status
 
-Proposed
+Accepted
 
 Aligned with the NDE [stack platform docs](https://docs.nde.nl/stack/layers/platform); the
 decisions below are reflected there.

--- a/docs/decisions/0004-search-api-graphql-surface.md
+++ b/docs/decisions/0004-search-api-graphql-surface.md
@@ -4,7 +4,7 @@ Date: 2026-06-25
 
 ## Status
 
-Proposed
+Accepted
 
 Builds on [ADR 3 (Search API core query model)](./0003-search-api-core-query-model.md).
 

--- a/docs/decisions/0005-batch-facet-queries-through-the-engine-port.md
+++ b/docs/decisions/0005-batch-facet-queries-through-the-engine-port.md
@@ -4,7 +4,7 @@ Date: 2026-07-06
 
 ## Status
 
-Proposed
+Accepted
 
 Amends [ADR 3 (Search API core query model)](./0003-search-api-core-query-model.md);
 refines the faceting described in

--- a/docs/decisions/0006-make-the-writer-transaction-aware.md
+++ b/docs/decisions/0006-make-the-writer-transaction-aware.md
@@ -4,7 +4,7 @@ Date: 2026-07-06
 
 ## Status
 
-Proposed
+Accepted
 
 Amends the pipeline model of
 [ADR 1 (Merge pipeline approaches)](./0001-merge-pipeline-approaches.md) and


### PR DESCRIPTION
ADRs 0003–0006 (search core query model, GraphQL surface, batch facets, transaction-aware writer) all shipped, but their `Status` stayed `Proposed`. Flip them to `Accepted` to match 0001/0002 and reflect the enacted decisions.

(0008, the per-reference label sources ADR, is flipped to Accepted on its own branch #566.)