### PR TITLE
feat(search): accept Iterable<Quad> in projectGraph

### DIFF
--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -218,6 +218,21 @@ triples are collapsed first, because some SPARQL engines (e.g. QLever) do not
 deduplicate `CONSTRUCT` output. The IR carries no `@context`, so a `derive` function
 reading it sees full predicate IRIs with language tags preserved.
 
+`projectGraph` **consumes the quads once** – a single scan builds the subject
+index every type frames off – and so accepts any `Iterable<Quad>`, not just a
+materialized array. A caller merging several sources can pass a chained
+generator instead of building a third full array at the projection peak:
+
+```ts
+projectGraph(
+  (function* () {
+    yield* registerQuads;
+    yield* dkgQuads;
+  })(),
+  schema,
+);
+```
+
 ## Locales
 
 `locales` is the **single** list of locales a `text` field projects (`und` =

--- a/packages/search/src/frame-by-type.ts
+++ b/packages/search/src/frame-by-type.ts
@@ -10,21 +10,91 @@ export type FramedNode = Record<string, unknown>;
 const FRAME_OPTIONS = { omitGraph: false, embed: '@always' as const };
 
 /**
- * Frame CONSTRUCT quads into one JSON-LD node per subject of `rootType`. Each
- * root subject’s own triples plus the one-hop nodes it references (e.g. nested
- * publisher/distribution resources) are grouped lazily and framed one at a
- * time, so beyond the subject index only a single subgraph is held — whole-graph
- * `jsonld.frame()` is ~O(N²). Duplicate triples are collapsed first because some
- * SPARQL engines
- * (e.g. QLever) do not dedupe CONSTRUCT output. The caller supplies the root
- * type, keeping the framing domain-agnostic; the frame carries no `@context`, so
- * framed keys are full predicate IRIs.
+ * A one-pass index of a quad source: every subject’s (deduplicated) triples,
+ * plus the root subjects of each requested type in appearance order. Built by
+ * {@link buildSubjectIndex} from a single iteration of the source, so a caller
+ * can pass a chained generator (`function* () { yield* a; yield* b; }`) rather
+ * than materialize a merged array; a multi-type projection then frames every
+ * type off this one index instead of re-scanning per type.
  */
-export async function* frameByType(
-  quads: readonly Quad[],
+export interface SubjectIndex {
+  /** Each subject IRI → its own deduplicated triples, in first-seen order. */
+  readonly bySubject: ReadonlyMap<string, readonly Quad[]>;
+  /** Each requested root type IRI → its root subjects, in appearance order. */
+  readonly rootsByType: ReadonlyMap<string, readonly string[]>;
+}
+
+/**
+ * Iterate `quads` once, grouping each subject’s triples and collecting the root
+ * subjects of every type in `rootTypes`. Duplicate triples are collapsed here
+ * because some SPARQL engines (e.g. QLever) do not deduplicate CONSTRUCT
+ * output. The source is consumed a single time, so it may be a one-shot
+ * iterable (a generator chaining several sources); the whole subject index is
+ * held, but never more than that plus one framed subgraph at a time
+ * downstream.
+ */
+export function buildSubjectIndex(
+  quads: Iterable<Quad>,
+  rootTypes: Iterable<string>,
+): SubjectIndex {
+  const bySubject = new Map<string, Quad[]>();
+  const rootsByType = new Map<string, string[]>();
+  for (const type of rootTypes) {
+    rootsByType.set(type, []);
+  }
+  const seen = new Set<string>();
+  for (const quad of quads) {
+    const key = `${quad.subject.value} ${quad.predicate.value} ${quad.object.value} ${quad.object.termType === 'Literal' ? quad.object.language || quad.object.datatype.value : ''}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const subject = quad.subject.value;
+    const owned = bySubject.get(subject);
+    if (owned === undefined) {
+      bySubject.set(subject, [quad]);
+    } else {
+      owned.push(quad);
+    }
+    // `rootsByType` is keyed by exactly the requested root types, so the lookup
+    // doubles as the membership test: a hit means this subject is a root.
+    if (quad.predicate.value === RDF_TYPE) {
+      const roots = rootsByType.get(quad.object.value);
+      if (roots !== undefined) {
+        roots.push(subject);
+      }
+    }
+  }
+  return { bySubject, rootsByType };
+}
+
+/**
+ * Frame every root subject of `rootType` from a prebuilt {@link SubjectIndex}
+ * into one JSON-LD node – the reusable core behind {@link frameByType}. Each
+ * root subject’s own triples plus the one-hop nodes it references (e.g. nested
+ * publisher/distribution resources) are framed one subject at a time, so beyond
+ * the shared subject index only a single subgraph is held (whole-graph
+ * `jsonld.frame()` is ~O(N²)). The frame carries no `@context`, so framed keys
+ * are full predicate IRIs.
+ */
+export async function* frameSubjects(
+  index: SubjectIndex,
   rootType: string,
 ): AsyncIterable<FramedNode> {
-  for (const { rootIri, subgraph } of groupByRoot(quads, rootType)) {
+  const { bySubject } = index;
+  // A type the index was not built for has no roots, so it frames nothing; the
+  // `projectType`/`projectGraph` callers only pass types they registered.
+  const roots = index.rootsByType.get(rootType) ?? [];
+  for (const rootIri of roots) {
+    const owned = bySubject.get(rootIri) ?? [];
+    const referenced = owned
+      .filter(
+        (quad) =>
+          quad.object.termType === 'NamedNode' ||
+          quad.object.termType === 'BlankNode',
+      )
+      .flatMap((quad) => bySubject.get(quad.object.value) ?? []);
+    const subgraph = [...owned, ...referenced];
     const expanded = await jsonld.fromRDF(subgraph);
     // Frame for THIS specific root subject by `@id`, not just by root type. A
     // one-hop reference can itself be of `rootType` (e.g. a terminology source
@@ -44,45 +114,15 @@ export async function* frameByType(
 }
 
 /**
- * Yield one self-contained quad subgraph per root subject – its own (deduped)
- * triples plus the triples of the one-hop IRI or blank nodes it references –
- * lazily, so only the subject index and the current subgraph are held at once
- * (never the whole materialized list of subgraphs).
+ * Frame CONSTRUCT quads into one JSON-LD node per subject of `rootType`, for a
+ * single root type. Consumes `quads` once (see {@link buildSubjectIndex}), so
+ * it accepts any `Iterable` – a materialized array or a chained generator. For
+ * a multi-type schema, {@link buildSubjectIndex} + {@link frameSubjects} share
+ * one index across types rather than re-scanning per type.
  */
-function* groupByRoot(
-  quads: readonly Quad[],
+export async function* frameByType(
+  quads: Iterable<Quad>,
   rootType: string,
-): Generator<{ rootIri: string; subgraph: Quad[] }> {
-  const bySubject = new Map<string, Quad[]>();
-  const rootIris: string[] = [];
-  const seen = new Set<string>();
-  for (const quad of quads) {
-    const key = `${quad.subject.value} ${quad.predicate.value} ${quad.object.value} ${quad.object.termType === 'Literal' ? quad.object.language || quad.object.datatype.value : ''}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    const subject = quad.subject.value;
-    const owned = bySubject.get(subject);
-    if (owned === undefined) {
-      bySubject.set(subject, [quad]);
-    } else {
-      owned.push(quad);
-    }
-    if (quad.predicate.value === RDF_TYPE && quad.object.value === rootType) {
-      rootIris.push(subject);
-    }
-  }
-
-  for (const iri of rootIris) {
-    const owned = bySubject.get(iri) ?? [];
-    const referenced = owned
-      .filter(
-        (quad) =>
-          quad.object.termType === 'NamedNode' ||
-          quad.object.termType === 'BlankNode',
-      )
-      .flatMap((quad) => bySubject.get(quad.object.value) ?? []);
-    yield { rootIri: iri, subgraph: [...owned, ...referenced] };
-  }
+): AsyncIterable<FramedNode> {
+  yield* frameSubjects(buildSubjectIndex(quads, [rootType]), rootType);
 }

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -1,6 +1,10 @@
 import type { Quad } from '@rdfjs/types';
 import { fold } from '@lde/text-normalization';
-import { frameByType, type FramedNode } from './frame-by-type.js';
+import {
+  buildSubjectIndex,
+  frameSubjects,
+  type FramedNode,
+} from './frame-by-type.js';
 import {
   isoToUnixSeconds,
   physicalFields,
@@ -45,13 +49,23 @@ export function projectDocument(
  * type’s declaration — the multi-shape pipeline. Streams one document at a time
  * so memory stays flat. The IR maps to a declaration by type, so adding a shape
  * is adding a `SearchType` to the schema (no engine change).
+ *
+ * Consumes `quads` once (a single scan builds the shared subject index that
+ * every type frames off), so it accepts any `Iterable` – a materialized array or
+ * a chained generator merging several sources (`function* () { yield* a; yield* b; }`)
+ * with no intermediate copy at the projection peak.
  */
 export async function* projectGraph(
-  quads: readonly Quad[],
+  quads: Iterable<Quad>,
   schema: SearchSchema,
 ): AsyncIterable<SearchDocument> {
-  for (const searchType of schema.values()) {
-    for await (const node of frameByType(quads, searchType.type)) {
+  const types = [...schema.values()];
+  const index = buildSubjectIndex(
+    quads,
+    types.map((searchType) => searchType.type),
+  );
+  for (const searchType of types) {
+    for await (const node of frameSubjects(index, searchType.type)) {
       yield projectDocument(node, searchType);
     }
   }

--- a/packages/search/test/frame-by-type.test.ts
+++ b/packages/search/test/frame-by-type.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { Parser } from 'n3';
 import { dcat, dcterms, foaf, rdf } from '@tpluscode/rdf-ns-builders';
-import { frameByType, type FramedNode } from '../src/frame-by-type.js';
+import {
+  buildSubjectIndex,
+  frameByType,
+  frameSubjects,
+  type FramedNode,
+} from '../src/frame-by-type.js';
 
 const DATASET = dcat.Dataset.value;
 
@@ -122,5 +127,36 @@ describe('frameByType', () => {
       ),
     );
     expect(nodes).toEqual([]);
+  });
+});
+
+describe('buildSubjectIndex / frameSubjects', () => {
+  it('scans a one-shot iterable once, indexing every requested root type', async () => {
+    const other = 'http://example.org/Other';
+    const source = quads(`
+      <https://ex/d/1> <${rdf.type.value}> <${DATASET}> .
+      <https://ex/d/1> <${dcterms.title.value}> "Titel"@nl .
+      <https://ex/x/1> <${rdf.type.value}> <${other}> .
+      <https://ex/x/1> <${dcterms.title.value}> "Ander"@nl .
+    `);
+    function* once(): Generator<(typeof source)[number]> {
+      yield* source;
+    }
+
+    // A single pass over the generator must still index both types.
+    const index = buildSubjectIndex(once(), [DATASET, other]);
+    const datasets = await collect(frameSubjects(index, DATASET));
+    const others = await collect(frameSubjects(index, other));
+
+    expect(datasets.map((node) => node['@id'])).toEqual(['https://ex/d/1']);
+    expect(others.map((node) => node['@id'])).toEqual(['https://ex/x/1']);
+  });
+
+  it('frames nothing for a type the index was not built for', async () => {
+    const index = buildSubjectIndex(
+      quads(`<https://ex/d/1> <${rdf.type.value}> <${DATASET}> .`),
+      [DATASET],
+    );
+    expect(await collect(frameSubjects(index, 'urn:unregistered'))).toEqual([]);
   });
 });

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -499,4 +499,35 @@ describe('projectGraph', () => {
     expect(byId['https://ex/d/1'].title_search_nl).toBe('titel');
     expect(byId['https://ex/d/2'].title_nl).toBe('Andere');
   });
+
+  it('consumes a one-shot iterable once, framing every type off a single scan', async () => {
+    const other = 'http://example.org/Other';
+    const quads = new Parser({ format: 'N-Triples' }).parse(`
+      <https://ex/d/1> <${rdf.type.value}> <${DATASET}> .
+      <https://ex/d/1> <${dcterms.title.value}> "Titel"@nl .
+      <https://ex/x/1> <${rdf.type.value}> <${other}> .
+      <https://ex/x/1> <${dcterms.title.value}> "Ander"@nl .
+    `);
+    // A generator is exhausted after one pass, so a per-type re-scan would drop
+    // every type but the first – projecting both proves the single-scan index.
+    function* once(): Generator<(typeof quads)[number]> {
+      yield* quads;
+    }
+
+    const documents: SearchDocument[] = [];
+    for await (const document of projectGraph(
+      once(),
+      searchSchema(
+        { name: 'Dataset', type: DATASET, fields },
+        { name: 'Other', type: other, fields },
+      ),
+    )) {
+      documents.push(document);
+    }
+
+    expect(documents.map((document) => document.id).sort()).toEqual([
+      'https://ex/d/1',
+      'https://ex/x/1',
+    ]);
+  });
 });

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 96.93,
+          branches: 96.96,
           statements: 100,
         },
       },


