### PR TITLE
ci: publish via OIDC trusted publishing, drop unused NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }} # Needed for pushing release commits.
 
+      # Publishes via npm OIDC trusted publishing (see id-token: write above), which
+      # mints a short-lived credential per run — no long-lived npm token needed.
       - run: npx nx release publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## What

Drop the unused `NODE_AUTH_TOKEN` from the `nx release publish` step so the Release workflow publishes purely via npm OIDC trusted publishing.

## Why

The publish step set both OIDC (`permissions: id-token: write` + `NPM_CONFIG_PROVENANCE: true`) and a long-lived token (`NODE_AUTH_TOKEN: secrets.NPM_TOKEN`). In practice npm authenticates via OIDC – recent releases (e.g. `@lde/pipeline@0.33.4` and `@lde/pipeline@0.34.0`) were published by `npm-oidc-no-reply@github.com`, confirming the token was never the auth mechanism and did not act as a fallback. It was dead weight and a standing credential liability.

This is hygiene, not a bug fix: the token was not the cause of the intermittent `Not Found - PUT` publish failures seen on 2026-07-09 (those occurred inside the OIDC publish path and cleared on retry with no config change – an npmjs-side blip).

## Notes

- `NPM_TOKEN` is referenced nowhere else in `.github/`, so after merge the secret is unused and can be revoked.
- No retry logic added here; if the transient OIDC failures recur often, a retry wrapper on the publish step is the follow-up.

Claude-Session: https://claude.ai/code/b44086b8-7c18-4170-ab47-bcc3d607521f
