### PR TITLE
feat(search-typesense): derive collection names from the search type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28940,6 +28940,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inflection": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-3.0.2.tgz",
+      "integrity": "sha512-+Bg3+kg+J6JUWn8J6bzFmOWkTQ6L/NHfDRSYU+EVvuKHDxUDHAXgqixHfVlzuBQaPOTac8hn43aPhMNk6rMe3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
@@ -38803,12 +38812,13 @@
     },
     "packages/search": {
       "name": "@lde/search",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@lde/text-normalization": "^0.1.1",
         "@rdfjs/types": "^2.0.1",
         "@tpluscode/rdf-ns-builders": "^5.0.0",
+        "inflection": "^3.0.2",
         "jsonld": "^9.0.0",
         "tslib": "^2.3.0"
       },
@@ -38827,10 +38837,10 @@
     },
     "packages/search-api-graphql": {
       "name": "@lde/search-api-graphql",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.6.0",
+        "@lde/search": "^0.7.0",
         "dataloader": "^2.2.3",
         "graphql": "^15.8.0",
         "tslib": "^2.3.0"
@@ -38838,15 +38848,15 @@
     },
     "packages/search-pipeline": {
       "name": "@lde/search-pipeline",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.6.0",
+        "@lde/search": "^0.7.0",
         "@rdfjs/types": "^2.0.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@lde/search-typesense": "^0.8.0",
+        "@lde/search-typesense": "^0.9.0",
         "n3": "^2.1.1",
         "testcontainers": "^12.0.3",
         "typesense": "^3.0.6"
@@ -38872,10 +38882,10 @@
     },
     "packages/search-typesense": {
       "name": "@lde/search-typesense",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.6.0",
+        "@lde/search": "^0.7.0",
         "@lde/text-normalization": "^0.1.1",
         "tslib": "^2.3.0",
         "typesense": "^3.0.6"

--- a/packages/search-pipeline/README.md
+++ b/packages/search-pipeline/README.md
@@ -60,9 +60,6 @@ const schema = searchSchema(
   },
 );
 
-// Each type maps to its own collection: an independent blue/green rebuild.
-const collectionName = { Dataset: 'datasets', Organization: 'organizations' };
-
 const pipeline = new Pipeline({
   datasetSelector,
   stages: [
@@ -71,12 +68,14 @@ const pipeline = new Pipeline({
       readers: new SparqlConstructReader({ query: '…' }),
     }),
   ],
+  // Each type gets its own collection – an independent blue/green rebuild –
+  // named by the adapter from the type itself (`Dataset` → `datasets`,
+  // `Organization` → `organizations`), so no naming map is passed here and the
+  // engine reading these collections cannot disagree about where they are.
   writers: searchIndexWriter({
     schema,
     writerFor: (searchType) =>
-      new BlueGreenRebuild(typesenseClient, searchType, {
-        name: collectionName[searchType.name],
-      }),
+      new BlueGreenRebuild(typesenseClient, searchType),
   }),
 });
 

