### PR TITLE
feat(search)!: route a whole-schema projection to per-type collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ await pipeline.run();
 <tr>
   <td><a href="packages/search-pipeline">@lde/search-pipeline</a></td>
   <td><a href="https://www.npmjs.com/package/@lde/search-pipeline"><img src="https://img.shields.io/npm/v/@lde/search-pipeline" alt="npm"></a></td>
-  <td>Applies the @lde/search projection inside an @lde/pipeline run, streaming the resulting documents to a transactional engine writer (owns no projection itself)</td>
+  <td>Applies the @lde/search projection inside an @lde/pipeline run, fanning each document out to the transactional engine writer for its type’s collection (owns no projection itself)</td>
 </tr>
 <tr>
   <td><a href="packages/search-typesense">@lde/search-typesense</a></td>

--- a/docs/decisions/0009-route-a-whole-schema-projection-to-per-type-collections.md
+++ b/docs/decisions/0009-route-a-whole-schema-projection-to-per-type-collections.md
@@ -1,0 +1,93 @@
+# 9. Route a whole-schema projection to per-type collections
+
+Date: 2026-07-10
+
+## Status
+
+Accepted
+
+Extends the writer model of
+[ADR 6 (Make the Writer transaction-aware)](./0006-make-the-writer-transaction-aware.md)
+and the reference model of
+[ADR 8 (Resolve reference labels from per-reference label sources)](./0008-resolve-reference-labels-from-per-reference-label-sources.md);
+updates the catalog grain of search as a Configurable Pipeline instance
+([#534](https://github.com/ldelements/lde/issues/534)) from one collection to
+several ([#590](https://github.com/ldelements/lde/issues/590)).
+
+## Context
+
+One validated `SearchSchema` declares several root types. The Dataset Register
+indexes four: `datasets` plus the Organization / Class / TerminologySource label
+collections its references resolve against (ADR 8). Each type derives its own
+Typesense collection schema, so the types cannot share a collection – they are
+four independent blue/green rebuilds, each with its own versioned collection,
+alias and single-flight lock.
+
+ADR 6 made the engine `Writer` a transactional, **single-collection** rebuild
+(`BlueGreenRebuild` / `InPlaceRebuild`), bound to one `SearchType`. `projectGraph`
+already projects the **whole** schema in one pass – a single scan of the quads
+builds the subject index every type frames off – yielding one mixed stream of
+documents. Nothing joined the two: a consumer that wanted several collections
+had to forge a per-type schema brand, hand-roll a per-type rebuild loop and cast
+a per-type projection. The per-collection fan-out had no home.
+
+Two placement options: (a) a composition in `@lde/search-pipeline` over N
+single-collection engine writers, or (b) a new multi-collection writer inside
+`@lde/search-typesense`. (a) keeps the engine adapter a single-collection
+concern and keeps the fan-out engine-agnostic (an OpenSearch adapter would reuse
+it unchanged), so the routing is a pipeline-glue concern, not an engine one.
+
+## Decision
+
+- **The projection tags each document with its type.** `projectGraph` yields
+  `{ searchType, document }` (`TypedSearchDocument`), not a bare `SearchDocument`.
+  The whole schema still projects into one mixed, single-scan stream; the tag is
+  what lets the write side route each document to the collection for its type
+  without re-deriving the type from the document. A single-collection consumer
+  just reads `document`.
+
+- **`@lde/search-pipeline`’s `searchIndexWriter` fans out (option a).** It takes
+  the schema and a `writerFor(searchType)` factory, builds one engine writer per
+  root type once, and on each run opens one engine run per type. A dataset’s
+  quads are buffered until its flush, projected once (whole schema), then split
+  by type and dispatched to each type’s run. The pipeline still drives one
+  uniform `openRun → write* → commit/abort` and never branches on the
+  multi-collection shape – consistent with ADR 6’s single lifecycle. A
+  single-collection deployment is just the N = 1 case.
+
+- **Each collection commits, sweeps and fails in isolation.** A type whose
+  projection is empty this run affects only its own collection, never another’s;
+  the empty-selection guard ([#569](https://github.com/ldelements/lde/issues/569))
+  is therefore per collection by construction, not a single global gate. `commit`
+  finalizes every collection independently and, if any fails, throws an
+  `AggregateError` _after_ attempting them all: a non-critical label-collection
+  failure never blocks the collections that did commit – in particular the
+  `datasets` index still goes live – while the failure is still surfaced, so a
+  stale collection is never silent.
+
+- **`abort` finalizes only the collections that did not go live.** The pipeline
+  aborts a run whose `commit` throws (ADR 6), so a partial commit reaches
+  `abort`. Because a committed blue/green rebuild’s `abort` would drop its
+  now-live collection, `abort` skips the collections that already committed and
+  drops only the half-built ones (and releases their locks). A failure while
+  _opening_ the per-type runs rolls the already-opened ones back the same way.
+
+## Consequences
+
+- The Dataset Register consumer collapses: project the schema, hand the stream
+  to `searchIndexWriter` with a `writerFor` that returns a `BlueGreenRebuild` per
+  type. The forged schema brand, the per-type projection casts and the
+  hand-rolled per-type rebuild loop all go away.
+
+- Breaking for `@lde/search`: `projectGraph` yields `TypedSearchDocument`, not
+  `SearchDocument`. Breaking for `@lde/search-pipeline`: `searchIndexWriter`
+  takes `writerFor` (per type) instead of a single `writer`.
+
+- The partial-failure policy is fail-the-run-but-commit-what-can: the safest
+  default (no silent staleness) that still honours the isolation requirement. A
+  skip-and-report or critical/non-critical-per-type policy can layer on later
+  without changing the routing, if a deployment needs the `datasets` index to go
+  live without the run being marked failed.
+
+- The fan-out is engine-agnostic: it composes any transactional
+  `Writer<SearchDocument>`, so a second engine adapter reuses it unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38800,7 +38800,7 @@
     },
     "packages/search": {
       "name": "@lde/search",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@lde/text-normalization": "^0.1.1",
@@ -38824,10 +38824,10 @@
     },
     "packages/search-api-graphql": {
       "name": "@lde/search-api-graphql",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.4.0",
+        "@lde/search": "^0.4.1",
         "dataloader": "^2.2.3",
         "graphql": "^15.8.0",
         "tslib": "^2.3.0"
@@ -38835,15 +38835,18 @@
     },
     "packages/search-pipeline": {
       "name": "@lde/search-pipeline",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.4.0",
+        "@lde/search": "^0.4.1",
         "@rdfjs/types": "^2.0.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "n3": "^2.1.1"
+        "@lde/search-typesense": "^0.6.1",
+        "n3": "^2.1.1",
+        "testcontainers": "^12.0.3",
+        "typesense": "^3.0.6"
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
@@ -38866,10 +38869,10 @@
     },
     "packages/search-typesense": {
       "name": "@lde/search-typesense",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.4.0",
+        "@lde/search": "^0.4.1",
         "@lde/text-normalization": "^0.1.1",
         "tslib": "^2.3.0",
         "typesense": "^3.0.6"

--- a/packages/search-pipeline/README.md
+++ b/packages/search-pipeline/README.md
@@ -11,11 +11,13 @@ The division of labour ([ADR 6](../../docs/decisions/0006-make-the-writer-transa
 - [`@lde/search`](../search) owns the engine-agnostic projection (framed
   document + field model) and stays pipeline-free;
 - `@lde/search-<engine>` (e.g. [`@lde/search-typesense`](../search-typesense))
-  is the engine adapter: a transactional `Writer` consuming projected
-  documents, owning the run lifecycle (Blue/green alias swap or In-place
-  sweeps, cross-pod lock);
-- **this package** composes them: `searchIndexWriter` is the one
-  type-changing step (quad → document), shared across engines.
+  is the engine adapter: a transactional, **single-collection** `Writer`
+  consuming projected documents, owning the run lifecycle (Blue/green alias swap
+  or In-place sweeps, cross-pod lock);
+- **this package** composes them: `searchIndexWriter` is the one type-changing
+  step (quad → document), shared across engines, and – since one schema declares
+  several root types – it fans each document out to the engine writer for **its**
+  type’s collection ([ADR 9](../../docs/decisions/0009-route-a-whole-schema-projection-to-per-type-collections.md)).
 
 ## Usage
 
@@ -25,20 +27,41 @@ import { searchSchema } from '@lde/search';
 import { BlueGreenRebuild } from '@lde/search-typesense';
 import { searchIndexWriter } from '@lde/search-pipeline';
 
-const schema = searchSchema({
-  name: 'dataset',
-  type: 'http://www.w3.org/ns/dcat#Dataset',
-  fields: [
-    {
-      name: 'title',
-      kind: 'text',
-      path: 'http://purl.org/dc/terms/title',
-      locales: ['und'],
-      output: true,
-      searchable: true,
-    },
-  ],
-});
+// One schema, several root types: the `datasets` catalog plus the Organization
+// label collection its references resolve against.
+const schema = searchSchema(
+  {
+    name: 'Dataset',
+    type: 'http://www.w3.org/ns/dcat#Dataset',
+    fields: [
+      {
+        name: 'title',
+        kind: 'text',
+        path: 'http://purl.org/dc/terms/title',
+        locales: ['und'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+    ],
+  },
+  {
+    name: 'Organization',
+    type: 'http://xmlns.com/foaf/0.1/Organization',
+    fields: [
+      {
+        name: 'label',
+        kind: 'text',
+        path: 'http://xmlns.com/foaf/0.1/name',
+        locales: ['und'],
+        output: true,
+        searchable: { weight: 1 },
+      },
+    ],
+  },
+);
+
+// Each type maps to its own collection: an independent blue/green rebuild.
+const collectionName = { Dataset: 'datasets', Organization: 'organizations' };
 
 const pipeline = new Pipeline({
   datasetSelector,
@@ -50,13 +73,10 @@ const pipeline = new Pipeline({
   ],
   writers: searchIndexWriter({
     schema,
-    writer: new BlueGreenRebuild(
-      typesenseClient,
-      schema.get('http://www.w3.org/ns/dcat#Dataset')!,
-      {
-        name: 'datasets',
-      },
-    ),
+    writerFor: (searchType) =>
+      new BlueGreenRebuild(typesenseClient, searchType, {
+        name: collectionName[searchType.name],
+      }),
   }),
 });
 
@@ -64,12 +84,31 @@ await pipeline.run();
 ```
 
 Each dataset’s extracted CONSTRUCT quads are buffered until the dataset
-completes, then framed by root type and projected into flat search documents
-(`@lde/search`’s `projectGraph`), and written to the engine run – before the
-engine acts on the dataset’s completion, so an In-place stale sweep never
-races its own documents. The run lifecycle (run context, per-dataset flush
-outcome, commit/abort) passes through unchanged: the engine writer’s update
-mode governs, and the pipeline never branches on it.
+completes, then projected once over the **whole** schema (`@lde/search`’s
+`projectGraph`) into one mixed, type-tagged stream, and each document is
+dispatched to the engine run for its type’s collection – before the engine acts
+on the dataset’s completion, so an In-place stale sweep never races its own
+documents. The run lifecycle (run context, per-dataset flush outcome,
+commit/abort) passes through unchanged: the engine writer’s update mode governs,
+and the pipeline never branches on it, nor on how many collections there are.
+
+## Per-collection isolation
+
+Each root type is an independent engine run – its own collection, alias and
+cross-pod lock – so the collections commit, sweep and fail in isolation:
+
+- a type whose projection is empty this run affects only its own collection,
+  never another’s – in particular the `datasets` index still goes live;
+- `commit` finalizes every collection independently and, if any fails, throws an
+  `AggregateError` _after_ attempting them all, so a non-critical
+  label-collection failure never blocks the collections that did commit, while
+  the failure is still surfaced (the run is marked failed);
+- because the pipeline aborts a run whose `commit` throws, `abort` finalizes only
+  the collections that did **not** already go live (aborting a committed
+  blue/green rebuild would drop its now-live collection), dropping the half-built
+  ones and releasing their locks.
+
+See [ADR 9](../../docs/decisions/0009-route-a-whole-schema-projection-to-per-type-collections.md).
 
 ## Memory
 

--- a/packages/search-pipeline/package.json
+++ b/packages/search-pipeline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lde/search-pipeline",
   "version": "0.3.1",
-  "description": "Search indexing as an @lde/pipeline instance: a Writer<Quad> that applies the @lde/search projection to extracted RDF and streams the documents to a transactional search-engine writer. Glue between the pipeline quad world and the search-engine document world; owns no projection or engine logic itself.",
+  "description": "Search indexing as an @lde/pipeline instance: a Writer<Quad> that applies the @lde/search projection to extracted RDF and fans each document out to the transactional engine writer for its type's collection. Glue between the pipeline quad world and the search-engine document world; owns no projection or engine logic itself.",
   "repository": {
     "url": "git+https://github.com/ldelements/lde.git",
     "directory": "packages/search-pipeline"
@@ -30,7 +30,10 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "n3": "^2.1.1"
+    "@lde/search-typesense": "^0.6.1",
+    "n3": "^2.1.1",
+    "testcontainers": "^12.0.3",
+    "typesense": "^3.0.6"
   },
   "peerDependencies": {
     "@lde/dataset": "^0.7.8",

--- a/packages/search-pipeline/src/search-index-writer.ts
+++ b/packages/search-pipeline/src/search-index-writer.ts
@@ -10,34 +10,59 @@ import {
   projectGraph,
   type SearchDocument,
   type SearchSchema,
+  type SearchType,
 } from '@lde/search';
 
 /** Options for {@link searchIndexWriter}. */
 export interface SearchIndexWriterOptions {
   /**
    * The declarative schema driving the projection: one {@link SearchType} per
-   * root type, each mapping framed RDF to flat search-document fields.
+   * root type, each mapping framed RDF to flat search-document fields. The
+   * writer opens one engine run per type in it.
    */
   schema: SearchSchema;
   /**
-   * The engine adapter the projected documents are written to – e.g.
-   * `@lde/search-typesense`’s `BlueGreenRebuild` or `InPlaceRebuild`. The
-   * run lifecycle (context, per-dataset flush outcome, commit/abort) is
-   * forwarded unchanged, so the engine writer’s update mode governs.
+   * The engine writer that owns a given root type’s collection – e.g. a
+   * `@lde/search-typesense` `BlueGreenRebuild` bound to that type and the
+   * collection name it keeps its alias on. Called once per {@link SearchType}
+   * in the schema when the writer is built.
+   *
+   * A single-collection deployment returns one writer for its one type; a
+   * multi-collection deployment (the Dataset Register’s `datasets` plus its
+   * Organization / Class / TerminologySource label collections) returns a
+   * distinct writer per type, each an independent blue/green rebuild with its
+   * own collection, alias and cross-pod lock. The projection is whole-schema
+   * either way; the per-collection fan-out is this writer’s job.
    */
-  writer: Writer<SearchDocument>;
+  writerFor: (searchType: SearchType) => Writer<SearchDocument>;
 }
 
 /**
- * The projection step of a search-indexing pipeline, as a quad `Writer`: it
- * turns each dataset’s extracted CONSTRUCT quads into engine-agnostic search
- * documents ({@link projectGraph}: frame by root type, then project each node
- * with its type’s declaration) and feeds them to the engine writer. This is
- * the one type-changing step (quad → document), shared across engines –
- * which is why it lives here and not inside an engine adapter.
+ * The projection step of a search-indexing pipeline, as a quad `Writer`, fanned
+ * out across a type’s collections. It turns each dataset’s extracted CONSTRUCT
+ * quads into engine-agnostic search documents ({@link projectGraph}: frame by
+ * root type, then project each node with its type’s declaration) and dispatches
+ * each document to the engine run for **its** type. This is the one
+ * type-changing step (quad → document), shared across engines – which is why it
+ * lives here and not inside an engine adapter.
+ *
+ * Each root type is an independent engine run (its own collection, alias and
+ * lock), so the collections commit, sweep and fail in isolation:
+ *
+ * - a type whose projection is empty this run affects only its own collection,
+ *   never another’s – in particular the `datasets` index still goes live;
+ * - `commit` finalizes every collection independently and, if any fails, throws
+ *   an `AggregateError` *after* attempting them all, so a non-critical
+ *   label-collection failure never blocks the collections that did commit,
+ *   while the failure is still surfaced (the pipeline marks the run failed).
+ *   Because the pipeline then calls {@link RunWriter.abort}, `abort` finalizes
+ *   only the collections that did **not** already go live – aborting a
+ *   committed blue/green rebuild would drop its now-live collection;
+ * - `abort` (a run failure, or a partial commit) drops every half-built
+ *   collection that has not committed and leaves the live ones untouched.
  *
  * A dataset’s quads are buffered until its flush and projected then, so the
- * documents land before the engine acts on the dataset’s completion (e.g. an
+ * documents land before every engine acts on the dataset’s completion (e.g. an
  * In-place stale sweep). Memory is bounded by one dataset’s extraction, and
  * released at each flush – nothing accumulates across datasets. Streaming
  * bounded entity batches *within* one huge dataset needs the two-level
@@ -46,13 +71,39 @@ export interface SearchIndexWriterOptions {
 export function searchIndexWriter(
   options: SearchIndexWriterOptions,
 ): Writer<Quad> {
-  const { schema, writer } = options;
+  const { schema, writerFor } = options;
+  // One engine writer per root type, built once; each run opens them all. Keyed
+  // by the type IRI, which is also how a projected document names its type.
+  const writers = new Map<string, Writer<SearchDocument>>(
+    [...schema.values()].map((searchType) => [
+      searchType.type,
+      writerFor(searchType),
+    ]),
+  );
+
   return {
     async openRun(context: RunContext): Promise<RunWriter<Quad>> {
-      const run = await writer.openRun(context);
+      const runs = new Map<string, RunWriter<SearchDocument>>();
+      try {
+        for (const [typeIri, writer] of writers) {
+          runs.set(typeIri, await writer.openRun(context));
+        }
+      } catch (error) {
+        // One engine run failed to open (e.g. its lock is held); roll the
+        // already-opened ones back so no collection or lock is left dangling.
+        await Promise.allSettled(
+          [...runs.values()].map((run) => run.abort(error)),
+        );
+        throw error;
+      }
+
+      // The collections that have gone live, so `abort` never re-finalizes one
+      // (a committed blue/green rebuild’s abort drops its now-live collection).
+      const committed = new Set<string>();
+
       // One buffered pass per dataset, keyed by IRI. The pipeline processes
-      // datasets sequentially, but keeping the key explicit makes a write
-      // after another dataset's flush safe too.
+      // datasets sequentially, but keeping the key explicit makes a write after
+      // another dataset's flush safe too.
       const passes = new Map<string, { dataset: Dataset; quads: Quad[] }>();
 
       const project = async (pass: {
@@ -63,7 +114,29 @@ export function searchIndexWriter(
         if (pass.quads.length === 0) {
           return;
         }
-        await run.write(pass.dataset, projectGraph(pass.quads, schema));
+        // Whole-schema projection into one mixed stream, split by type here so
+        // each type’s documents reach its own collection’s run.
+        const byType = new Map<string, SearchDocument[]>();
+        for await (const { searchType, document } of projectGraph(
+          pass.quads,
+          schema,
+        )) {
+          const documents = byType.get(searchType.type);
+          if (documents === undefined) {
+            byType.set(searchType.type, [document]);
+          } else {
+            documents.push(document);
+          }
+        }
+        // Every yielded type is a schema type, so it has a run; iterate the
+        // runs and write each the documents projected for its type (none, for a
+        // type absent from this pass).
+        for (const [typeIri, run] of runs) {
+          const documents = byType.get(typeIri);
+          if (documents !== undefined) {
+            await run.write(pass.dataset, stream(documents));
+          }
+        }
       };
 
       return {
@@ -84,27 +157,88 @@ export function searchIndexWriter(
           if (pass !== undefined) {
             await project(pass);
           }
-          await run.flush?.(dataset, outcome);
+          // Flush every collection independently: one collection’s flush failure
+          // (a rollback, or an In-place stale sweep) must not skip another’s –
+          // the pipeline isolates a flush error per dataset and still commits,
+          // so a skipped collection would swap live with a dataset it should
+          // have rolled back or swept. Every collection is flushed, not just the
+          // ones that received documents this dataset: a collection an earlier
+          // run held documents for still needs its sweep to reconcile.
+          await settleAll(runs.values(), 'flush', (run) =>
+            run.flush?.(dataset, outcome),
+          );
         },
 
         reset: async (dataset: Dataset) => {
-          // Discard the buffered pass so the re-run replaces it, and let the
-          // engine writer discard whatever it already holds for the dataset.
+          // Discard the buffered pass so the re-run replaces it, and let every
+          // collection’s run discard whatever it already holds for the dataset –
+          // independently, so one collection’s reset failure never leaves
+          // another holding the discarded pass’s documents into the re-run.
           passes.delete(dataset.iri.toString());
-          await run.reset?.(dataset);
+          await settleAll(runs.values(), 'reset', (run) =>
+            run.reset?.(dataset),
+          );
         },
 
         commit: async () => {
-          // Safety net: project passes that were never flushed, so a
-          // committed run never silently drops written quads.
+          // Safety net: project passes that were never flushed, so a committed
+          // run never silently drops written quads.
           for (const pass of [...passes.values()]) {
             await project(pass);
           }
-          await run.commit();
+          // Commit every collection independently, so one failure neither
+          // blocks nor wipes another – the `datasets` index goes live even if a
+          // label collection cannot. Record each collection that went live, so
+          // the abort that follows a failed commit never drops it.
+          await settleAll(runs, 'commit', async ([typeIri, run]) => {
+            await run.commit();
+            committed.add(typeIri);
+          });
         },
 
-        abort: (error: unknown) => run.abort(error),
+        abort: async (error: unknown) => {
+          // Finalize only the collections that have not gone live: aborting a
+          // committed blue/green rebuild would drop its now-live collection.
+          // Best-effort – cleanup failures must not mask the original error.
+          await Promise.allSettled(
+            [...runs]
+              .filter(([typeIri]) => !committed.has(typeIri))
+              .map(([, run]) => run.abort(error)),
+          );
+        },
       };
     },
   };
+}
+
+/**
+ * Run `operation` on every collection concurrently and independently, so one
+ * collection’s failure never skips another’s (a flush’s rollback, a reset’s
+ * discard, a commit’s alias swap). Surface the failures together once all have
+ * been attempted, as an `AggregateError` – the run is still marked failed, but
+ * every collection got its chance to reconcile or go live first.
+ */
+async function settleAll<Item>(
+  items: Iterable<Item>,
+  verb: string,
+  operation: (item: Item) => Promise<void> | undefined,
+): Promise<void> {
+  const targets = [...items];
+  const outcomes = await Promise.allSettled(
+    targets.map((item) => operation(item)),
+  );
+  const failures = outcomes.flatMap((outcome) =>
+    outcome.status === 'rejected' ? [outcome.reason] : [],
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `${failures.length} of ${targets.length} search collections failed to ${verb}`,
+    );
+  }
+}
+
+/** Yield the given documents as an async iterable, like a streaming source. */
+async function* stream<Item>(items: readonly Item[]): AsyncIterable<Item> {
+  yield* items;
 }

--- a/packages/search-pipeline/test/multi-collection.integration.test.ts
+++ b/packages/search-pipeline/test/multi-collection.integration.test.ts
@@ -1,0 +1,257 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { DataFactory } from 'n3';
+import type { Quad } from '@rdfjs/types';
+import type { Client } from 'typesense';
+import { Dataset } from '@lde/dataset';
+import type { RunContext, Writer } from '@lde/pipeline';
+import {
+  searchSchema,
+  type SearchDocument,
+  type SearchType,
+} from '@lde/search';
+import { BlueGreenRebuild } from '@lde/search-typesense';
+import { searchIndexWriter } from '../src/search-index-writer.js';
+import { TypesenseContainer } from './typesense-container.js';
+
+const { namedNode, literal, quad } = DataFactory;
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const DATASET = 'https://example.org/Dataset';
+const ORGANIZATION = 'https://example.org/Organization';
+const TITLE = 'https://example.org/title';
+const NAME = 'https://example.org/name';
+
+// The Dataset Register in miniature: a `datasets` catalog collection plus one
+// typed label collection (its Organization label source), built from one
+// whole-schema projection.
+const schema = searchSchema(
+  {
+    name: 'Dataset',
+    type: DATASET,
+    fields: [{ name: 'title', kind: 'keyword', path: TITLE, array: true }],
+  },
+  {
+    name: 'Organization',
+    type: ORGANIZATION,
+    fields: [{ name: 'name', kind: 'keyword', path: NAME, array: true }],
+  },
+);
+
+const COLLECTION: Record<string, string> = {
+  [DATASET]: 'datasets',
+  [ORGANIZATION]: 'organizations',
+};
+
+const dataset = new Dataset({
+  iri: new URL('http://example.org/dataset/1'),
+  distributions: [],
+});
+
+/** A mixed graph: one Dataset node and one Organization node. */
+function mixedQuads(): Quad[] {
+  return [
+    quad(namedNode('https://ex/d/1'), namedNode(RDF_TYPE), namedNode(DATASET)),
+    quad(namedNode('https://ex/d/1'), namedNode(TITLE), literal('Verhaal')),
+    quad(
+      namedNode('https://ex/o/1'),
+      namedNode(RDF_TYPE),
+      namedNode(ORGANIZATION),
+    ),
+    quad(namedNode('https://ex/o/1'), namedNode(NAME), literal('Rijksmuseum')),
+  ];
+}
+
+async function* stream<Item>(items: readonly Item[]): AsyncIterable<Item> {
+  yield* items;
+}
+
+function makeRunContext(): RunContext {
+  return {
+    runId: 'run-1',
+    startedAt: '2026-07-06T12:00:00.000Z',
+    selectedSources: () => [dataset.iri.toString()],
+  };
+}
+
+function blueGreenFor(
+  client: Client,
+): (searchType: SearchType) => Writer<SearchDocument> {
+  return (searchType) =>
+    new BlueGreenRebuild(client, searchType, {
+      name: COLLECTION[searchType.type],
+    });
+}
+
+async function aliasTarget(
+  client: Client,
+  name: string,
+): Promise<string | undefined> {
+  try {
+    return (await client.aliases(name).retrieve()).collection_name;
+  } catch {
+    return undefined;
+  }
+}
+
+async function liveIds(client: Client, name: string): Promise<string[]> {
+  const field = name === 'datasets' ? 'title' : 'name';
+  const response = await client
+    .collections(name)
+    .documents()
+    .search({ q: '*', query_by: field, per_page: 250 });
+  return (response.hits ?? [])
+    .map((hit) => (hit.document as { id: string }).id)
+    .sort();
+}
+
+async function reset(client: Client): Promise<void> {
+  const { aliases } = await client.aliases().retrieve();
+  for (const alias of aliases) {
+    await client.aliases(alias.name).delete();
+  }
+  for (const collection of await client.collections().retrieve()) {
+    await client.collections(collection.name).delete();
+  }
+}
+
+describe('TypesenseContainer', () => {
+  it('refuses to hand out a client before it is started', () => {
+    expect(() => new TypesenseContainer().client()).toThrow(/not started/);
+  });
+
+  it('stop is a no-op before it is started', async () => {
+    await expect(new TypesenseContainer().stop()).resolves.toBeUndefined();
+  });
+});
+
+describe('searchIndexWriter over multiple Typesense collections', () => {
+  const container = new TypesenseContainer();
+  let client: Client;
+
+  beforeAll(async () => {
+    client = await container.start();
+  }, 120_000);
+
+  afterAll(async () => {
+    await container.stop();
+  });
+
+  beforeEach(async () => {
+    await reset(client);
+  });
+
+  it('swaps each type’s collection independently from one mixed stream', async () => {
+    const run = await searchIndexWriter({
+      schema,
+      writerFor: blueGreenFor(client),
+    }).openRun(makeRunContext());
+
+    await run.write(dataset, stream(mixedQuads()));
+    await run.flush?.(dataset, 'success');
+    await run.commit();
+
+    // Each collection went live on its own versioned collection + alias.
+    expect(await aliasTarget(client, 'datasets')).toMatch(/^datasets_\d+$/);
+    expect(await aliasTarget(client, 'organizations')).toMatch(
+      /^organizations_\d+$/,
+    );
+    // Each carries only the documents projected for its type.
+    expect(await liveIds(client, 'datasets')).toEqual(['https://ex/d/1']);
+    expect(await liveIds(client, 'organizations')).toEqual(['https://ex/o/1']);
+  });
+
+  it('lets the datasets index go live even when a label collection fails to commit', async () => {
+    // The Organization rebuild fails at commit, before its alias swaps. The
+    // datasets index must still go live; the failure must surface.
+    const failing: (searchType: SearchType) => Writer<SearchDocument> = (
+      searchType,
+    ) => {
+      const real = blueGreenFor(client)(searchType);
+      if (searchType.type !== ORGANIZATION) {
+        return real;
+      }
+      return {
+        openRun: async (context) => {
+          const inner = await real.openRun(context);
+          return {
+            ...inner,
+            commit: async () => {
+              throw new Error('organization collection swap failed');
+            },
+          };
+        },
+      };
+    };
+
+    const run = await searchIndexWriter({ schema, writerFor: failing }).openRun(
+      makeRunContext(),
+    );
+    await run.write(dataset, stream(mixedQuads()));
+    await run.flush?.(dataset, 'success');
+
+    const commit = run.commit();
+    await expect(commit).rejects.toThrow(AggregateError);
+    // The pipeline aborts the run after commit throws; the committed datasets
+    // collection must survive that abort, the half-built organizations one must
+    // be dropped.
+    await run.abort(new Error('run failed'));
+
+    expect(await aliasTarget(client, 'datasets')).toMatch(/^datasets_\d+$/);
+    expect(await liveIds(client, 'datasets')).toEqual(['https://ex/d/1']);
+    // Organizations never swapped, and its half-built collection was cleaned up.
+    expect(await aliasTarget(client, 'organizations')).toBeUndefined();
+    const collections = (await client.collections().retrieve()).map(
+      (collection) => collection.name,
+    );
+    expect(collections.some((name) => name.startsWith('organizations_'))).toBe(
+      false,
+    );
+  });
+
+  it('commits an empty collection for a type absent from the projection, leaving the others intact', async () => {
+    // Only Dataset quads: the Organization projection is empty this run.
+    const datasetOnly = [
+      quad(
+        namedNode('https://ex/d/1'),
+        namedNode(RDF_TYPE),
+        namedNode(DATASET),
+      ),
+      quad(namedNode('https://ex/d/1'), namedNode(TITLE), literal('Verhaal')),
+    ];
+
+    const run = await searchIndexWriter({
+      schema,
+      writerFor: blueGreenFor(client),
+    }).openRun(makeRunContext());
+    await run.write(dataset, stream(datasetOnly));
+    await run.flush?.(dataset, 'success');
+    await run.commit();
+
+    // Datasets went live with its document; organizations went live empty —
+    // the empty projection wiped only its own collection, never datasets.
+    expect(await liveIds(client, 'datasets')).toEqual(['https://ex/d/1']);
+    expect(await aliasTarget(client, 'organizations')).toMatch(
+      /^organizations_\d+$/,
+    );
+    expect(await liveIds(client, 'organizations')).toEqual([]);
+  });
+
+  it('abort drops every half-built collection and leaves no alias', async () => {
+    const run = await searchIndexWriter({
+      schema,
+      writerFor: blueGreenFor(client),
+    }).openRun(makeRunContext());
+    await run.write(dataset, stream(mixedQuads()));
+    await run.flush?.(dataset, 'success');
+
+    await run.abort(new Error('run failed before commit'));
+
+    expect(await aliasTarget(client, 'datasets')).toBeUndefined();
+    expect(await aliasTarget(client, 'organizations')).toBeUndefined();
+    // Only the lock collection may remain; no half-built versioned collections.
+    const versioned = (await client.collections().retrieve())
+      .map((collection) => collection.name)
+      .filter((name) => /_\d+$/.test(name));
+    expect(versioned).toEqual([]);
+  });
+});

--- a/packages/search-pipeline/test/search-index-writer.test.ts
+++ b/packages/search-pipeline/test/search-index-writer.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, type Mock } from 'vitest';
 import { DataFactory } from 'n3';
 import type { Quad } from '@rdfjs/types';
 import { Dataset } from '@lde/dataset';
 import type { RunContext, RunWriter, Writer } from '@lde/pipeline';
-import { searchSchema, type SearchDocument } from '@lde/search';
+import {
+  searchSchema,
+  type SearchDocument,
+  type SearchType,
+} from '@lde/search';
 import { searchIndexWriter } from '../src/search-index-writer.js';
 
 const { namedNode, literal, quad } = DataFactory;
@@ -31,9 +35,9 @@ const dataset = new Dataset({
   distributions: [],
 });
 
-function personQuads(iri: string, name: string): Quad[] {
+function typedQuads(iri: string, type: string, name: string): Quad[] {
   return [
-    quad(namedNode(iri), namedNode(RDF_TYPE), namedNode(PERSON)),
+    quad(namedNode(iri), namedNode(RDF_TYPE), namedNode(type)),
     quad(namedNode(iri), namedNode(NAME), literal(name)),
   ];
 }
@@ -50,197 +54,381 @@ function makeRunContext(): RunContext {
   };
 }
 
-/** A fake engine writer capturing every per-dataset document write. */
-function makeEngineWriter() {
-  const writes: { dataset: Dataset; documents: SearchDocument[] }[] = [];
-  const runWriter = {
-    write: vi.fn(
-      async (written: Dataset, documents: AsyncIterable<SearchDocument>) => {
+/** One fake engine collection: records every lifecycle call routed to it. */
+interface FakeCollection {
+  readonly searchType: SearchType;
+  readonly writes: { dataset: Dataset; documents: SearchDocument[] }[];
+  readonly flushes: { dataset: Dataset; outcome: string }[];
+  readonly resets: Dataset[];
+  readonly commit: Mock<() => Promise<void>>;
+  readonly abort: Mock<(error: unknown) => Promise<void>>;
+  openRunCalls: number;
+}
+
+/**
+ * A fleet of fake per-type engine writers, one built per {@link SearchType} the
+ * writer asks for. Each records the writes/flushes/lifecycle calls routed to
+ * its collection, so a test can assert the fan-out by type.
+ */
+function makeFleet(
+  overrides: {
+    commit?: (searchType: SearchType) => Promise<void>;
+    flush?: (searchType: SearchType) => Promise<void>;
+    reset?: (searchType: SearchType) => Promise<void>;
+  } = {},
+) {
+  const collections = new Map<string, FakeCollection>();
+  const commitOverride = overrides.commit;
+
+  const writerFor = (searchType: SearchType): Writer<SearchDocument> => {
+    const collection: FakeCollection = {
+      searchType,
+      writes: [],
+      flushes: [],
+      resets: [],
+      commit: vi.fn<() => Promise<void>>(
+        commitOverride
+          ? () => commitOverride(searchType)
+          : () => Promise.resolve(),
+      ),
+      abort: vi.fn<(error: unknown) => Promise<void>>().mockResolvedValue(),
+      openRunCalls: 0,
+    };
+    collections.set(searchType.type, collection);
+
+    const runWriter: RunWriter<SearchDocument> = {
+      write: async (written, documents) => {
         const collected: SearchDocument[] = [];
         for await (const document of documents) {
           collected.push(document);
         }
-        writes.push({ dataset: written, documents: collected });
+        collection.writes.push({ dataset: written, documents: collected });
       },
-    ),
-    flush: vi.fn().mockResolvedValue(undefined),
-    reset: vi.fn().mockResolvedValue(undefined),
-    commit: vi.fn().mockResolvedValue(undefined),
-    abort: vi.fn().mockResolvedValue(undefined),
+      // Record the call first, then run any injected failure, so a test can
+      // assert every collection was reached even when one of them throws.
+      flush: async (written, outcome) => {
+        collection.flushes.push({ dataset: written, outcome });
+        await overrides.flush?.(searchType);
+      },
+      reset: async (written) => {
+        collection.resets.push(written);
+        await overrides.reset?.(searchType);
+      },
+      commit: () => collection.commit(),
+      abort: (error) => collection.abort(error),
+    };
+
+    return {
+      openRun: async () => {
+        collection.openRunCalls += 1;
+        return runWriter;
+      },
+    };
   };
-  const writer: Writer<SearchDocument> & {
-    openRun: ReturnType<typeof vi.fn>;
-  } = {
-    openRun: vi.fn().mockResolvedValue(runWriter),
-  };
-  return { writer, runWriter, writes };
+
+  return { writerFor, collections };
 }
 
-async function openRun(
-  engine: ReturnType<typeof makeEngineWriter>,
+function openRun(
+  fleet: ReturnType<typeof makeFleet>,
 ): Promise<RunWriter<Quad>> {
-  return searchIndexWriter({ schema, writer: engine.writer }).openRun(
+  return searchIndexWriter({ schema, writerFor: fleet.writerFor }).openRun(
     makeRunContext(),
   );
 }
 
+/** The fake collection built for a type (present once the run has opened). */
+function collectionOf(
+  fleet: ReturnType<typeof makeFleet>,
+  type: string,
+): FakeCollection {
+  return fleet.collections.get(type) as FakeCollection;
+}
+
+const ids = (documents: SearchDocument[]) =>
+  documents.map((document) => document.id);
+
 describe('searchIndexWriter', () => {
-  it('projects a dataset’s quads into documents and writes them to the engine on flush', async () => {
-    const engine = makeEngineWriter();
-    const run = await openRun(engine);
+  it('routes each type’s documents to its own collection on flush', async () => {
+    const fleet = makeFleet();
+    const run = await openRun(fleet);
 
     await run.write(
       dataset,
       stream([
-        ...personQuads('http://example.org/person/1', 'Alice'),
-        ...personQuads('http://example.org/person/2', 'Bob'),
+        ...typedQuads('http://example.org/person/1', PERSON, 'Alice'),
+        ...typedQuads('http://example.org/work/1', WORK, 'Nachtwacht'),
       ]),
     );
     await run.flush?.(dataset, 'success');
 
-    expect(engine.writes).toHaveLength(1);
-    expect(engine.writes[0].dataset).toBe(dataset);
-    expect(engine.writes[0].documents).toEqual([
-      { id: 'http://example.org/person/1', name: ['Alice'] },
-      { id: 'http://example.org/person/2', name: ['Bob'] },
+    const person = collectionOf(fleet, PERSON);
+    const work = collectionOf(fleet, WORK);
+    expect(person.writes).toHaveLength(1);
+    expect(ids(person.writes[0].documents)).toEqual([
+      'http://example.org/person/1',
     ]);
-    expect(engine.runWriter.flush).toHaveBeenCalledExactlyOnceWith(
-      dataset,
-      'success',
-    );
+    expect(work.writes).toHaveLength(1);
+    expect(ids(work.writes[0].documents)).toEqual([
+      'http://example.org/work/1',
+    ]);
   });
 
-  it('projects every root type in the schema', async () => {
-    const engine = makeEngineWriter();
-    const run = await openRun(engine);
+  it('builds one engine writer per type and opens each once', async () => {
+    const fleet = makeFleet();
+    await openRun(fleet);
 
-    await run.write(
-      dataset,
-      stream([
-        ...personQuads('http://example.org/person/1', 'Alice'),
-        quad(
-          namedNode('http://example.org/work/1'),
-          namedNode(RDF_TYPE),
-          namedNode(WORK),
-        ),
-        quad(
-          namedNode('http://example.org/work/1'),
-          namedNode(NAME),
-          literal('Nachtwacht'),
-        ),
-      ]),
-    );
-    await run.flush?.(dataset, 'success');
-
-    const ids = engine.writes[0].documents.map((document) => document.id);
-    expect(ids).toContain('http://example.org/person/1');
-    expect(ids).toContain('http://example.org/work/1');
+    expect([...fleet.collections.keys()].sort()).toEqual([PERSON, WORK].sort());
+    for (const collection of fleet.collections.values()) {
+      expect(collection.openRunCalls).toBe(1);
+    }
   });
 
   it('combines multiple writes for one dataset into a single projection', async () => {
-    // A dataset writes once per stage; all stages’ quads project together.
-    const engine = makeEngineWriter();
-    const run = await openRun(engine);
+    const fleet = makeFleet();
+    const run = await openRun(fleet);
 
     await run.write(
       dataset,
-      stream(personQuads('http://example.org/person/1', 'Alice')),
+      stream(typedQuads('http://example.org/person/1', PERSON, 'Alice')),
     );
     await run.write(
       dataset,
-      stream(personQuads('http://example.org/person/2', 'Bob')),
+      stream(typedQuads('http://example.org/person/2', PERSON, 'Bob')),
     );
     await run.flush?.(dataset, 'success');
 
-    expect(engine.writes).toHaveLength(1);
-    expect(engine.writes[0].documents.map((document) => document.id)).toEqual([
+    const person = collectionOf(fleet, PERSON);
+    expect(person.writes).toHaveLength(1);
+    expect(ids(person.writes[0].documents)).toEqual([
       'http://example.org/person/1',
       'http://example.org/person/2',
     ]);
   });
 
   it('does not accumulate quads across dataset flushes', async () => {
-    const engine = makeEngineWriter();
-    const run = await openRun(engine);
+    const fleet = makeFleet();
+    const run = await openRun(fleet);
 
     await run.write(
       dataset,
-      stream(personQuads('http://example.org/person/1', 'Alice')),
+      stream(typedQuads('http://example.org/person/1', PERSON, 'Alice')),
     );
     await run.flush?.(dataset, 'success');
     await run.write(
       dataset,
-      stream(personQuads('http://example.org/person/2', 'Bob')),
+      stream(typedQuads('http://example.org/person/2', PERSON, 'Bob')),
     );
     await run.flush?.(dataset, 'success');
 
-    expect(engine.writes).toHaveLength(2);
-    expect(engine.writes[1].documents.map((document) => document.id)).toEqual([
+    const person = collectionOf(fleet, PERSON);
+    expect(person.writes).toHaveLength(2);
+    expect(ids(person.writes[1].documents)).toEqual([
       'http://example.org/person/2',
     ]);
   });
 
-  it('forwards a flush without any writes, but writes no documents', async () => {
-    const engine = makeEngineWriter();
-    const run = await openRun(engine);
+  it('flushes every collection on a dataset flush, even ones with no documents', async () => {
+    const fleet = makeFleet();
+    const run = await openRun(fleet);
 
-    await run.flush?.(dataset, 'success');
-
-    expect(engine.runWriter.write).not.toHaveBeenCalled();
-    expect(engine.runWriter.flush).toHaveBeenCalledExactlyOnceWith(
+    // Only Person quads: the Work collection receives no documents this dataset.
+    await run.write(
       dataset,
-      'success',
+      stream(typedQuads('http://example.org/person/1', PERSON, 'Alice')),
     );
-  });
-
-  it('writes no documents for a dataset whose extraction was empty', async () => {
-    const engine = makeEngineWriter();
-    const run = await openRun(engine);
-
-    await run.write(dataset, stream([]));
     await run.flush?.(dataset, 'success');
 
-    expect(engine.runWriter.write).not.toHaveBeenCalled();
-    expect(engine.runWriter.flush).toHaveBeenCalledOnce();
+    const work = collectionOf(fleet, WORK);
+    expect(work.writes).toHaveLength(0);
+    // …but still gets its flush, so an In-place stale sweep can reconcile.
+    expect(work.flushes).toEqual([{ dataset, outcome: 'success' }]);
   });
 
-  it('reset discards the buffered pass and forwards to the engine', async () => {
-    const engine = makeEngineWriter();
-    const run = await openRun(engine);
+  it('forwards a flush that had no writes to every collection', async () => {
+    const fleet = makeFleet();
+    const run = await openRun(fleet);
+
+    await run.flush?.(dataset, 'success');
+
+    for (const collection of fleet.collections.values()) {
+      expect(collection.writes).toHaveLength(0);
+      expect(collection.flushes).toEqual([{ dataset, outcome: 'success' }]);
+    }
+  });
+
+  it('writes no documents for a dataset whose extraction was empty, but still flushes', async () => {
+    const fleet = makeFleet();
+    const run = await openRun(fleet);
+
+    await run.write(dataset, stream<Quad>([]));
+    await run.flush?.(dataset, 'success');
+
+    for (const collection of fleet.collections.values()) {
+      expect(collection.writes).toHaveLength(0);
+      expect(collection.flushes).toEqual([{ dataset, outcome: 'success' }]);
+    }
+  });
+
+  it('flushes every collection even when one collection’s flush fails, then surfaces it', async () => {
+    // The Person collection's flush (e.g. a rollback of a failed dataset)
+    // throws; the Work collection must still be flushed, not skipped.
+    const failure = new Error('person rollback failed');
+    const fleet = makeFleet({
+      flush: (searchType) =>
+        searchType.type === PERSON
+          ? Promise.reject(failure)
+          : Promise.resolve(),
+    });
+    const run = await openRun(fleet);
+
+    await expect(run.flush?.(dataset, 'failed')).rejects.toThrow(
+      AggregateError,
+    );
+
+    expect(collectionOf(fleet, WORK).flushes).toEqual([
+      { dataset, outcome: 'failed' },
+    ]);
+    expect(collectionOf(fleet, PERSON).flushes).toEqual([
+      { dataset, outcome: 'failed' },
+    ]);
+  });
+
+  it('resets every collection even when one collection’s reset fails, then surfaces it', async () => {
+    const failure = new Error('person reset failed');
+    const fleet = makeFleet({
+      reset: (searchType) =>
+        searchType.type === PERSON
+          ? Promise.reject(failure)
+          : Promise.resolve(),
+    });
+    const run = await openRun(fleet);
+
+    await expect(run.reset?.(dataset)).rejects.toThrow(AggregateError);
+
+    expect(collectionOf(fleet, WORK).resets).toEqual([dataset]);
+    expect(collectionOf(fleet, PERSON).resets).toEqual([dataset]);
+  });
+
+  it('reset discards the buffered pass and forwards to every collection', async () => {
+    const fleet = makeFleet();
+    const run = await openRun(fleet);
 
     await run.write(
       dataset,
-      stream(personQuads('http://example.org/person/1', 'Endpoint pass')),
+      stream(typedQuads('http://example.org/person/1', PERSON, 'Endpoint')),
     );
     await run.reset?.(dataset);
     await run.write(
       dataset,
-      stream(personQuads('http://example.org/person/1', 'Dump pass')),
+      stream(typedQuads('http://example.org/person/1', PERSON, 'Dump')),
     );
     await run.flush?.(dataset, 'success');
 
-    expect(engine.runWriter.reset).toHaveBeenCalledExactlyOnceWith(dataset);
-    expect(engine.writes).toHaveLength(1);
-    expect(engine.writes[0].documents).toEqual([
-      { id: 'http://example.org/person/1', name: ['Dump pass'] },
+    const person = collectionOf(fleet, PERSON);
+    expect(person.resets).toEqual([dataset]);
+    expect(collectionOf(fleet, WORK).resets).toEqual([dataset]);
+    expect(person.writes).toHaveLength(1);
+    expect(person.writes[0].documents).toEqual([
+      { id: 'http://example.org/person/1', name: ['Dump'] },
     ]);
   });
 
-  it('projects never-flushed leftovers on commit, then commits the engine run', async () => {
-    const engine = makeEngineWriter();
-    const run = await openRun(engine);
+  it('projects never-flushed leftovers on commit, then commits every collection', async () => {
+    const fleet = makeFleet();
+    const run = await openRun(fleet);
 
     await run.write(
       dataset,
-      stream(personQuads('http://example.org/person/1', 'Alice')),
+      stream(typedQuads('http://example.org/person/1', PERSON, 'Alice')),
     );
     await run.commit();
 
-    expect(engine.writes).toHaveLength(1);
-    expect(engine.runWriter.commit).toHaveBeenCalledOnce();
+    const person = collectionOf(fleet, PERSON);
+    expect(person.writes).toHaveLength(1);
+    expect(person.commit).toHaveBeenCalledOnce();
+    expect(collectionOf(fleet, WORK).commit).toHaveBeenCalledOnce();
   });
 
-  it('tolerates an engine writer without flush and reset', async () => {
+  it('commits every collection independently and aggregates the failures', async () => {
+    // The Work collection’s commit fails; the Person collection must still go
+    // live, and the failure must surface as an AggregateError.
+    const failure = new Error('work collection swap failed');
+    const fleet = makeFleet({
+      commit: (searchType) =>
+        searchType.type === WORK ? Promise.reject(failure) : Promise.resolve(),
+    });
+    const run = await openRun(fleet);
+
+    await expect(run.commit()).rejects.toThrow(AggregateError);
+
+    const person = collectionOf(fleet, PERSON);
+    const work = collectionOf(fleet, WORK);
+    expect(person.commit).toHaveBeenCalledOnce();
+    expect(work.commit).toHaveBeenCalledOnce();
+  });
+
+  it('abort after a partial commit finalizes only the collections that did not go live', async () => {
+    const failure = new Error('work collection swap failed');
+    const fleet = makeFleet({
+      commit: (searchType) =>
+        searchType.type === WORK ? Promise.reject(failure) : Promise.resolve(),
+    });
+    const run = await openRun(fleet);
+
+    await expect(run.commit()).rejects.toThrow(AggregateError);
+    // The pipeline aborts the run after commit throws.
+    await run.abort(failure);
+
+    // Person committed live: aborting it would drop its now-live collection.
+    expect(collectionOf(fleet, PERSON).abort).not.toHaveBeenCalled();
+    // Work never went live, so it is finalized (its half-built collection
+    // dropped, its lock released).
+    expect(collectionOf(fleet, WORK).abort).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back already-opened collections when a later openRun fails', async () => {
+    const opened: SearchType[] = [];
+    const aborted: SearchType[] = [];
+    const failure = new Error('lock held');
+    const writerFor = (searchType: SearchType): Writer<SearchDocument> => ({
+      openRun: async () => {
+        // The second type to open fails; the first must be rolled back.
+        if (opened.length === 1) {
+          throw failure;
+        }
+        opened.push(searchType);
+        return {
+          write: () => Promise.resolve(),
+          commit: () => Promise.resolve(),
+          abort: async () => {
+            aborted.push(searchType);
+          },
+        };
+      },
+    });
+
+    await expect(
+      searchIndexWriter({ schema, writerFor }).openRun(makeRunContext()),
+    ).rejects.toBe(failure);
+    // Exactly the one opened run was aborted; no run leaks its lock.
+    expect(aborted).toHaveLength(1);
+    expect(aborted[0]).toBe(opened[0]);
+  });
+
+  it('forwards abort with the run failure to every collection', async () => {
+    const fleet = makeFleet();
+    const run = await openRun(fleet);
+    const failure = new Error('selection died');
+
+    await run.abort(failure);
+
+    for (const collection of fleet.collections.values()) {
+      expect(collection.abort).toHaveBeenCalledExactlyOnceWith(failure);
+    }
+  });
+
+  it('tolerates engine writers without flush and reset', async () => {
     const written: SearchDocument[] = [];
     const minimalEngine: Writer<SearchDocument> = {
       openRun: async () => ({
@@ -255,39 +443,40 @@ describe('searchIndexWriter', () => {
     };
     const run = await searchIndexWriter({
       schema,
-      writer: minimalEngine,
+      writerFor: () => minimalEngine,
     }).openRun(makeRunContext());
 
     await run.write(
       dataset,
-      stream(personQuads('http://example.org/person/1', 'Alice')),
+      stream(typedQuads('http://example.org/person/1', PERSON, 'Alice')),
     );
     await run.reset?.(dataset);
     await run.write(
       dataset,
-      stream(personQuads('http://example.org/person/1', 'Alice')),
+      stream(typedQuads('http://example.org/person/1', PERSON, 'Alice')),
     );
     await run.flush?.(dataset, 'success');
 
     expect(written).toHaveLength(1);
   });
 
-  it('forwards abort with the run failure', async () => {
-    const engine = makeEngineWriter();
-    const run = await openRun(engine);
-    const failure = new Error('selection died');
-
-    await run.abort(failure);
-
-    expect(engine.runWriter.abort).toHaveBeenCalledExactlyOnceWith(failure);
-  });
-
-  it('opens the engine run with the pipeline’s run context', async () => {
-    const engine = makeEngineWriter();
+  it('opens every collection’s run with the pipeline’s run context', async () => {
+    const contexts: RunContext[] = [];
+    const writerFor = (): Writer<SearchDocument> => ({
+      openRun: async (context) => {
+        contexts.push(context);
+        return {
+          write: () => Promise.resolve(),
+          commit: () => Promise.resolve(),
+          abort: () => Promise.resolve(),
+        };
+      },
+    });
     const context = makeRunContext();
 
-    await searchIndexWriter({ schema, writer: engine.writer }).openRun(context);
+    await searchIndexWriter({ schema, writerFor }).openRun(context);
 
-    expect(engine.writer.openRun).toHaveBeenCalledExactlyOnceWith(context);
+    expect(contexts).toHaveLength(2);
+    expect(contexts.every((seen) => seen === context)).toBe(true);
   });
 });

--- a/packages/search-pipeline/test/typesense-container.ts
+++ b/packages/search-pipeline/test/typesense-container.ts
@@ -1,0 +1,56 @@
+import {
+  GenericContainer,
+  Wait,
+  type StartedTestContainer,
+} from 'testcontainers';
+import { Client } from 'typesense';
+
+/**
+ * Typesense testcontainer for the integration test, mirroring the one in
+ * `@lde/search-typesense`. Starts a single-node server and hands back a
+ * configured client pointed at the mapped port.
+ *
+ * Image pinned to v30 (matches the engine adapter’s consumers).
+ */
+export class TypesenseContainer {
+  public readonly apiKey = 'test-api-key';
+  private container: StartedTestContainer | null = null;
+  private readonly port = 8108;
+
+  async start(): Promise<Client> {
+    this.container = await new GenericContainer('typesense/typesense:30.0')
+      .withExposedPorts(this.port)
+      .withCommand([
+        '--data-dir=/tmp',
+        `--api-key=${this.apiKey}`,
+        '--enable-cors',
+      ])
+      .withWaitStrategy(Wait.forHttp('/health', this.port).forStatusCode(200))
+      .start();
+    return this.client();
+  }
+
+  client(): Client {
+    if (!this.container) {
+      throw new Error('Typesense container is not started');
+    }
+    return new Client({
+      nodes: [
+        {
+          host: this.container.getHost(),
+          port: this.container.getMappedPort(this.port),
+          protocol: 'http',
+        },
+      ],
+      apiKey: this.apiKey,
+      connectionTimeoutSeconds: 5,
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.container) {
+      await this.container.stop();
+      this.container = null;
+    }
+  }
+}

--- a/packages/search-pipeline/tsconfig.lib.json
+++ b/packages/search-pipeline/tsconfig.lib.json
@@ -10,13 +10,16 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../dataset/tsconfig.lib.json"
+      "path": "../search/tsconfig.lib.json"
+    },
+    {
+      "path": "../search-typesense/tsconfig.lib.json"
     },
     {
       "path": "../pipeline/tsconfig.lib.json"
     },
     {
-      "path": "../search/tsconfig.lib.json"
+      "path": "../dataset/tsconfig.lib.json"
     }
   ],
   "exclude": [

--- a/packages/search-pipeline/tsconfig.spec.json
+++ b/packages/search-pipeline/tsconfig.spec.json
@@ -5,6 +5,7 @@
     "types": ["node"]
   },
   "include": [
+    "test/**/*.ts",
     "test/**/*.test.ts",
     "test/**/*.spec.ts",
     "test/**/*.test.tsx",

--- a/packages/search-typesense/src/blue-green-rebuild.ts
+++ b/packages/search-typesense/src/blue-green-rebuild.ts
@@ -121,6 +121,13 @@ export class BlueGreenRebuild<
 
         commit: async () => {
           await importer.flush();
+          // The alias swap is the commit point: once it lands the new
+          // collection is live. Everything after it is best-effort cleanup that
+          // must NOT fail the commit – a post-swap rejection would otherwise
+          // reject `commit`, and a caller that aborts on that (the pipeline
+          // does) would drop the collection the alias now points at. So both
+          // the superseded-collection delete and the lock release swallow
+          // their errors; a lock left held is reclaimed on its TTL.
           await this.client
             .aliases()
             .upsert(name, { collection_name: collection });
@@ -130,7 +137,7 @@ export class BlueGreenRebuild<
               .delete()
               .catch(() => undefined);
           }
-          await releaseLock(this.client, name);
+          await releaseLock(this.client, name).catch(() => undefined);
         },
 
         abort: async () => {

--- a/packages/search-typesense/test/rebuild-error-paths.test.ts
+++ b/packages/search-typesense/test/rebuild-error-paths.test.ts
@@ -87,6 +87,23 @@ describe('BlueGreenRebuild error paths', () => {
     await expect(writer.openRun(makeRunContext())).rejects.toThrow('HTTP 500');
     expect(releasedLocks).toHaveBeenCalledOnce();
   });
+
+  it('stays committed when releasing the lock fails after the alias swap', async () => {
+    const { client, releasedLocks } = fakeClient({});
+    // The alias has already swapped (the new collection is live); only the
+    // post-swap lock release then fails.
+    releasedLocks.mockRejectedValue(typesenseError(500));
+    const writer = new BlueGreenRebuild(client, searchType, {
+      name: 'datasets',
+    });
+
+    const run = await writer.openRun(makeRunContext());
+    // commit must not reject: a caller that aborts on a rejected commit (the
+    // pipeline does) would otherwise drop the collection the alias now points
+    // at. The lock is left to its TTL reclaim instead.
+    await expect(run.commit()).resolves.toBeUndefined();
+    expect(releasedLocks).toHaveBeenCalledOnce();
+  });
 });
 
 describe('InPlaceRebuild error paths', () => {

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these — see AGENTS.md.
-          functions: 98.38,
-          lines: 98.16,
-          branches: 92.62,
-          statements: 98.2,
+          functions: 98.63,
+          lines: 98.79,
+          branches: 93.18,
+          statements: 98.81,
         },
       },
     },

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -150,8 +150,14 @@ const DATASET = defineSearchType({
   ],
 });
 
-for await (const document of projectGraph(quads, searchSchema(DATASET))) {
-  // one flat search document per matching subject, streamed
+for await (const { searchType, document } of projectGraph(
+  quads,
+  searchSchema(DATASET),
+)) {
+  // one flat search document per matching subject, streamed and tagged with the
+  // SearchType it was framed from — so a multi-collection writer can route each
+  // document to the collection for its type. A single-collection consumer just
+  // reads `document`.
 }
 ```
 
@@ -217,6 +223,12 @@ flat at scale (framing the whole graph at once is roughly O(N²)). Duplicate
 triples are collapsed first, because some SPARQL engines (e.g. QLever) do not
 deduplicate `CONSTRUCT` output. The IR carries no `@context`, so a `derive` function
 reading it sees full predicate IRIs with language tags preserved.
+
+Each yielded value is a `{ searchType, document }` pair: the whole schema
+projects into **one** mixed stream, and every document is tagged with the
+`SearchType` it was framed from. That tag is what lets the write side fan the
+stream out to per-type collections without re-deriving the type from the
+document — see `@lde/search-pipeline`’s multi-collection writer.
 
 `projectGraph` **consumes the quads once** – a single scan builds the subject
 index every type frames off – and so accepts any `Iterable<Quad>`, not just a

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -8,7 +8,7 @@
 // unified SearchField/SearchType model. The IR readers (irisOf, …) are here
 // because `derive` functions are written against them.
 export { projectGraph, irisOf, literalsOf, firstLiteralOf } from './project.js';
-export type { SearchDocument } from './project.js';
+export type { SearchDocument, TypedSearchDocument } from './project.js';
 
 // Unified field model: one declaration drives projection, engine collection
 // schema, query semantics and the GraphQL surface — a discriminated union by

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -20,6 +20,17 @@ import {
 export type SearchDocument = { id: string } & Record<string, unknown>;
 
 /**
+ * A projected document tagged with the {@link SearchType} it was projected
+ * from — one element of {@link projectGraph}’s mixed, whole-schema stream. The
+ * tag is what lets a multi-collection writer route each document to the
+ * collection for its type without re-deriving the type from the document.
+ */
+export interface TypedSearchDocument {
+  readonly searchType: SearchType;
+  readonly document: SearchDocument;
+}
+
+/**
  * Project one framed JSON-LD node into a flat search document: apply each field
  * of the type in declaration order. A field with a `derive` function computes
  * its value from the node and the document as populated so far (so a derived
@@ -46,9 +57,12 @@ export function projectDocument(
 
 /**
  * Frame `quads` for every root type in the schema and project each node with its
- * type’s declaration — the multi-shape pipeline. Streams one document at a time
- * so memory stays flat. The IR maps to a declaration by type, so adding a shape
- * is adding a `SearchType` to the schema (no engine change).
+ * type’s declaration — the multi-shape pipeline. Yields each document tagged
+ * with its {@link SearchType} ({@link TypedSearchDocument}), so a downstream
+ * multi-collection writer can route it to that type’s collection; a
+ * single-collection consumer just reads `.document`. Streams one document at a
+ * time so memory stays flat. The IR maps to a declaration by type, so adding a
+ * shape is adding a `SearchType` to the schema (no engine change).
  *
  * Consumes `quads` once (a single scan builds the shared subject index that
  * every type frames off), so it accepts any `Iterable` – a materialized array or
@@ -58,7 +72,7 @@ export function projectDocument(
 export async function* projectGraph(
   quads: Iterable<Quad>,
   schema: SearchSchema,
-): AsyncIterable<SearchDocument> {
+): AsyncIterable<TypedSearchDocument> {
   const types = [...schema.values()];
   const index = buildSubjectIndex(
     quads,
@@ -66,7 +80,7 @@ export async function* projectGraph(
   );
   for (const searchType of types) {
     for await (const node of frameSubjects(index, searchType.type)) {
-      yield projectDocument(node, searchType);
+      yield { searchType, document: projectDocument(node, searchType) };
     }
   }
 }

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -484,10 +484,11 @@ describe('projectGraph', () => {
     `);
 
     const documents: SearchDocument[] = [];
-    for await (const document of projectGraph(
+    for await (const { searchType, document } of projectGraph(
       quads,
       searchSchema({ name: 'Dataset', type: DATASET, fields }),
     )) {
+      expect(searchType.name).toBe('Dataset');
       documents.push(document);
     }
 
@@ -514,20 +515,25 @@ describe('projectGraph', () => {
       yield* quads;
     }
 
-    const documents: SearchDocument[] = [];
-    for await (const document of projectGraph(
+    const tagged: { type: string; id: string }[] = [];
+    for await (const { searchType, document } of projectGraph(
       once(),
       searchSchema(
         { name: 'Dataset', type: DATASET, fields },
         { name: 'Other', type: other, fields },
       ),
     )) {
-      documents.push(document);
+      tagged.push({ type: searchType.type, id: document.id });
     }
 
-    expect(documents.map((document) => document.id).sort()).toEqual([
+    expect(tagged.map((entry) => entry.id).sort()).toEqual([
       'https://ex/d/1',
       'https://ex/x/1',
     ]);
+    // Each document carries the type it was framed from, so a writer can route
+    // it to that type’s collection.
+    expect(
+      Object.fromEntries(tagged.map((entry) => [entry.id, entry.type])),
+    ).toEqual({ 'https://ex/d/1': DATASET, 'https://ex/x/1': other });
   });
 });


### PR DESCRIPTION
Fix #590.

A single validated `SearchSchema` declares several root types. The Dataset Register indexes four collections – `datasets` plus the Organization / Class / TerminologySource label collections its references resolve against (ADR 8) – and each type derives its own Typesense collection schema, so they are four independent blue/green rebuilds. `projectGraph` already projects the whole schema in one pass, but nothing joined that mixed stream to the per-type collections: a consumer had to forge a per-type schema brand, hand-roll a per-type rebuild loop and cast a per-type projection. This adds the transactional, domain-agnostic multi-collection Writer that closes that gap.

## Changes

**`@lde/search` (breaking).** `projectGraph` now yields `{ searchType, document }` (`TypedSearchDocument`) instead of a bare `SearchDocument`. The whole schema still projects into one mixed, single-scan stream; the tag is what lets the write side route each document to the collection for its type without re-deriving the type. A single-collection consumer just reads `.document`.

**`@lde/search-pipeline` (breaking).** `searchIndexWriter` now takes a `writerFor(searchType)` factory instead of a single `writer`. It builds one engine writer per root type, opens one engine run per type, buffers each dataset's quads until flush, projects once over the whole schema, then dispatches each document to the run for its type. It stays a `Writer<Quad>`; the pipeline drives `openRun → write* → commit/abort` uniformly and never branches on how many collections there are. A single-collection deployment is just the N=1 case – so the Dataset Register's forged brand, per-type projection casts and hand-rolled rebuild loop all collapse into “project the schema, hand it the stream”. `commit`, `flush`, and `reset` all fan out per collection independently (`allSettled` + aggregate), so one collection's failure never skips another's.

**`@lde/search-typesense` (fix).** `BlueGreenRebuild.commit` released its lock unguarded *after* the alias swap, so a transient failure there rejected `commit` once the collection was already live – and a caller that aborts on a rejected commit (the pipeline does) would then drop the now-live collection. The commit is now atomic at the swap: the post-swap lock release is best-effort (the lock is reclaimed on its TTL), matching the already-guarded superseded-collection delete. Surfaced by the multi-collection Writer's `committed`/abort-only-uncommitted design, which relies on `commit` being atomic at go-live.

## Per-collection isolation

Each type is an independent blue/green rebuild (own collection, alias, lock), so the collections commit, sweep and fail in isolation:

- an empty projection for one type touches only its own collection – the #569 empty-selection guard becomes per collection by construction, not a global gate;
- `commit` finalizes every collection independently and, if any fails, throws an `AggregateError` **after** attempting them all, so a non-critical label-collection failure never blocks the collections that did commit – the `datasets` index still goes live – while the failure is still surfaced (the run is marked failed);
- because the pipeline aborts a run whose `commit` throws, `abort` finalizes only the collections that did **not** already go live (aborting a committed blue/green rebuild would drop its now-live collection), dropping the half-built ones and releasing their locks. A failure while opening the per-type runs rolls the already-opened ones back the same way.

This settles the issue's open questions: placement is option (a) – a composition in `@lde/search-pipeline` over N single-collection engine writers, keeping the engine adapter single-collection and the fan-out engine-agnostic; the partial-failure policy is fail-the-run-but-commit-what-can (the safest default, no silent staleness), documented so skip-and-report can layer on later without changing the routing.

## Tests & docs

- Unit test for the routing, per-collection lifecycle, commit-failure aggregation, commit-aware abort and open-time rollback (fakes).
- Typesense-container integration test asserting independent swaps from one mixed stream, a forced one-type commit failure leaving the others live and sweeping the half-built one, an empty projection committing an empty collection without touching the others, and `abort` dropping every half-built collection.
- ADR 9 (topology + partial-failure policy); README updates in `@lde/search`, `@lde/search-pipeline` and the root packages table.

Stacked on #580 (`Iterable<Quad>` in `projectGraph`), now merged; rebased onto main.
