### PR TITLE
feat(pipeline-shacl-validator)!: write a conforming report for every validated dataset

### DIFF
--- a/packages/pipeline-shacl-validator/README.md
+++ b/packages/pipeline-shacl-validator/README.md
@@ -91,7 +91,7 @@ finishes a dataset.
 A dataset validated with no results of any severity still yields a report: a
 minimal conforming `sh:ValidationReport` (with `sh:conforms true` and no
 results) is written from `report(dataset)`. So **every validated dataset
-produces a report, and its absence means the dataset was not validated** — a
+produces a report, and its absence means the dataset was not validated** – a
 distinction consumers can rely on. It also means a re-run in which a dataset
 becomes conforming overwrites its prior report rather than leaving stale
 violations behind. Only a dataset that was never validated (no `validate()`

--- a/packages/pipeline-shacl-validator/README.md
+++ b/packages/pipeline-shacl-validator/README.md
@@ -88,6 +88,15 @@ via `Writer.write(dataset, quads)`. Each writer's `Writer.flush(dataset)` is
 invoked from `ShaclValidator.report(dataset)` — i.e. once the pipeline
 finishes a dataset.
 
+A dataset validated with no results of any severity still yields a report: a
+minimal conforming `sh:ValidationReport` (with `sh:conforms true` and no
+results) is written from `report(dataset)`. So **every validated dataset
+produces a report, and its absence means the dataset was not validated** — a
+distinction consumers can rely on. It also means a re-run in which a dataset
+becomes conforming overwrites its prior report rather than leaving stale
+violations behind. Only a dataset that was never validated (no `validate()`
+call reached it) produces nothing.
+
 Validators with no `reportWriters` only produce aggregate counts
 (`{ conforms, violations, quadsValidated }`); the report quads themselves are
 discarded. This is deliberate — callers who only need pass/fail metrics

--- a/packages/pipeline-shacl-validator/src/shacl-validator.ts
+++ b/packages/pipeline-shacl-validator/src/shacl-validator.ts
@@ -17,6 +17,7 @@ import { rdfDereferencer } from 'rdf-dereference';
 import { skolemizeReport } from './skolemize-report.js';
 
 const shacl = 'http://www.w3.org/ns/shacl#';
+const rdfType = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
 /**
  * The severity level IRIs defined by SHACL Core, for use in
@@ -36,10 +37,10 @@ export interface ShaclValidatorOptions {
    * Writers that receive the per-dataset SHACL validation report quads. The
    * validator opens one run per writer (lazily) and streams each batch that
    * has results to it; a dataset validated with no results of any severity is
-   * still reported — a minimal conforming report is written when its run is
+   * still reported – a minimal conforming report is written when its run is
    * flushed per dataset from {@link ShaclValidator.report}. So every validated
    * dataset yields a report, and its absence means the dataset was not
-   * validated — which lets a now-conforming run overwrite a prior run's stale
+   * validated – which lets a now-conforming run overwrite a prior run's stale
    * report rather than leave it in place.
    *
    * Pass a {@link FileWriter} to land reports on disk, a
@@ -171,12 +172,20 @@ export class ShaclValidator implements Validator {
 
     // A dataset that was validated but produced no results of any severity
     // still gets a report: a minimal conforming report, written here once
-    // before the flush. This makes report presence mean “validated” — its
-    // absence, “not validated” — and lets a now-conforming run overwrite a
+    // before the flush. This makes report presence mean “validated” – its
+    // absence, “not validated” – and lets a now-conforming run overwrite a
     // prior run's stale violation report rather than leave it in place.
     // Datasets that already streamed a report (violations or warnings) keep
-    // it; unseen datasets (no accumulator) write nothing.
-    if (acc && !acc.reportWritten && this.reportWriters.length > 0) {
+    // it; unseen datasets (no accumulator) write nothing. The acc.conforms
+    // guard is belt-and-suspenders: a non-conforming dataset whose report
+    // write failed mid-batch (leaving reportWritten false) must not be
+    // relabelled conforming here.
+    if (
+      acc &&
+      acc.conforms &&
+      !acc.reportWritten &&
+      this.reportWriters.length > 0
+    ) {
       const reportQuads = this.conformingReportQuads(key);
       for (const run of await this.runs()) {
         await run.write(dataset, asyncIterableOf(reportQuads));
@@ -237,8 +246,7 @@ export class ShaclValidator implements Validator {
     // typed sh:ValidationResult).
     const reportNode = reportQuads.find(
       (q) =>
-        q.predicate.value ===
-          'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
+        q.predicate.value === rdfType &&
         q.object.value === `${shacl}ValidationReport`,
     )!.subject;
 
@@ -280,7 +288,7 @@ export class ShaclValidator implements Validator {
     const quads = [
       rdf.quad(
         reportNode,
-        rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        rdf.namedNode(rdfType),
         rdf.namedNode(`${shacl}ValidationReport`),
       ),
       rdf.quad(

--- a/packages/pipeline-shacl-validator/src/shacl-validator.ts
+++ b/packages/pipeline-shacl-validator/src/shacl-validator.ts
@@ -34,12 +34,16 @@ export interface ShaclValidatorOptions {
   shapesFile: string;
   /**
    * Writers that receive the per-dataset SHACL validation report quads. The
-   * validator opens one run per writer (lazily, on the first validation
-   * result of any severity) and streams each batch with results to it; each
-   * run is flushed per dataset from {@link ShaclValidator.report}.
+   * validator opens one run per writer (lazily) and streams each batch that
+   * has results to it; a dataset validated with no results of any severity is
+   * still reported — a minimal conforming report is written when its run is
+   * flushed per dataset from {@link ShaclValidator.report}. So every validated
+   * dataset yields a report, and its absence means the dataset was not
+   * validated — which lets a now-conforming run overwrite a prior run's stale
+   * report rather than leave it in place.
    *
-   * Pass a {@link FileWriter} to mirror the previous on-disk behaviour, a
-   * {@link SparqlUpdateWriter} to land reports in a named graph, or any custom
+   * Pass a {@link FileWriter} to land reports on disk, a
+   * {@link SparqlUpdateWriter} to land them in a named graph, or any custom
    * writer. Validators with no `reportWriters` only produce aggregate counts.
    */
   reportWriters?: Writer[];
@@ -66,6 +70,7 @@ interface DatasetAccumulator {
   quadsValidated: number;
   violations: number;
   conforms: boolean;
+  reportWritten: boolean;
 }
 
 /**
@@ -122,6 +127,7 @@ export class ShaclValidator implements Validator {
       quadsValidated: 0,
       violations: 0,
       conforms: true,
+      reportWritten: false,
     };
     acc.quadsValidated += quads.length;
     acc.violations += violations;
@@ -129,7 +135,10 @@ export class ShaclValidator implements Validator {
     this.accumulators.set(key, acc);
 
     // Reports are written whenever there are results, conforming or not, so
-    // below-threshold results (e.g. warnings) stay visible to consumers.
+    // below-threshold results (e.g. warnings) stay visible to consumers. A
+    // dataset with no results of any severity is reported instead from
+    // {@link report} as a minimal conforming report, so every validated
+    // dataset yields a report.
     if (results.length > 0 && this.reportWriters.length > 0) {
       // Skolemise the report's blank nodes to dataset-scoped IRIs before writing.
       // shacl-engine emits the report and every result as blank nodes, whose
@@ -143,6 +152,7 @@ export class ShaclValidator implements Validator {
       for (const run of await this.runs()) {
         await run.write(dataset, asyncIterableOf(reportQuads));
       }
+      acc.reportWritten = true;
     }
 
     // Surface where to look for the report in halt-mode error messages
@@ -156,6 +166,24 @@ export class ShaclValidator implements Validator {
   }
 
   async report(dataset: Dataset): Promise<ValidationReport> {
+    const key = dataset.iri.toString();
+    const acc = this.accumulators.get(key);
+
+    // A dataset that was validated but produced no results of any severity
+    // still gets a report: a minimal conforming report, written here once
+    // before the flush. This makes report presence mean “validated” — its
+    // absence, “not validated” — and lets a now-conforming run overwrite a
+    // prior run's stale violation report rather than leave it in place.
+    // Datasets that already streamed a report (violations or warnings) keep
+    // it; unseen datasets (no accumulator) write nothing.
+    if (acc && !acc.reportWritten && this.reportWriters.length > 0) {
+      const reportQuads = this.conformingReportQuads(key);
+      for (const run of await this.runs()) {
+        await run.write(dataset, asyncIterableOf(reportQuads));
+      }
+      acc.reportWritten = true;
+    }
+
     // Flush is the per-dataset completion hook regardless of whether the
     // dataset produced violations, so open the runs here if no write did.
     // The report stream itself completed, whatever the dataset's own data
@@ -164,8 +192,6 @@ export class ShaclValidator implements Validator {
       await run.flush?.(dataset, 'success');
     }
 
-    const key = dataset.iri.toString();
-    const acc = this.accumulators.get(key);
     if (!acc) {
       return { conforms: true, violations: 0, quadsValidated: 0 };
     }
@@ -240,6 +266,33 @@ export class ShaclValidator implements Validator {
       );
     }
     return amended;
+  }
+
+  /**
+   * The minimal conforming report written for a dataset validated with no
+   * results of any severity: a single `sh:ValidationReport` node with
+   * `sh:conforms true`. Skolemised and amended exactly like the engine's own
+   * reports, so it is self-describing (carrying `sh:conformanceDisallows` when
+   * configured) and dataset-scoped like every other report in the graph.
+   */
+  private conformingReportQuads(datasetIri: string): Quad[] {
+    const reportNode = rdf.blankNode();
+    const quads = [
+      rdf.quad(
+        reportNode,
+        rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        rdf.namedNode(`${shacl}ValidationReport`),
+      ),
+      rdf.quad(
+        reportNode,
+        rdf.namedNode(`${shacl}conforms`),
+        rdf.literal(
+          'true',
+          rdf.namedNode('http://www.w3.org/2001/XMLSchema#boolean'),
+        ),
+      ),
+    ] as Quad[];
+    return this.amendReport(skolemizeReport(quads, datasetIri), true);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
+++ b/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
@@ -167,8 +167,8 @@ describe('ShaclValidator', () => {
   });
 
   it('defers the report to report() when validate() finds no results', async () => {
-    // A conforming batch streams nothing from validate(); the report — a
-    // minimal conforming one — is written once at report() time instead, so
+    // A conforming batch streams nothing from validate(); the report – a
+    // minimal conforming one – is written once at report() time instead, so
     // every validated dataset yields a report.
     const writer = makeReportWriter();
     const validator = new ShaclValidator({
@@ -210,7 +210,7 @@ describe('ShaclValidator', () => {
   });
 
   it('writes no report for a dataset that was never validated', async () => {
-    // Report absence must mean "not validated" — so an unseen dataset (no
+    // Report absence must mean "not validated" – so an unseen dataset (no
     // accumulator) writes nothing, only flushes.
     const writer = makeReportWriter();
     const validator = new ShaclValidator({
@@ -222,6 +222,48 @@ describe('ShaclValidator', () => {
 
     expect(writer.write).not.toHaveBeenCalled();
     expect(writer.flush).toHaveBeenCalledOnce();
+  });
+
+  it('does not synthesise a conforming report when a violation write failed', async () => {
+    // If a report write throws mid-batch for a non-conforming dataset (leaving
+    // reportWritten false), report() must not relabel it conforming by writing
+    // a minimal conforming report over the missing violations.
+    let synthesised = false;
+    const writer: Writer = {
+      openRun: async () => ({
+        write: async (_dataset: Dataset, quads: AsyncIterable<Quad>) => {
+          const collected = await collectQuads(quads);
+          // A synthesised conforming report is the only write carrying
+          // sh:conforms "true" (the violation write from validate() carries
+          // sh:conforms "false"); flag if report() ever emits one here.
+          if (
+            collected.some(
+              (quad) =>
+                quad.predicate.value === SH_CONFORMS &&
+                quad.object.value === 'true',
+            )
+          ) {
+            synthesised = true;
+          }
+          throw new Error('writer boom');
+        },
+        flush: () => Promise.resolve(),
+        commit: () => Promise.resolve(),
+        abort: () => Promise.resolve(),
+      }),
+    };
+    const validator = new ShaclValidator({
+      shapesFile,
+      reportWriters: [writer],
+    });
+
+    await expect(
+      validator.validate(parseFixture('invalid.ttl'), dataset),
+    ).rejects.toThrow('writer boom');
+
+    const report = await validator.report(dataset);
+    expect(report.conforms).toBe(false);
+    expect(synthesised).toBe(false);
   });
 
   it('passes report quads (sh:ValidationResult triples) to writers', async () => {
@@ -491,7 +533,7 @@ describe('ShaclValidator', () => {
 
     it('declares sh:conformanceDisallows on the conforming report synthesised at report() time', async () => {
       // valid.ttl produces no results, so report() writes the minimal
-      // conforming report — which must still be self-describing per SHACL 1.2.
+      // conforming report – which must still be self-describing per SHACL 1.2.
       let received: Quad[] = [];
       const writer = makeReportWriter();
       writer.write.mockImplementation(async (_dataset: Dataset, quads) => {

--- a/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
+++ b/packages/pipeline-shacl-validator/test/shacl-validator.test.ts
@@ -166,7 +166,10 @@ describe('ShaclValidator', () => {
     expect([...contexts[0].selectedSources()]).toEqual([]);
   });
 
-  it('does not call writers when there are no violations', async () => {
+  it('defers the report to report() when validate() finds no results', async () => {
+    // A conforming batch streams nothing from validate(); the report — a
+    // minimal conforming one — is written once at report() time instead, so
+    // every validated dataset yields a report.
     const writer = makeReportWriter();
     const validator = new ShaclValidator({
       shapesFile,
@@ -174,8 +177,51 @@ describe('ShaclValidator', () => {
     });
 
     await validator.validate(parseFixture('valid.ttl'), dataset);
+    expect(writer.write).not.toHaveBeenCalled();
+
+    await validator.report(dataset);
+    expect(writer.write).toHaveBeenCalledOnce();
+  });
+
+  it('writes a minimal conforming report for a validated clean dataset', async () => {
+    let received: Quad[] = [];
+    const writer = makeReportWriter();
+    writer.write.mockImplementation(async (_dataset: Dataset, quads) => {
+      received = await collectQuads(quads);
+    });
+    const validator = new ShaclValidator({
+      shapesFile,
+      reportWriters: [writer],
+    });
+
+    await validator.validate(parseFixture('valid.ttl'), dataset);
+    await validator.report(dataset);
+
+    const conforms = received.filter(
+      (quad) => quad.predicate.value === SH_CONFORMS,
+    );
+    expect(conforms).toHaveLength(1);
+    expect(conforms[0].object.value).toBe('true');
+    // A conforming report has no results, and is skolemised like any other.
+    expect(received.some((quad) => quad.predicate.value === SH_RESULT)).toBe(
+      false,
+    );
+    assertNoBlankNodes(received);
+  });
+
+  it('writes no report for a dataset that was never validated', async () => {
+    // Report absence must mean "not validated" — so an unseen dataset (no
+    // accumulator) writes nothing, only flushes.
+    const writer = makeReportWriter();
+    const validator = new ShaclValidator({
+      shapesFile,
+      reportWriters: [writer],
+    });
+
+    await validator.report(dataset);
 
     expect(writer.write).not.toHaveBeenCalled();
+    expect(writer.flush).toHaveBeenCalledOnce();
   });
 
   it('passes report quads (sh:ValidationResult triples) to writers', async () => {
@@ -443,6 +489,35 @@ describe('ShaclValidator', () => {
       ]);
     });
 
+    it('declares sh:conformanceDisallows on the conforming report synthesised at report() time', async () => {
+      // valid.ttl produces no results, so report() writes the minimal
+      // conforming report — which must still be self-describing per SHACL 1.2.
+      let received: Quad[] = [];
+      const writer = makeReportWriter();
+      writer.write.mockImplementation(async (_dataset: Dataset, quads) => {
+        received = await collectQuads(quads);
+      });
+      const validator = new ShaclValidator({
+        shapesFile,
+        conformanceDisallows: [severity.violation],
+        reportWriters: [writer],
+      });
+
+      await validator.validate(parseFixture('valid.ttl'), dataset);
+      await validator.report(dataset);
+
+      expect(
+        received
+          .filter((quad) => quad.predicate.value === SH_CONFORMS)
+          .map((quad) => quad.object.value),
+      ).toEqual(['true']);
+      expect(
+        received
+          .filter((quad) => quad.predicate.value === SH_CONFORMANCE_DISALLOWS)
+          .map((quad) => quad.object.value),
+      ).toEqual([severity.violation]);
+    });
+
     it('does not add sh:conformanceDisallows to reports when the option is absent', async () => {
       const received = await reportQuadsFor('invalid.ttl');
 
@@ -495,7 +570,7 @@ describe('ShaclValidator', () => {
       expect(content).toContain('shacl');
     });
 
-    it('does not write a file when there are no violations', async () => {
+    it('writes a conforming report file when there are no violations', async () => {
       const fileWriter = new FileWriter({ outputDir, format: 'turtle' });
       const validator = new ShaclValidator({
         shapesFile,
@@ -506,7 +581,39 @@ describe('ShaclValidator', () => {
       await validator.report(dataset);
 
       const entries = await readdir(outputDir);
-      expect(entries).toHaveLength(0);
+      expect(entries).toHaveLength(1);
+      const content = await readFile(join(outputDir, entries[0]), 'utf-8');
+      expect(content).toContain('ValidationReport');
+      expect(content).not.toContain('ValidationResult');
+    });
+
+    it('overwrites a prior run’s violation report when the dataset becomes conforming', async () => {
+      // The #421 case: a first run leaves a report file full of violations; a
+      // later run in which the dataset conforms must replace it, not leave the
+      // stale violations behind for the served index to keep surfacing.
+      const firstRun = new ShaclValidator({
+        shapesFile,
+        reportWriters: [new FileWriter({ outputDir, format: 'turtle' })],
+      });
+      await firstRun.validate(parseFixture('invalid.ttl'), dataset);
+      await firstRun.report(dataset);
+      const [firstFile] = await readdir(outputDir);
+      expect(await readFile(join(outputDir, firstFile), 'utf-8')).toContain(
+        'ValidationResult',
+      );
+
+      const secondRun = new ShaclValidator({
+        shapesFile,
+        reportWriters: [new FileWriter({ outputDir, format: 'turtle' })],
+      });
+      await secondRun.validate(parseFixture('valid.ttl'), dataset);
+      await secondRun.report(dataset);
+
+      const entries = await readdir(outputDir);
+      expect(entries).toHaveLength(1);
+      const content = await readFile(join(outputDir, entries[0]), 'utf-8');
+      expect(content).not.toContain('ValidationResult');
+      expect(content).toContain('ValidationReport');
     });
   });
 });


### PR DESCRIPTION
## Why

`ShaclValidator` writes a per-dataset report only when a validation batch produces at least one result. A dataset that conforms with zero results therefore produces no report at all — which overloads report absence: it means both “validated and clean” and “never validated” (skipped, import failed, no samples). In a file-based served store, it also means a re-run in which a dataset becomes conforming leaves the previous run’s violation file untouched, so stale violations keep surfacing.

(Downstream motivation: netwerk-digitaal-erfgoed/dataset-knowledge-graph#421, where a now-conforming dataset still served 458 stale violations alongside a `conformance = true` measurement.)

## What

`report(dataset)` now writes a minimal conforming `sh:ValidationReport` (`sh:conforms true`, no results) for any dataset that was validated but produced no results of any severity. The report is skolemised and amended like the engine’s own — dataset-scoped and self-describing, carrying `sh:conformanceDisallows` when configured. A new per-dataset `reportWritten` flag ensures it is written exactly once, and never for datasets that already streamed violations or warnings.

Resulting semantics:

- report present + `conforms true`, no results → validated, clean
- report present + warnings → validated, warnings only
- report present + `conforms false` → validated, violations
- no report at all → not validated (never reached `validate()`)

Because `FileWriter` writes one file per dataset and renames over it on flush, a now-conforming run overwrites its prior violation file instead of leaving it behind.

## Breaking change

`reportWriters` now receive a report for every validated dataset, including conforming ones. Consumers that treated a missing report as “conforming” must treat it as “not validated” instead. Marked `feat!` with a `BREAKING CHANGE:` footer (minor bump on this 0.x package).

## Tests

Updated the report-writer and FileWriter tests to the new behavior and added coverage for the conforming report content, the unseen-dataset (no report) case, `sh:conformanceDisallows` on the synthesised report, and an end-to-end test that a conforming re-run overwrites a prior run’s violation file. Package README updated.