--- a/packages/search-pipeline/README.md
+++ b/packages/search-pipeline/README.md
@@ -82,6 +82,25 @@ const pipeline = new Pipeline({
 await pipeline.run();
 ```
 
+Collection names are the engine adapter’s to decide, not this package’s – see
+[Collection naming](../search-typesense#collection-naming). A deployment that
+needs other names passes one per type, and environment prefixing **composes
+with** the convention rather than replacing it, since the adapter exports the
+derivation:
+
+```ts
+import { BlueGreenRebuild, deriveCollectionName } from '@lde/search-typesense';
+
+writerFor: (searchType) =>
+  new BlueGreenRebuild(typesenseClient, searchType, {
+    name: `${process.env.INDEX_PREFIX}_${deriveCollectionName(searchType)}`,
+  });
+```
+
+Whatever the writers are named, the engine reading these collections must be
+given the same names (`collections`), or it reads the derived ones and finds an
+empty index.
+
 Each dataset’s extracted CONSTRUCT quads are buffered until the dataset
 completes, then projected once over the **whole** schema (`@lde/search`’s
 `projectGraph`) into one mixed, type-tagged stream, and each document is

--- a/packages/search-typesense/README.md
+++ b/packages/search-typesense/README.md
@@ -9,9 +9,56 @@ Typesense search params, runs it, reconstructs the engine-neutral `SearchResult`
 and manages the search index lifecycle as transactional `@lde/pipeline`
 writers (Blue/green Rebuild and In-place Rebuild).
 
+## Collection naming
+
+You pass `SearchType`s; this package names the collections. `deriveCollectionName`
+turns a type’s logical `name` into a Typesense collection name by Typesense’s own
+convention – snake_case, named after the plural of what the collection holds, as
+its [collection guide](https://typesense.org/docs/guide/organizing-collections.html)
+writes them (`people`, `companies`, `blog_articles`):
+
+| `SearchType.name` | collection       |
+| ----------------- | ---------------- |
+| `Dataset`         | `datasets`       |
+| `CreativeWork`    | `creative_works` |
+| `Person`          | `people`         |
+| `TVSeries`        | `tv_series`      |
+| `DCATDataset`     | `dcat_datasets`  |
+
+The writers and the engine all fall back to this one convention, so documents
+cannot be written to `creative_works` and queried from `creativeWorks` – and a
+reference’s `labelSource` resolves to its label type’s collection the same way.
+Every naming input is therefore optional: `buildCollectionDefinition(type)`,
+`new BlueGreenRebuild(client, type)`, `createTypesenseSearchEngine(client, schema)`.
+
+Naming lives here rather than in `@lde/search` because it is engine-specific:
+Elasticsearch/OpenSearch index names are kebab-case and
+[constrained](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html)
+(lowercase only, no `\ / * ? " < > | space , #`, no leading `-` `_` `+`, ≤ 255
+bytes), so a future `@lde/search-elasticsearch` formats the same neutral tokens
+(`@lde/search`’s `physicalNameTokens`) its own way. The core stays engine-neutral.
+
+Pass an explicit name to **override** the convention – an env prefix, a
+multi-tenant name, a collection that already exists, a migration:
+
+```ts
+const writer = new BlueGreenRebuild(client, CREATIVE_WORK, {
+  name: 'staging_creative_works',
+});
+const engine = createTypesenseSearchEngine(client, schema, {
+  collections: { CreativeWork: 'staging_creative_works' },
+});
+writer.collectionName; // 'staging_creative_works' – read-only, for logs/health checks
+engine.collectionNameFor(CREATIVE_WORK); // the same name, resolved once at construction
+```
+
+`collections` overrides only the types it names; the rest stay derived. A type
+name the convention cannot turn into a legal collection name throws when the
+writer or engine is constructed, not on the first rebuild or search.
+
 ## Collection schema and engine
 
-`buildCollectionDefinition(searchType, { name, defaultSortingField, … })` derives a
+`buildCollectionDefinition(searchType, { name?, defaultSortingField, … })` derives a
 Typesense collection from the unified `SearchField` model – the Typesense field
 type comes from each field’s `kind`, and the physical fanout (per-locale
 search/sort keys, plus one regex display field per output text field) matches
@@ -29,7 +76,7 @@ facet/reference and `*_sort_${locale}` companions are indexed. Keeping
 retrieval-only fields un-indexed is the lever for holding a large index’s RAM
 down.
 
-`createTypesenseSearchEngine(client, schema, { collections })` is the
+`createTypesenseSearchEngine(client, schema, { collections? })` is the
 `SearchEngine` implementation. Each search:
 
 - validates the query against the search type (the port contract – a
@@ -45,9 +92,9 @@ down.
   maps, labelled references, labelled facet buckets.
 
 A label source is just another `SearchType` in the schema (with an `output`,
-`searchable` text field called `label`) whose collection appears in
-`collections` – a typed entity collection and a ‘labels collection’ are the
-same kind of thing.
+`searchable` text field called `label`), so its collection is named by the same
+convention as any other type’s – a typed entity collection and a ‘labels
+collection’ are the same kind of thing.
 
 `searchFacets` – the port’s batch entry point – answers a whole batch of
 facet-only queries (e.g. a faceted listing’s skip-own-filter variants) as a
@@ -98,7 +145,8 @@ const client = new Client({
   apiKey,
 });
 
-const writer = new BlueGreenRebuild(client, DATASET, { name: 'datasets' });
+// The collection is named from the type: `Dataset` → `datasets`.
+const writer = new BlueGreenRebuild(client, DATASET);
 // Standalone use; under @lde/pipeline the Pipeline drives this lifecycle.
 const run = await writer.openRun(context);
 await run.write(dataset, documents);

--- a/packages/search-typesense/README.md
+++ b/packages/search-typesense/README.md
@@ -52,9 +52,19 @@ writer.collectionName; // 'staging_creative_works' – read-only, for logs/healt
 engine.collectionNameFor(CREATIVE_WORK); // the same name, resolved once at construction
 ```
 
-`collections` overrides only the types it names; the rest stay derived. A type
-name the convention cannot turn into a legal collection name throws when the
-writer or engine is constructed, not on the first rebuild or search.
+`collections` overrides only the types it names; the rest stay derived.
+
+Everything the convention cannot do, it refuses to guess at, when the writer or
+engine is constructed rather than on the first rebuild or search:
+
+- a name it cannot spell (`Café` would quietly become `cafs`) or turn into a
+  legal collection name;
+- two types whose names **derive to the same collection** – English collapses
+  `Medium` and `Media` onto `media`, `Person` and `People` onto `people` – which
+  would land both types’ documents in one collection, each search returning the
+  other’s. Name either one explicitly to resolve it. Types that share a
+  collection _deliberately_ (say, several label sources in one `labels`
+  collection) are fine: name both, and it is your call, not an accident.
 
 ## Collection schema and engine
 

--- a/packages/search-typesense/src/blue-green-rebuild.ts
+++ b/packages/search-typesense/src/blue-green-rebuild.ts
@@ -17,10 +17,12 @@ import {
   resolveRebuildOptions,
   stampDocuments,
   type RebuildOptions,
+  type ResolvedRebuildOptions,
 } from './rebuild-support.js';
 
 /** {@link BlueGreenRebuild} options: the collection-definition options (`name` is
- *  the logical index name the alias is kept on) plus the rebuild tuning knobs. */
+ *  the logical index name the alias is kept on – omit it to derive one from the
+ *  {@link SearchType}) plus the rebuild tuning knobs. */
 export type BlueGreenRebuildOptions = RebuildOptions;
 
 /**
@@ -47,24 +49,38 @@ export type BlueGreenRebuildOptions = RebuildOptions;
  * - `abort` drops the half-built collection and releases the lock; the live
  *   index is untouched.
  *
- * The caller passes only the logical index `name`; the versioned collection
- * name and the alias are managed here.
+ * The caller passes at most the logical index `name` – omitted, it is derived
+ * from the {@link SearchType} ({@link deriveCollectionName}), the same
+ * convention the engine reads by; the versioned collection name and the alias
+ * are managed here.
  */
 export class BlueGreenRebuild<
   TDocument extends { id: string },
 > implements Writer<TDocument> {
+  /**
+   * The live Typesense alias this writer keeps pointed at its newest build:
+   * the explicit `options.name`, or the name derived from the
+   * {@link SearchType}. Read-only and for observability (logging, health
+   * checks) – never an input, and the same name
+   * {@link createTypesenseSearchEngine} reads the type from. The versioned
+   * collections behind it (`${collectionName}_<timestamp>`) stay internal.
+   */
+  public readonly collectionName: string;
+  private readonly resolved: ResolvedRebuildOptions;
+
   constructor(
     private readonly client: Client,
     private readonly searchType: SearchType,
-    private readonly options: BlueGreenRebuildOptions,
+    options: BlueGreenRebuildOptions = {},
   ) {
     // `source` is stamped on every document for per-dataset rollback.
     assertNoReservedFields(searchType, [SOURCE_FIELD]);
+    this.resolved = resolveRebuildOptions(searchType, options);
+    this.collectionName = this.resolved.name;
   }
 
   async openRun(context: RunContext): Promise<RunWriter<TDocument>> {
-    const { name, batchSize, lockTtlMs, definitionOptions } =
-      resolveRebuildOptions(this.options);
+    const { name, batchSize, lockTtlMs, definitionOptions } = this.resolved;
 
     return openLockedRun(this.client, name, lockTtlMs, async () => {
       // Create the fresh (blue) collection up front, so a failure surfaces

--- a/packages/search-typesense/src/collection-definition.ts
+++ b/packages/search-typesense/src/collection-definition.ts
@@ -2,11 +2,14 @@ import type { CollectionCreateSchema } from 'typesense';
 import type { CollectionFieldSchema } from 'typesense/lib/Typesense/Collection.js';
 import { type SearchField, type SearchType } from '@lde/search';
 import { displayFieldPattern, physicalFields } from '@lde/search/adapter';
+import { deriveCollectionName } from './collection-name.js';
 
 /** Deployment-specific options the generic field model does not carry. */
 export interface CollectionDefinitionOptions {
-  /** The Typesense collection (or alias) name. */
-  readonly name: string;
+  /** The Typesense collection (or alias) name. Omit to derive it from the
+   *  type’s `name` ({@link deriveCollectionName}); supply one to override that
+   *  (an env prefix, a multi-tenant name, an existing collection). */
+  readonly name?: string;
   /** Snowball stemming locale for non-localized searchable fields (e.g. `en`).
    *  Unset, those fields are not stemmed – folding still applies – so no
    *  language is ever assumed. Localized text search fields always stem in
@@ -30,6 +33,10 @@ export interface CollectionDefinitionOptions {
  * stems in `defaultLocale` when one is set, and is left unstemmed (folded
  * only) otherwise.
  *
+ * The collection `name` is optional: omitted, it is derived from the type’s own
+ * `name` ({@link deriveCollectionName}), so a caller that has no naming opinion
+ * states none.
+ *
  * Memory lever: Typesense holds the index in RAM (with a raw copy of each
  * document on disk), so RAM tracks the *indexed* surface – roughly 2–3× the
  * size of the fields you search, facet or sort on – not the whole document.
@@ -42,11 +49,11 @@ export interface CollectionDefinitionOptions {
  */
 export function buildCollectionDefinition(
   searchType: SearchType,
-  options: CollectionDefinitionOptions,
+  options: CollectionDefinitionOptions = {},
 ): CollectionCreateSchema {
   const { defaultLocale } = options;
   const collection: CollectionCreateSchema = {
-    name: options.name,
+    name: options.name ?? deriveCollectionName(searchType),
     fields: searchType.fields.flatMap((field) =>
       typesenseFields(field, defaultLocale, options.defaultSortingField),
     ),

--- a/packages/search-typesense/src/collection-name.ts
+++ b/packages/search-typesense/src/collection-name.ts
@@ -1,0 +1,45 @@
+import type { SearchType } from '@lde/search';
+import { physicalNameTokens } from '@lde/search/adapter';
+
+/**
+ * The Typesense collection name for a {@link SearchType}, derived from its
+ * logical `name` – the default every writer and the engine fall back to when a
+ * deployment supplies none, so the write side and the read side share one
+ * convention and cannot drift.
+ *
+ * The convention is Typesense’s own, as its docs write collection names:
+ * snake_case, named after the plural of what the collection holds – `people`,
+ * `companies`, `blog_articles`
+ * ({@link https://typesense.org/docs/guide/organizing-collections.html |
+ * Organizing collections}, which frames a collection as ‘similar to a table in
+ * a relational database’). So `CreativeWork` → `creative_works`, `Person` →
+ * `people`, `TVSeries` → `tv_series`. The engine-neutral half – the word split
+ * and the inflection – is {@link physicalNameTokens}; only the `_` join and the
+ * validation below are Typesense’s.
+ *
+ * A deployment that needs another name (an env prefix, a multi-tenant name, an
+ * index that already exists) passes it explicitly instead; the override is
+ * never validated here, since an existing collection’s name is the
+ * deployment’s business.
+ */
+export function deriveCollectionName(searchType: SearchType): string {
+  const name = physicalNameTokens(searchType).join('_');
+  if (!DERIVED_COLLECTION_NAME.test(name)) {
+    throw new Error(
+      `Cannot derive a Typesense collection name from search type “${searchType.name}”: it yields “${name}”, which is not a legal collection name. Rename the type, or pass an explicit name.`,
+    );
+  }
+  return name;
+}
+
+/**
+ * What a *derived* name must look like. Typesense documents no collection-name
+ * rules, but a name travels in the URL path of every collection call
+ * (`/collections/:name`), so a character with URL meaning breaks that call
+ * rather than being rejected at creation – `#` and `+` silently strand a
+ * collection ({@link https://github.com/typesense/typesense/issues/548}). This
+ * charset is the safe subset {@link physicalNameTokens} can produce anyway, so
+ * the check is really a guard on the type name behind it: a `name` with no
+ * alphanumerics at all (tokens `[]`, name `''`) is the case that reaches it.
+ */
+const DERIVED_COLLECTION_NAME = /^[a-z][a-z0-9_]*$/;

--- a/packages/search-typesense/src/collection-name.ts
+++ b/packages/search-typesense/src/collection-name.ts
@@ -23,6 +23,11 @@ import { physicalNameTokens } from '@lde/search/adapter';
  * deployment’s business.
  */
 export function deriveCollectionName(searchType: SearchType): string {
+  if (!NAMEABLE_TYPE_NAME.test(searchType.name)) {
+    throw new Error(
+      `Cannot derive a Typesense collection name from search type “${searchType.name}”: it carries characters the convention would silently drop rather than name. Rename the type, or pass an explicit name.`,
+    );
+  }
   const name = physicalNameTokens(searchType).join('_');
   if (!DERIVED_COLLECTION_NAME.test(name)) {
     throw new Error(
@@ -31,6 +36,19 @@ export function deriveCollectionName(searchType: SearchType): string {
   }
   return name;
 }
+
+/**
+ * A type name this convention can name a collection after without silently
+ * losing part of it. {@link physicalNameTokens} matches ASCII words and drops
+ * everything else, which is what lets a name already written `creative_work` or
+ * `creative-work` tokenize like `CreativeWork` – but it would just as quietly
+ * turn `Café` into `cafs` and `Musée` into `mus_es`: legal names for the wrong
+ * collection, which is worse than no name at all. So a name is nameable only
+ * when it is ASCII words and word separators; anything else is rejected rather
+ * than mangled. An explicit name still overrides, since a deployment may
+ * legitimately index a type whose name this cannot spell.
+ */
+const NAMEABLE_TYPE_NAME = /^[A-Za-z0-9 _-]+$/;
 
 /**
  * What a *derived* name must look like. Typesense documents no collection-name

--- a/packages/search-typesense/src/in-place-rebuild.ts
+++ b/packages/search-typesense/src/in-place-rebuild.ts
@@ -25,6 +25,7 @@ import {
   resolveRebuildOptions,
   stampDocuments,
   type RebuildOptions,
+  type ResolvedRebuildOptions,
 } from './rebuild-support.js';
 
 /**
@@ -82,21 +83,33 @@ export interface InPlaceRebuildOptions extends RebuildOptions {
 export class InPlaceRebuild<
   TDocument extends { id: string },
 > implements Writer<TDocument> {
+  /**
+   * The Typesense collection this writer maintains: the explicit
+   * `options.name`, or the name derived from the {@link SearchType}. Read-only
+   * and for observability (logging, health checks) – never an input, and the
+   * same name {@link createTypesenseSearchEngine} reads the type from.
+   */
+  public readonly collectionName: string;
+  private readonly maxSweepableSources: number;
+  private readonly resolved: ResolvedRebuildOptions;
+
   constructor(
     private readonly client: Client,
     private readonly searchType: SearchType,
-    private readonly options: InPlaceRebuildOptions,
+    options: InPlaceRebuildOptions = {},
   ) {
     assertNoReservedFields(searchType, [SOURCE_FIELD, LAST_SEEN_FIELD]);
-  }
-
-  async openRun(context: RunContext): Promise<RunWriter<TDocument>> {
     const {
       maxSweepableSources = DEFAULT_MAX_SWEEPABLE_SOURCES,
       ...rebuildOptions
-    } = this.options;
-    const { name, batchSize, lockTtlMs, definitionOptions } =
-      resolveRebuildOptions(rebuildOptions);
+    } = options;
+    this.maxSweepableSources = maxSweepableSources;
+    this.resolved = resolveRebuildOptions(searchType, rebuildOptions);
+    this.collectionName = this.resolved.name;
+  }
+
+  async openRun(context: RunContext): Promise<RunWriter<TDocument>> {
+    const { name, batchSize, lockTtlMs, definitionOptions } = this.resolved;
 
     return openLockedRun(this.client, name, lockTtlMs, async () => {
       // Create the collection on demand: SearchType schema + the bookkeeping
@@ -164,7 +177,7 @@ export class InPlaceRebuild<
         commit: async () => {
           await importer.flush();
           const departed = departedSources(
-            await this.indexedSources(name, maxSweepableSources),
+            await this.indexedSources(name, this.maxSweepableSources),
             context.selectedSources(),
           );
           for (const filter of membershipSweepFilters(departed)) {

--- a/packages/search-typesense/src/index.ts
+++ b/packages/search-typesense/src/index.ts
@@ -11,10 +11,12 @@ export {
 } from './sweep.js';
 export { buildCollectionDefinition } from './collection-definition.js';
 export type { CollectionDefinitionOptions } from './collection-definition.js';
+export { deriveCollectionName } from './collection-name.js';
 export { buildSearchParams } from './query-compiler.js';
 export type { BuildSearchParamsOptions } from './query-compiler.js';
 export { createTypesenseSearchEngine, parseSearchResponse } from './search.js';
 export type {
+  TypesenseSearchEngine,
   TypesenseSearchEngineOptions,
   TypesenseSearchResponse,
 } from './search.js';

--- a/packages/search-typesense/src/rebuild-support.ts
+++ b/packages/search-typesense/src/rebuild-support.ts
@@ -1,6 +1,7 @@
 import type { Client } from 'typesense';
 import type { SearchType } from '@lde/search';
 import type { CollectionDefinitionOptions } from './collection-definition.js';
+import { deriveCollectionName } from './collection-name.js';
 import { DEFAULT_LOCK_TTL_MS } from './lock.js';
 import { DEFAULT_BATCH_SIZE } from './import.js';
 
@@ -24,8 +25,18 @@ export interface ResolvedRebuildOptions {
   readonly definitionOptions: CollectionDefinitionOptions;
 }
 
-/** Apply the shared defaults, once, so neither writer restates them. */
+/**
+ * Apply the shared defaults, once, so neither writer restates them – including
+ * the collection name, derived from the type ({@link deriveCollectionName})
+ * when the deployment supplies none. The resolved name is put back into
+ * `definitionOptions`, so the collection a writer talks to and the definition
+ * it creates are the same one name, resolved once.
+ *
+ * Writers resolve at construction rather than per run, so an underivable name
+ * throws when the writer is built, not on the first rebuild.
+ */
 export function resolveRebuildOptions(
+  searchType: SearchType,
   options: RebuildOptions,
 ): ResolvedRebuildOptions {
   const {
@@ -33,11 +44,12 @@ export function resolveRebuildOptions(
     lockTtlMs = DEFAULT_LOCK_TTL_MS,
     ...definitionOptions
   } = options;
+  const name = definitionOptions.name ?? deriveCollectionName(searchType);
   return {
-    name: definitionOptions.name,
+    name,
     batchSize,
     lockTtlMs,
-    definitionOptions,
+    definitionOptions: { ...definitionOptions, name },
   };
 }
 

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -32,20 +32,26 @@ import {
   escapeFilterValue,
   type BuildSearchParamsOptions,
 } from './query-compiler.js';
+import { deriveCollectionName } from './collection-name.js';
 
 /** Where the engine reads documents – plus every query-compiler knob
  *  ({@link BuildSearchParamsOptions}), declared once there and forwarded
- *  wholesale into each search. `TypeName` is the union of the schema’s type
- *  names, so a literal schema makes the `collections` map exhaustive at
- *  compile time. Reference labels resolve per field from the collection of
- *  the SearchType its `labelSource` names – a label source is just another
- *  entry in `collections`. */
+ *  wholesale into each search. Reference labels resolve per field from the
+ *  collection of the SearchType its `labelSource` names – a label source is
+ *  just another type, so it is named the same way. */
 export interface TypesenseSearchEngineOptions<
   TypeName extends string = string,
 > extends BuildSearchParamsOptions {
-  /** The collection (or alias) per search type, keyed by the type’s `name` –
-   *  with a literal schema, omitting a type is a compile error. */
-  readonly collections: Readonly<Record<TypeName, string>>;
+  /**
+   * Overrides the collection (or alias) a search type reads, keyed by the
+   * type’s `name`. Every type not named here reads the collection derived from
+   * its own name ({@link deriveCollectionName}) – the same convention the
+   * writers create, so the read side and the write side cannot drift. Supply an
+   * entry only where a deployment needs another name (an env prefix, a
+   * multi-tenant name, an existing collection); `TypeName` is the union of the
+   * schema’s type names, so a typo is still a compile error.
+   */
+  readonly collections?: Partial<Readonly<Record<TypeName, string>>>;
   /**
    * Called when reference-label resolution fails; the search then degrades to
    * id-only references rather than failing. Optional – omit to swallow silently.
@@ -60,6 +66,24 @@ export interface TypesenseSearchEngineOptions<
    * {@link fetchLabels} behaviour unchanged.
    */
   readonly labelCacheTtlMs?: number;
+}
+
+/**
+ * A {@link SearchEngine} backed by Typesense: the port, plus the one engine
+ * specific worth exposing – which collection each type actually reads.
+ */
+export interface TypesenseSearchEngine<
+  Types extends readonly SearchType[] = readonly SearchType[],
+> extends SearchEngine<Types> {
+  /**
+   * The collection `searchType` reads: its {@link
+   * TypesenseSearchEngineOptions.collections} override, or the name derived
+   * from the type. Resolved at construction and read-only – for observability
+   * (logging a search’s target, a health check asserting the collection
+   * exists), never an input. Throws for a type outside this engine’s schema,
+   * like every other entry point.
+   */
+  collectionNameFor(searchType: Types[number]): string;
 }
 
 /**
@@ -98,23 +122,19 @@ export function createTypesenseSearchEngine<
 >(
   client: Client,
   schema: SearchSchema<Types>,
-  options: TypesenseSearchEngineOptions<Types[number]['name']>,
-): SearchEngine<Types> {
-  // Resolve every type's collection ONCE at construction, so a
-  // misconfiguration fails at startup – never on the first search that
-  // happens to hit the unwired type.
+  options: TypesenseSearchEngineOptions<Types[number]['name']> = {},
+): TypesenseSearchEngine<Types> {
+  // Resolve every type's collection ONCE at construction – the override when
+  // the deployment named one, the derived name otherwise – so an underivable
+  // name fails at startup, never on the first search that happens to hit that
+  // type.
   const collections = new Map<string, string>(
-    [...schema.values()].map((searchType) => {
-      const collection = (
-        options.collections as Readonly<Record<string, string>>
-      )[searchType.name];
-      if (collection === undefined) {
-        throw new Error(
-          `No collection configured for search type “${searchType.name}”; set options.collections.${searchType.name}.`,
-        );
-      }
-      return [searchType.class, collection];
-    }),
+    [...schema.values()].map((searchType) => [
+      searchType.class,
+      (options.collections as Readonly<Record<string, string>> | undefined)?.[
+        searchType.name
+      ] ?? deriveCollectionName(searchType),
+    ]),
   );
   // Resolve every reference field's label source ONCE at construction. The
   // schema already guarantees the named type exists and serves labels
@@ -292,8 +312,12 @@ export function createTypesenseSearchEngine<
     }
   }
 
-  const engine: SearchEngine = {
+  const engine: TypesenseSearchEngine = {
     schema,
+    collectionNameFor(searchType: SearchType): string {
+      assertTypeInSchema(schema, searchType);
+      return collections.get(searchType.class) as string;
+    },
     async search(
       searchType: SearchType,
       query: SearchQuery,
@@ -376,7 +400,7 @@ export function createTypesenseSearchEngine<
     },
   };
   // The runtime object is string-keyed; the literal-schema typing narrows it.
-  return engine as SearchEngine<Types>;
+  return engine as TypesenseSearchEngine<Types>;
 }
 
 /** One label lookup: a source and the distinct IRIs to resolve against it. */

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -128,17 +128,27 @@ export function createTypesenseSearchEngine<
   // the deployment named one, the derived name otherwise – so an underivable
   // name fails at startup, never on the first search that happens to hit that
   // type.
+  const resolved = [...schema.values()].map((searchType) => {
+    const override = (
+      options.collections as Readonly<Record<string, string>> | undefined
+    )?.[searchType.name];
+    return {
+      searchType,
+      collection: override ?? deriveCollectionName(searchType),
+      derived: override === undefined,
+    };
+  });
+  assertNoAccidentalSharing(resolved);
   const collections = new Map<string, string>(
-    [...schema.values()].map((searchType) => [
+    resolved.map(({ searchType, collection }) => [
       searchType.class,
-      (options.collections as Readonly<Record<string, string>> | undefined)?.[
-        searchType.name
-      ] ?? deriveCollectionName(searchType),
+      collection,
     ]),
   );
   // Resolve every reference field's label source ONCE at construction. The
   // schema already guarantees the named type exists and serves labels
-  // (`searchSchema`/`labelFieldOf`), and `collections` is exhaustive per type.
+  // (`searchSchema`/`labelFieldOf`), and every type resolved a collection
+  // above, so both lookups below always hit.
   const typesByName = new Map(
     [...schema.values()].map((searchType) => [searchType.name, searchType]),
   );
@@ -401,6 +411,45 @@ export function createTypesenseSearchEngine<
   };
   // The runtime object is string-keyed; the literal-schema typing narrows it.
   return engine as TypesenseSearchEngine<Types>;
+}
+
+/**
+ * Reject two types landing in one collection *by accident*.
+ *
+ * A schema keeps type names distinct, but distinct names can still derive the
+ * same collection – English collapses them (`Medium` and `Media` both give
+ * `media`, `Person` and `People` both give `people`). Nothing downstream would
+ * complain: both writers would build the one collection, each type’s search
+ * would return the other’s documents, and the membership sweep would delete
+ * across them. Exactly the drift deriving names is meant to end, so it fails at
+ * construction with the override that resolves it.
+ *
+ * Sharing a collection *deliberately* stays allowed – several label-source
+ * types served by one `labels` collection is a reasonable deployment – so this
+ * fires only when at least one side was derived, i.e. when nobody chose it.
+ */
+function assertNoAccidentalSharing(
+  resolved: readonly {
+    searchType: SearchType;
+    collection: string;
+    derived: boolean;
+  }[],
+): void {
+  const byCollection = new Map<string, typeof resolved>();
+  for (const entry of resolved) {
+    byCollection.set(entry.collection, [
+      ...(byCollection.get(entry.collection) ?? []),
+      entry,
+    ]);
+  }
+  for (const [collection, entries] of byCollection) {
+    if (entries.length > 1 && entries.some((entry) => entry.derived)) {
+      const names = entries.map((entry) => `“${entry.searchType.name}”`);
+      throw new Error(
+        `Search types ${names.join(' and ')} would share the Typesense collection “${collection}”, which no deployment asked for: their names derive to it. Give ${names.join(' or ')} an explicit collections entry.`,
+      );
+    }
+  }
 }
 
 /** One label lookup: a source and the distinct IRIs to resolve against it. */

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -101,8 +101,9 @@ export interface LabelSource {
 /**
  * A Typesense-backed {@link SearchEngine}, bound to the whole
  * {@link SearchSchema} at construction – like every other schema consumer.
- * Each type’s collection comes from `options.collections`. `search` compiles
- * the query ({@link buildSearchParams}), runs it against the type’s
+ * Each type’s collection is derived from the type ({@link
+ * deriveCollectionName}) unless `options.collections` overrides it. `search`
+ * compiles the query ({@link buildSearchParams}), runs it against the type’s
  * collection, resolves the reference labels for the page of hits – each
  * reference field from its own label source’s collection, all sources bundled
  * into one lookup – and reconstructs the engine-neutral

--- a/packages/search-typesense/test/collection-name.test.ts
+++ b/packages/search-typesense/test/collection-name.test.ts
@@ -38,6 +38,26 @@ describe('deriveCollectionName', () => {
       /Cannot derive a Typesense collection name from search type “---”/,
     );
   });
+
+  it.each(['Café', 'Musée', 'Straße', 'Creative@Work'])(
+    'rejects %s rather than silently dropping what it cannot spell',
+    (name) => {
+      // Tokenizing drops non-ASCII, so these would otherwise yield a legal
+      // name for the wrong collection (`Café` → `cafs`) – worse than throwing.
+      expect(() => deriveCollectionName(typeNamed(name))).toThrow(
+        /carries characters the convention would silently drop/,
+      );
+    },
+  );
+
+  it('still accepts a name written with word separators', () => {
+    expect(deriveCollectionName(typeNamed('creative_work'))).toBe(
+      'creative_works',
+    );
+    expect(deriveCollectionName(typeNamed('Creative Work'))).toBe(
+      'creative_works',
+    );
+  });
 });
 
 describe('buildCollectionDefinition', () => {
@@ -98,6 +118,41 @@ describe('the writers and the engine agree on a type’s collection', () => {
 
     expect(engine.collectionNameFor(creativeWork)).toBe('staging_works');
     expect(engine.collectionNameFor(person)).toBe('people');
+  });
+
+  // English collapses these two distinct names onto one collection: both
+  // derive `media`. The schema itself is happy – the names differ.
+  const medium = typeNamed('Medium');
+  const media = typeNamed('Media');
+
+  it('rejects two types whose names derive to one collection, which nobody asked for', () => {
+    // Left alone, each type’s search would return the other’s documents.
+    expect(() =>
+      createTypesenseSearchEngine(noClient, searchSchema(medium, media)),
+    ).toThrow(
+      /Search types “Medium” and “Media” would share the Typesense collection “media”/,
+    );
+  });
+
+  it('accepts the collision once an override separates the two', () => {
+    const engine = createTypesenseSearchEngine(
+      noClient,
+      searchSchema(medium, media),
+      { collections: { Medium: 'mediums' } },
+    );
+
+    expect(engine.collectionNameFor(medium)).toBe('mediums');
+    expect(engine.collectionNameFor(media)).toBe('media');
+  });
+
+  it('still lets types deliberately share one collection, both named explicitly', () => {
+    // Several label sources served by one `labels` collection is a reasonable
+    // deployment, so an explicit pairing is the deployment’s to make.
+    expect(() =>
+      createTypesenseSearchEngine(noClient, searchSchema(medium, media), {
+        collections: { Medium: 'labels', Media: 'labels' },
+      }),
+    ).not.toThrow();
   });
 
   it('rejects a type outside the schema, like every other entry point', () => {

--- a/packages/search-typesense/test/collection-name.test.ts
+++ b/packages/search-typesense/test/collection-name.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import type { Client } from 'typesense';
+import { searchSchema, type SearchQuery, type SearchType } from '@lde/search';
+import { deriveCollectionName } from '../src/collection-name.js';
+import { buildCollectionDefinition } from '../src/collection-definition.js';
+import { createTypesenseSearchEngine } from '../src/search.js';
+import { BlueGreenRebuild } from '../src/blue-green-rebuild.js';
+import { InPlaceRebuild } from '../src/in-place-rebuild.js';
+import { fakeTypesenseClient, labelLookup } from './fake-typesense-client.js';
+
+const typeNamed = (name: string): SearchType => ({
+  name,
+  class: `https://example.org/${name}`,
+  fields: [{ name: 'title', kind: 'keyword' }],
+});
+
+/** Neither the writers nor the engine touch a client at construction, so the
+ *  naming can be asserted without one. */
+const noClient = {} as Client;
+
+describe('deriveCollectionName', () => {
+  it.each([
+    // The convention is Typesense’s own, as its docs write collection names:
+    // https://typesense.org/docs/guide/organizing-collections.html
+    ['CreativeWork', 'creative_works'],
+    ['BlogArticle', 'blog_articles'],
+    ['Company', 'companies'],
+    ['Person', 'people'],
+    ['Dataset', 'datasets'],
+    ['TVSeries', 'tv_series'],
+    ['DCATDataset', 'dcat_datasets'],
+  ])('names the collection for %s “%s”', (name, expected) => {
+    expect(deriveCollectionName(typeNamed(name))).toBe(expected);
+  });
+
+  it('rejects a type name it cannot derive a legal collection name from', () => {
+    expect(() => deriveCollectionName(typeNamed('---'))).toThrow(
+      /Cannot derive a Typesense collection name from search type “---”/,
+    );
+  });
+});
+
+describe('buildCollectionDefinition', () => {
+  it('derives the collection name from the type when none is given', () => {
+    expect(buildCollectionDefinition(typeNamed('CreativeWork')).name).toBe(
+      'creative_works',
+    );
+  });
+
+  it('lets an explicit name override the derived one', () => {
+    const definition = buildCollectionDefinition(typeNamed('CreativeWork'), {
+      name: 'staging_creative_works',
+    });
+    expect(definition.name).toBe('staging_creative_works');
+  });
+});
+
+describe('the writers and the engine agree on a type’s collection', () => {
+  const creativeWork = typeNamed('CreativeWork');
+  const schema = searchSchema(creativeWork);
+
+  it('derives the same name on the write side and the read side', () => {
+    // The point of the issue: an adapter owns both its writers and its engine,
+    // so documents cannot be written to one collection and queried from
+    // another.
+    const engine = createTypesenseSearchEngine(noClient, schema);
+
+    expect(new InPlaceRebuild(noClient, creativeWork).collectionName).toBe(
+      'creative_works',
+    );
+    expect(new BlueGreenRebuild(noClient, creativeWork).collectionName).toBe(
+      'creative_works',
+    );
+    expect(engine.collectionNameFor(creativeWork)).toBe('creative_works');
+  });
+
+  it('honours the explicit override on both sides', () => {
+    const engine = createTypesenseSearchEngine(noClient, schema, {
+      collections: { CreativeWork: 'staging_works' },
+    });
+    const options = { name: 'staging_works' };
+
+    expect(
+      new InPlaceRebuild(noClient, creativeWork, options).collectionName,
+    ).toBe('staging_works');
+    expect(
+      new BlueGreenRebuild(noClient, creativeWork, options).collectionName,
+    ).toBe('staging_works');
+    expect(engine.collectionNameFor(creativeWork)).toBe('staging_works');
+  });
+
+  it('overrides only the type named, leaving its siblings derived', () => {
+    const person = typeNamed('Person');
+    const mixed = searchSchema(creativeWork, person);
+    const engine = createTypesenseSearchEngine(noClient, mixed, {
+      collections: { CreativeWork: 'staging_works' },
+    });
+
+    expect(engine.collectionNameFor(creativeWork)).toBe('staging_works');
+    expect(engine.collectionNameFor(person)).toBe('people');
+  });
+
+  it('rejects a type outside the schema, like every other entry point', () => {
+    const engine = createTypesenseSearchEngine(noClient, schema);
+
+    expect(() => engine.collectionNameFor(typeNamed('Foreign'))).toThrow(
+      /is not in this engine’s schema/,
+    );
+  });
+});
+
+describe('label sources', () => {
+  const organization: SearchType = {
+    name: 'Organization',
+    class: 'http://xmlns.com/foaf/0.1/Organization',
+    fields: [
+      {
+        name: 'label',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        searchable: { weight: 1 },
+      },
+    ],
+  };
+  const dataset: SearchType = {
+    name: 'Dataset',
+    class: 'http://www.w3.org/ns/dcat#Dataset',
+    fields: [
+      {
+        name: 'publisher',
+        kind: 'reference',
+        output: true,
+        labelSource: 'Organization',
+        ref: { typeName: 'Organization', strategy: 'labelOnly' },
+      },
+    ],
+  };
+  const schema = searchSchema(organization, dataset);
+
+  const browse: SearchQuery = {
+    text: '',
+    where: [],
+    facets: [],
+    orderBy: [],
+    limit: 10,
+    offset: 0,
+    locale: 'nl',
+  };
+
+  it('resolves a reference’s labels from the label type’s derived collection', async () => {
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [{ document: { id: 'https://d/1', publisher: 'https://org/1' } }],
+      },
+      multiSearch: labelLookup({
+        'https://org/1': { label_nl: 'Het Archief' },
+      }),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema);
+
+    const result = await engine.search(dataset, browse);
+
+    // The label lookup must target the collection the Organization writer
+    // would have built – the same convention, never a second naming map.
+    expect(fake.performs[0][0].collection).toBe('organizations');
+    expect(result.hits[0].document.publisher).toEqual({
+      id: 'https://org/1',
+      label: { nl: ['Het Archief'] },
+    });
+  });
+
+  it('resolves labels from the label type’s override when it has one', async () => {
+    const fake = fakeTypesenseClient({
+      searchResponse: {
+        found: 1,
+        hits: [{ document: { id: 'https://d/1', publisher: 'https://org/1' } }],
+      },
+      multiSearch: labelLookup({
+        'https://org/1': { label_nl: 'Het Archief' },
+      }),
+    });
+    const engine = createTypesenseSearchEngine(fake.client, schema, {
+      collections: { Organization: 'labels' },
+    });
+
+    await engine.search(dataset, browse);
+
+    expect(fake.performs[0][0].collection).toBe('labels');
+  });
+});

--- a/packages/search-typesense/test/derived-names.test.ts
+++ b/packages/search-typesense/test/derived-names.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'typesense';
+import { searchSchema, type SearchQuery, type SearchType } from '@lde/search';
+import { Dataset } from '@lde/dataset';
+import { BlueGreenRebuild } from '../src/blue-green-rebuild.js';
+import { createTypesenseSearchEngine } from '../src/search.js';
+import { TypesenseContainer } from './typesense-container.js';
+import { makeRunContext, stream } from './helpers.js';
+
+/**
+ * A multi-word PascalCase name whose plural is irregular, so the round-trip
+ * exercises every moving part of the convention at once: the word split, the
+ * inflection, and the `_` join – `CreativeWork` → `creative_works`.
+ */
+const creativeWork: SearchType = {
+  name: 'CreativeWork',
+  class: 'https://schema.org/CreativeWork',
+  fields: [
+    { name: 'title', kind: 'keyword', output: true, searchable: { weight: 5 } },
+  ],
+};
+
+const dataset = new Dataset({
+  iri: new URL('http://example.org/dataset/1'),
+  distributions: [],
+});
+
+const browse: SearchQuery = {
+  text: '',
+  where: [],
+  facets: [],
+  orderBy: [],
+  limit: 10,
+  offset: 0,
+  locale: 'nl',
+};
+
+/**
+ * Typesense documents no collection-name rules, so that the derived name is
+ * one the server actually accepts is an assumption worth proving against a
+ * real one – as is the claim this whole change rests on: that a writer given
+ * no name and an engine given no wiring land on the same collection.
+ */
+describe('derived collection names, end to end', () => {
+  const container = new TypesenseContainer();
+  let client: Client;
+
+  beforeAll(async () => {
+    client = await container.start();
+  }, 120_000);
+
+  afterAll(async () => {
+    await container.stop();
+  });
+
+  it('round-trips a document through the collection both sides derived, with no name configured anywhere', async () => {
+    const writer = new BlueGreenRebuild<{ id: string; title: string }>(
+      client,
+      creativeWork,
+    );
+    expect(writer.collectionName).toBe('creative_works');
+
+    const run = await writer.openRun(makeRunContext([dataset.iri.toString()]));
+    await run.write(
+      dataset,
+      stream([{ id: 'https://work/1', title: 'Nachtwacht' }]),
+    );
+    await run.commit();
+
+    // Typesense accepted the derived name: the live alias exists under it.
+    const alias = await client.aliases('creative_works').retrieve();
+    expect(alias.collection_name).toMatch(/^creative_works_\d+$/);
+
+    // The engine is handed the schema and nothing else, yet reads the very
+    // collection the writer just built.
+    const engine = createTypesenseSearchEngine(
+      client,
+      searchSchema(creativeWork),
+    );
+    expect(engine.collectionNameFor(creativeWork)).toBe('creative_works');
+
+    const result = await engine.search(creativeWork, browse);
+    expect(result.total).toBe(1);
+    expect(result.hits[0].document.title).toBe('Nachtwacht');
+  });
+});

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -811,20 +811,21 @@ describe('schema binding', () => {
     );
   });
 
-  it('rejects a missing collection at construction, not on the first search', () => {
+  it('derives the collection of a type the wiring does not name, rather than demanding one', () => {
     const other: SearchType = {
       name: 'Other',
       class: 'urn:example:Other',
       fields: [],
     };
-    expect(() =>
-      createTypesenseSearchEngine(
-        noClient,
-        searchSchema(organization, schema, other),
-        // The widened schema loses compile-time exhaustiveness; the
-        // constructor still rejects the missing entry at startup.
-        { collections: labelledCollections },
-      ),
-    ).toThrow(/No collection configured for search type “Other”/);
+    const engine = createTypesenseSearchEngine(
+      noClient,
+      searchSchema(organization, schema, other),
+      // `collections` is an override map, so a type absent from it is not a
+      // misconfiguration: it reads the collection derived from its own name.
+      { collections: labelledCollections },
+    );
+
+    expect(engine.collectionNameFor(other)).toBe('others');
+    expect(engine.collectionNameFor(schema)).toBe('datasets');
   });
 });

--- a/packages/search-typesense/test/rebuild-support.test.ts
+++ b/packages/search-typesense/test/rebuild-support.test.ts
@@ -19,8 +19,14 @@ async function* stream<T>(items: readonly T[]): AsyncIterable<T> {
 }
 
 describe('resolveRebuildOptions', () => {
+  const OBJECT: SearchType = {
+    name: 'MuseumObject',
+    class: 'https://example.org/Object',
+    fields: [],
+  };
+
   it('applies the shared defaults and keeps the residual schema options', () => {
-    const resolved = resolveRebuildOptions({
+    const resolved = resolveRebuildOptions(OBJECT, {
       name: 'objects',
       defaultSortingField: 'rank',
     });
@@ -35,13 +41,27 @@ describe('resolveRebuildOptions', () => {
   });
 
   it('honours explicit overrides', () => {
-    const resolved = resolveRebuildOptions({
+    const resolved = resolveRebuildOptions(OBJECT, {
       name: 'objects',
       batchSize: 50,
       lockTtlMs: 1_000,
     });
     expect(resolved.batchSize).toBe(50);
     expect(resolved.lockTtlMs).toBe(1_000);
+  });
+
+  it('derives the name from the type when none is given, and passes the resolved one on to the definition', () => {
+    const resolved = resolveRebuildOptions(OBJECT, {
+      defaultSortingField: 'rank',
+    });
+
+    expect(resolved.name).toBe('museum_objects');
+    // The definition must be built for the very collection the writer talks
+    // to, so the derived name is put back rather than left undefined.
+    expect(resolved.definitionOptions).toEqual({
+      name: 'museum_objects',
+      defaultSortingField: 'rank',
+    });
   });
 });
 

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these – see AGENTS.md.
-          functions: 98.62,
-          lines: 98.8,
-          branches: 93.43,
-          statements: 98.82,
+          functions: 98.65,
+          lines: 98.83,
+          branches: 93.61,
+          statements: 98.85,
         },
       },
     },

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these – see AGENTS.md.
-          functions: 98.6,
-          lines: 98.78,
-          branches: 93.18,
-          statements: 98.8,
+          functions: 98.62,
+          lines: 98.8,
+          branches: 93.43,
+          statements: 98.82,
         },
       },
     },

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -309,18 +309,20 @@ unrepresentable; the port enforces them for everyone else (deployment
 An engine is **bound to the whole `SearchSchema` at construction** – like
 every other schema consumer (`projectGraph(quads, schema)`,
 `buildGraphQLSchema(schema)`): the adapter factory takes the deployment’s
-declaration together with each type’s physical location, so a query can never
-meet the wrong index, and deployment-level concerns (the label cache,
-cross-type search, facet batching) have one home. A search names its type per
+declaration, so a query can never meet the wrong index, and deployment-level
+concerns (the label cache, cross-type search, facet batching) have one home.
+Where each type physically lives is the **adapter’s** to decide – it derives a
+collection/index name from the type, by its own engine’s naming conventions,
+and a deployment only overrides that where it must. A search names its type per
 call. Because `searchSchema()` captures the declared types as a literal
 tuple, `search()` accepts **only the deployment’s own types** (a foreign type
 is a compile error) and returns facet/document keys typed by the type passed
 – no caller-side generics:
 
 ```ts
-const engine = createTypesenseSearchEngine(client, schema, {
-  collections: { Dataset: 'datasets', Person: 'people' }, // omitting one = type error
-});
+// No `collections`: each type reads the collection the adapter names it,
+// which is the one its writer builds. Pass `collections` only to override.
+const engine = createTypesenseSearchEngine(client, schema);
 
 const result = await engine.search(DATASET, query);
 result.facets.publisher; // typed: only DATASET’s facetable fields are keys

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -40,6 +40,7 @@
     "@lde/text-normalization": "^0.1.1",
     "@rdfjs/types": "^2.0.1",
     "@tpluscode/rdf-ns-builders": "^5.0.0",
+    "inflection": "^3.0.2",
     "jsonld": "^9.0.0",
     "tslib": "^2.3.0"
   },

--- a/packages/search/src/adapter.ts
+++ b/packages/search/src/adapter.ts
@@ -25,6 +25,7 @@ export {
   unixSecondsToIso,
 } from './schema.js';
 export type { PhysicalFields } from './schema.js';
+export { physicalNameTokens } from './physical-name.js';
 export {
   filterOperatorFor,
   filterOperator,

--- a/packages/search/src/physical-name.ts
+++ b/packages/search/src/physical-name.ts
@@ -1,0 +1,47 @@
+import { pluralize } from 'inflection';
+import type { SearchType } from './schema.js';
+
+/**
+ * The engine-neutral word tokens an adapter formats into the physical name of a
+ * {@link SearchType}’s container – a Typesense collection, an Elasticsearch or
+ * OpenSearch index: the type’s `name` split into words, lowercased, with the
+ * last word pluralized (`CreativeWork` → `['creative', 'works']`).
+ *
+ * Both engines document the same convention – name a container after the plural
+ * of what it holds – and differ only in how they join the words: Typesense
+ * snake_case (`blog_articles`), Elasticsearch/OpenSearch kebab-case
+ * (`blog-articles`). So the split and the inflection are shared here, and only
+ * the join and the engine’s own legality rules live in the adapter – which is
+ * why this returns tokens rather than a formatted name, and why it is spelled
+ * neutrally (‘container’, not ‘collection’ or ‘index’).
+ *
+ * Acronyms stay whole (`DCATDataset` → `['dcat', 'datasets']`, `TVSeries` →
+ * `['tv', 'series']`), which is why the split is hand-rolled rather than
+ * delegated to an inflector’s `underscore`/`tableize` – those split on every
+ * capital (`t_v_series`).
+ *
+ * Pluralization is a real inflector, so irregular and invariant nouns land the
+ * way the engines’ own docs write them (`Person` → `people`, `TVSeries` →
+ * `tv_series`, `Analysis` → `analyses`) rather than as the non-words regular
+ * rules produce (`serieses`, `analysises`). An already-plural name is
+ * idempotent (`People` → `people`).
+ *
+ * Returns an empty array when `name` carries no alphanumerics at all; the
+ * adapter decides what that means, since only it knows its engine’s rules.
+ */
+export function physicalNameTokens(searchType: SearchType): readonly string[] {
+  const words = searchType.name.match(NAME_WORD_PATTERN) ?? [];
+  const tokens = words.map((word) => word.toLowerCase());
+  const last = tokens.at(-1);
+  return last === undefined ? [] : [...tokens.slice(0, -1), pluralize(last)];
+}
+
+/**
+ * One word of a PascalCase/camelCase name, in precedence order: a run of
+ * capitals not followed by a lowercase letter (an acronym – `DCAT` in
+ * `DCATDataset`, `TV` in `TVSeries`); a capital starting an ordinary word; or a
+ * lowercase run. Anything else (a separator, punctuation) matches nothing and
+ * is dropped, so a name already written as `creative_work` or `creative-work`
+ * tokenizes the same way.
+ */
+const NAME_WORD_PATTERN = /[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+/g;

--- a/packages/search/test/physical-name.test.ts
+++ b/packages/search/test/physical-name.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { SearchType } from '../src/schema.js';
+import { physicalNameTokens } from '../src/physical-name.js';
+
+const typeNamed = (name: string): SearchType => ({
+  name,
+  class: 'https://example.org/Thing',
+  fields: [],
+});
+
+const tokensOf = (name: string): readonly string[] =>
+  physicalNameTokens(typeNamed(name));
+
+describe('physicalNameTokens', () => {
+  it('splits a PascalCase name into lowercase words and pluralizes the last', () => {
+    expect(tokensOf('CreativeWork')).toEqual(['creative', 'works']);
+  });
+
+  it('pluralizes a single-word name', () => {
+    expect(tokensOf('Dataset')).toEqual(['datasets']);
+  });
+
+  it.each([
+    // The names the engines’ own docs use, which is the convention this
+    // implements: https://typesense.org/docs/guide/organizing-collections.html
+    ['BlogArticle', ['blog', 'articles']],
+    ['Company', ['companies']],
+    ['Person', ['people']],
+  ])('matches the engine docs’ own naming for %s', (name, expected) => {
+    expect(tokensOf(name)).toEqual(expected);
+  });
+
+  it.each([
+    // A real inflector, so these land as English rather than as the non-words
+    // regular rules give (`serieses`, `analysises`, `criterions`).
+    ['TVSeries', ['tv', 'series']],
+    ['Analysis', ['analyses']],
+    ['Criterion', ['criteria']],
+  ])('inflects the irregular/invariant noun %s', (name, expected) => {
+    expect(tokensOf(name)).toEqual(expected);
+  });
+
+  it.each([
+    // Splitting on every capital would give `d_c_a_t_datasets` / `t_v_series`;
+    // acronyms are everywhere in RDF vocabularies, so they stay whole.
+    ['DCATDataset', ['dcat', 'datasets']],
+    ['HTTPEndpoint', ['http', 'endpoints']],
+    ['IIIFManifest', ['iiif', 'manifests']],
+  ])('keeps the acronym in %s whole', (name, expected) => {
+    expect(tokensOf(name)).toEqual(expected);
+  });
+
+  it('is idempotent for an already-plural name', () => {
+    expect(tokensOf('People')).toEqual(['people']);
+  });
+
+  it('tokenizes camelCase and separator-written names the same way', () => {
+    for (const name of ['creativeWork', 'creative_work', 'creative-work']) {
+      expect(tokensOf(name)).toEqual(['creative', 'works']);
+    }
+  });
+
+  it('keeps digits with the word they are attached to', () => {
+    expect(tokensOf('Rfc9110Header')).toEqual(['rfc9110', 'headers']);
+  });
+
+  it('yields no tokens for a name carrying no alphanumerics, leaving the adapter to rule on it', () => {
+    expect(tokensOf('---')).toEqual([]);
+    expect(tokensOf('')).toEqual([]);
+  });
+});

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 97.22,
+          branches: 97.27,
           statements: 100,
         },
       },


### PR DESCRIPTION
Fix #603

Callers had to supply the physical collection name everywhere a `SearchType` met the engine, so every deployment reinvented the same logical-to-physical naming map – and the write side and the read side could silently drift (documents written to `creative_works`, queried from `creativeWorks`). Now the adapter names its own collections, and consumers pass only `SearchType`s.

## The convention

Taken from what the engines’ own docs do, not invented here. Typesense’s [collection guide](https://typesense.org/docs/guide/organizing-collections.html) writes collection names as snake_case plurals – `people`, `companies`, `blog_articles` – and frames a collection as “similar to a table in a relational database”:

| `SearchType.name` | collection       |
| ----------------- | ---------------- |
| `Dataset`         | `datasets`       |
| `CreativeWork`    | `creative_works` |
| `Person`          | `people`         |
| `TVSeries`        | `tv_series`      |
| `DCATDataset`     | `dcat_datasets`  |

Every naming input becomes optional, and an explicit one still overrides – per type, so `collections` can name one type and leave its siblings derived:

```ts
new BlueGreenRebuild(client, CREATIVE_WORK); // → creative_works
createTypesenseSearchEngine(client, schema); // reads the same collections

new BlueGreenRebuild(client, CREATIVE_WORK, { name: 'staging_works' }); // still overrides
```

Overriding is documented where each audience looks: a **Collection naming** section in `@lde/search-typesense`’s README (the convention, the override, the read-only exposure), and in `@lde/search-pipeline`’s README – where writers are actually wired – env prefixing shown *composing with* the convention rather than replacing it, via the exported `deriveCollectionName`:

```ts
new BlueGreenRebuild(client, searchType, {
  name: `${process.env.INDEX_PREFIX}_${deriveCollectionName(searchType)}`,
});
```

## Why the split lands where it does

Physical naming is engine-specific, so the default and its validation live in the adapter, per the issue. But the two engines differ **only in the join character** – Typesense `blog_articles`, Elasticsearch/OpenSearch `blog-articles` – which makes the word split and the inflection provably engine-neutral. So `@lde/search` exposes `physicalNameTokens` (`CreativeWork` → `['creative', 'works']`) and the adapter owns the `_` join plus validation. A future `@lde/search-elasticsearch` formats the same tokens with `-` and validates against its [stricter rules](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html) (lowercase only, no `\ / * ? " < > | space , #`, no leading `-` `_` `+`, ≤ 255 bytes). The core stays engine-neutral.

## Two findings worth flagging

**Pluralization needs a real inflector** (new `inflection` dep on `@lde/search`). Hand-rolled regular rules produce non-words for real schema.org types: `TVSeries` → `tv_serieses`, `Analysis` → `analysises`, `Criterion` → `criterions`. `TVSeries`/`RadioSeries` are plausible NDE type names, and a collection name cannot be un-shipped. Known quirk: `inflection` treats `-us` nouns as invariant (`Corpus` → `corpus`); the explicit override covers it.

**Acronyms rule out `tableize`.** The library’s own `tableize`/`underscore` split on every capital – `TVSeries` → `t_v_series`, `DCATDataset` → `d_c_a_t_datasets` – which is disqualifying in an RDF/heritage context (DCAT, SKOS, IIIF). Hence the hand-rolled acronym-aware split, with `inflection` used only to inflect the last token.

## Refusing to guess, rather than guessing wrong

A self-review caught two ways the derivation could silently name the *wrong* collection. Both now fail at construction, not on the first rebuild or search:

- **Distinct type names can derive one collection**, because English collapses them – `Medium` and `Media` both give `media`, `Person` and `People` both give `people`. `searchSchema` keeps *names* distinct and so never noticed. Both writers would have built the one collection, each type’s search returning the other’s documents, and the membership sweep deleting across them – precisely the drift this PR exists to end. The engine holds the whole schema, so it is the only place that can see it. Deliberate sharing (several label sources in one `labels` collection) stays allowed: the check fires only when a side was *derived*, and so chosen by nobody.
- **The tokenizer drops what it cannot match** – which is what lets `creative_work` tokenize like `CreativeWork`, but would just as quietly turn `Café` into `cafs` and `Musée` into `mus_es`. A name is nameable only when it is ASCII words and separators. Worth noting `SearchType.name` is validated nowhere else in the codebase (only *field* names are).

## Behaviour change

`createTypesenseSearchEngine`’s `collections` is now an optional `Partial<…>` override map rather than a required exhaustive one. Existing call sites passing a full map are unaffected; the removed startup throw for an unnamed type is replaced by derivation. Key typos remain compile errors.

## Verification

Beyond unit tests, `derived-names.test.ts` round-trips a document against a **real Typesense container** with no name configured anywhere: the writer builds `creative_works`, the engine reads it back. Typesense documents no collection-name rules, so that it accepts a derived name was worth proving rather than assuming.

`search-pipeline`’s README loses its hand-maintained `{ Dataset: 'datasets', Organization: 'organizations' }` map – it was already exactly what the convention derives.