### PR DESCRIPTION
`projectGraph(quads, …)` required a materialized `readonly Quad[]`, so a consumer merging several sources had to build a third full array at the projection peak:

```ts
projectGraph([...registerQuads, ...dkgQuads], schema); // copies every quad
```

This widens the input to `Iterable<Quad>`, so a caller can pass a chained generator instead:

```ts
projectGraph(
  (function* () {
    yield* registerQuads;
    yield* dkgQuads;
  })(),
  schema,
);
```

To make that safe, framing is refactored into `buildSubjectIndex` + `frameSubjects`: `projectGraph` now scans the input **once** (a single subject index every type frames off) rather than re-scanning the quads per type. Widening `readonly Quad[]` → `Iterable<Quad>` is backward compatible — an array is already an `Iterable`.

This addresses gap 2 of #579. The other gaps in that issue were reframed in discussion and are intentionally **not** here:

- **Gap 1 (single-type projection)** — dropped. A validated `SearchSchema` is a cohesive unit; the per-collection fan-out belongs on the write side (#534's transactional multi-collection Writer), not in a projection that carves the schema up. `projectGraph(quads, schema)` stays the sole projection entry point.
- **Gap 3 (minted collection name)** — dropped for a minimal API surface; it is subsumed by #534's Writer.
- **Gap 4 (label language-variant projection)** — postponed to a follow-up PR.

Refs #579
