### PR TITLE
feat(search)!: refuse to name a search type whose name cannot be spelled

### DIFF
--- a/packages/search-typesense/README.md
+++ b/packages/search-typesense/README.md
@@ -120,7 +120,8 @@ direct use and testing.
 Indexing runs through two transactional writers, one per update mode – the
 [NDE Stack](https://docs.nde.nl/stack/patterns) patterns of the same names:
 
-- [**Blue/green Rebuild**](#bluegreen-rebuild: build a fresh index, then swap to it atomically;
+- [**Blue/green Rebuild**](#bluegreen-rebuild): build a fresh index, then swap to
+  it atomically;
 - [**In-place Rebuild**](#in-place-rebuild): update the live index directly by
   upserting changed sources and sweeping the rest.
 

--- a/packages/search-typesense/src/blue-green-rebuild.ts
+++ b/packages/search-typesense/src/blue-green-rebuild.ts
@@ -76,11 +76,12 @@ export class BlueGreenRebuild<
     // `source` is stamped on every document for per-dataset rollback.
     assertNoReservedFields(searchType, [SOURCE_FIELD]);
     this.resolved = resolveRebuildOptions(searchType, options);
-    this.collectionName = this.resolved.name;
+    this.collectionName = this.resolved.definitionOptions.name;
   }
 
   async openRun(context: RunContext): Promise<RunWriter<TDocument>> {
-    const { name, batchSize, lockTtlMs, definitionOptions } = this.resolved;
+    const { batchSize, lockTtlMs, definitionOptions } = this.resolved;
+    const name = this.collectionName;
 
     return openLockedRun(this.client, name, lockTtlMs, async () => {
       // Create the fresh (blue) collection up front, so a failure surfaces

--- a/packages/search-typesense/src/collection-name.ts
+++ b/packages/search-typesense/src/collection-name.ts
@@ -23,11 +23,9 @@ import { physicalNameTokens } from '@lde/search/adapter';
  * deployment’s business.
  */
 export function deriveCollectionName(searchType: SearchType): string {
-  if (!NAMEABLE_TYPE_NAME.test(searchType.name)) {
-    throw new Error(
-      `Cannot derive a Typesense collection name from search type “${searchType.name}”: it carries characters the convention would silently drop rather than name. Rename the type, or pass an explicit name.`,
-    );
-  }
+  // A name the split cannot spell at all throws in physicalNameTokens, which
+  // owns that engine-neutral rule; what is left to check here is whether the
+  // formatted result is legal for THIS engine.
   const name = physicalNameTokens(searchType).join('_');
   if (!DERIVED_COLLECTION_NAME.test(name)) {
     throw new Error(
@@ -38,26 +36,13 @@ export function deriveCollectionName(searchType: SearchType): string {
 }
 
 /**
- * A type name this convention can name a collection after without silently
- * losing part of it. {@link physicalNameTokens} matches ASCII words and drops
- * everything else, which is what lets a name already written `creative_work` or
- * `creative-work` tokenize like `CreativeWork` – but it would just as quietly
- * turn `Café` into `cafs` and `Musée` into `mus_es`: legal names for the wrong
- * collection, which is worse than no name at all. So a name is nameable only
- * when it is ASCII words and word separators; anything else is rejected rather
- * than mangled. An explicit name still overrides, since a deployment may
- * legitimately index a type whose name this cannot spell.
- */
-const NAMEABLE_TYPE_NAME = /^[A-Za-z0-9 _-]+$/;
-
-/**
  * What a *derived* name must look like. Typesense documents no collection-name
  * rules, but a name travels in the URL path of every collection call
  * (`/collections/:name`), so a character with URL meaning breaks that call
  * rather than being rejected at creation – `#` and `+` silently strand a
- * collection ({@link https://github.com/typesense/typesense/issues/548}). This
- * charset is the safe subset {@link physicalNameTokens} can produce anyway, so
- * the check is really a guard on the type name behind it: a `name` with no
- * alphanumerics at all (tokens `[]`, name `''`) is the case that reaches it.
+ * collection ({@link https://github.com/typesense/typesense/issues/548}).
+ * {@link physicalNameTokens} already guarantees lowercase ASCII words, so what
+ * this still rules on is the leading character: a type named `123` derives
+ * `123s`, and a name should open with a letter rather than read as a number.
  */
 const DERIVED_COLLECTION_NAME = /^[a-z][a-z0-9_]*$/;

--- a/packages/search-typesense/src/in-place-rebuild.ts
+++ b/packages/search-typesense/src/in-place-rebuild.ts
@@ -105,11 +105,12 @@ export class InPlaceRebuild<
     } = options;
     this.maxSweepableSources = maxSweepableSources;
     this.resolved = resolveRebuildOptions(searchType, rebuildOptions);
-    this.collectionName = this.resolved.name;
+    this.collectionName = this.resolved.definitionOptions.name;
   }
 
   async openRun(context: RunContext): Promise<RunWriter<TDocument>> {
-    const { name, batchSize, lockTtlMs, definitionOptions } = this.resolved;
+    const { batchSize, lockTtlMs, definitionOptions } = this.resolved;
+    const name = this.collectionName;
 
     return openLockedRun(this.client, name, lockTtlMs, async () => {
       // Create the collection on demand: SearchType schema + the bookkeeping

--- a/packages/search-typesense/src/rebuild-support.ts
+++ b/packages/search-typesense/src/rebuild-support.ts
@@ -19,18 +19,20 @@ export interface RebuildOptions extends CollectionDefinitionOptions {
 /** The shared options resolved to concrete values plus the residual
  *  collection-definition options a writer passes to {@link buildCollectionDefinition}. */
 export interface ResolvedRebuildOptions {
-  readonly name: string;
   readonly batchSize: number;
   readonly lockTtlMs: number;
-  readonly definitionOptions: CollectionDefinitionOptions;
+  /** The collection-definition options with the `name` resolved – the one place
+   *  the resolved name lives, so the collection a writer talks to and the
+   *  definition it creates cannot say different things. */
+  readonly definitionOptions: CollectionDefinitionOptions & {
+    readonly name: string;
+  };
 }
 
 /**
  * Apply the shared defaults, once, so neither writer restates them – including
  * the collection name, derived from the type ({@link deriveCollectionName})
- * when the deployment supplies none. The resolved name is put back into
- * `definitionOptions`, so the collection a writer talks to and the definition
- * it creates are the same one name, resolved once.
+ * when the deployment supplies none.
  *
  * Writers resolve at construction rather than per run, so an underivable name
  * throws when the writer is built, not on the first rebuild.
@@ -44,12 +46,13 @@ export function resolveRebuildOptions(
     lockTtlMs = DEFAULT_LOCK_TTL_MS,
     ...definitionOptions
   } = options;
-  const name = definitionOptions.name ?? deriveCollectionName(searchType);
   return {
-    name,
     batchSize,
     lockTtlMs,
-    definitionOptions: { ...definitionOptions, name },
+    definitionOptions: {
+      ...definitionOptions,
+      name: definitionOptions.name ?? deriveCollectionName(searchType),
+    },
   };
 }
 

--- a/packages/search-typesense/test/collection-name.test.ts
+++ b/packages/search-typesense/test/collection-name.test.ts
@@ -33,19 +33,21 @@ describe('deriveCollectionName', () => {
     expect(deriveCollectionName(typeNamed(name))).toBe(expected);
   });
 
-  it('rejects a type name it cannot derive a legal collection name from', () => {
-    expect(() => deriveCollectionName(typeNamed('---'))).toThrow(
-      /Cannot derive a Typesense collection name from search type “---”/,
+  it('rejects a name that is legal to spell but not to call a collection', () => {
+    // `123` spells fine (`123s`); a collection name opening with a digit is
+    // this engine’s rule to make, so this is the check that stays here.
+    expect(() => deriveCollectionName(typeNamed('123'))).toThrow(
+      /it yields “123s”, which is not a legal collection name/,
     );
   });
 
-  it.each(['Café', 'Musée', 'Straße', 'Creative@Work'])(
-    'rejects %s rather than silently dropping what it cannot spell',
+  it.each(['Café', '---'])(
+    'passes %s through to the engine-neutral spelling rule',
     (name) => {
-      // Tokenizing drops non-ASCII, so these would otherwise yield a legal
-      // name for the wrong collection (`Café` → `cafs`) – worse than throwing.
+      // The rule that a name must be spellable at all lives in @lde/search, so
+      // no adapter can derive a name without it – this only proves it fires.
       expect(() => deriveCollectionName(typeNamed(name))).toThrow(
-        /carries characters the convention would silently drop/,
+        /Cannot name search type/,
       );
     },
   );

--- a/packages/search-typesense/test/rebuild-support.test.ts
+++ b/packages/search-typesense/test/rebuild-support.test.ts
@@ -31,7 +31,6 @@ describe('resolveRebuildOptions', () => {
       defaultSortingField: 'rank',
     });
 
-    expect(resolved.name).toBe('objects');
     expect(resolved.batchSize).toBe(1000);
     expect(resolved.lockTtlMs).toBe(600_000);
     expect(resolved.definitionOptions).toEqual({
@@ -50,14 +49,13 @@ describe('resolveRebuildOptions', () => {
     expect(resolved.lockTtlMs).toBe(1_000);
   });
 
-  it('derives the name from the type when none is given, and passes the resolved one on to the definition', () => {
+  it('derives the name from the type when none is given', () => {
     const resolved = resolveRebuildOptions(OBJECT, {
       defaultSortingField: 'rank',
     });
 
-    expect(resolved.name).toBe('museum_objects');
     // The definition must be built for the very collection the writer talks
-    // to, so the derived name is put back rather than left undefined.
+    // to, so the derived name is resolved here rather than left undefined.
     expect(resolved.definitionOptions).toEqual({
       name: 'museum_objects',
       defaultSortingField: 'rank',

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -20,7 +20,7 @@ export default mergeConfig(
           // partial vitest run must never rewrite these – see AGENTS.md.
           functions: 98.65,
           lines: 98.83,
-          branches: 93.61,
+          branches: 93.57,
           statements: 98.85,
         },
       },

--- a/packages/search/src/physical-name.ts
+++ b/packages/search/src/physical-name.ts
@@ -26,15 +26,50 @@ import type { SearchType } from './schema.js';
  * rules produce (`serieses`, `analysises`). An already-plural name is
  * idempotent (`People` → `people`).
  *
- * Returns an empty array when `name` carries no alphanumerics at all; the
- * adapter decides what that means, since only it knows its engine’s rules.
+ * **Throws rather than name the wrong container.** Dropping what it cannot
+ * match is what lets `creative_work` tokenize like `CreativeWork`, but it would
+ * just as quietly turn `Café` into `['cafs']` and `Musée` into `['mus', 'es']`
+ * – a perfectly legal name for a container nobody meant. So a name is spellable
+ * only when it is ASCII words and word separators, and only when it leaves at
+ * least one word to name anything after; anything else throws here. This guard
+ * lives with the split it protects, not in each adapter: an adapter cannot
+ * derive a name without going through this function, so it cannot forget to
+ * check – and `SearchType.name` is otherwise unvalidated
+ * ({@link validateSearchType} rules on field names only). A deployment whose
+ * type name this cannot spell passes its adapter an explicit name instead.
  */
 export function physicalNameTokens(searchType: SearchType): readonly string[] {
-  const words = searchType.name.match(NAME_WORD_PATTERN) ?? [];
-  const tokens = words.map((word) => word.toLowerCase());
+  const { name } = searchType;
+  if (!SPELLABLE_NAME.test(name)) {
+    throw new Error(
+      `Cannot name search type “${name}”: a physical name is derived from the type’s name, and this one carries characters outside ASCII words and word separators – deriving would silently drop them and name the wrong container. Rename the type, or give the adapter an explicit name.`,
+    );
+  }
+  const tokens = (name.match(NAME_WORD_PATTERN) ?? []).map((word) =>
+    word.toLowerCase(),
+  );
   const last = tokens.at(-1);
-  return last === undefined ? [] : [...tokens.slice(0, -1), pluralize(last)];
+  if (last === undefined) {
+    throw new Error(
+      `Cannot name search type “${name}”: its name carries no word to name a container after. Rename the type, or give the adapter an explicit name.`,
+    );
+  }
+  return [...tokens.slice(0, -1), pluralize(last)];
 }
+
+/**
+ * A name the split can spell without losing part of it: ASCII letters and
+ * digits, plus the separators a name may already be written with (`creative
+ * work`, `creative_work`, `creative-work` all tokenize like `CreativeWork`).
+ * Deliberately narrower than what {@link NAME_WORD_PATTERN} would tolerate –
+ * that one skips anything it does not match, which is precisely the silent
+ * mangling this rejects.
+ *
+ * Matches the empty name too, on purpose: nothing about it is *unspellable*,
+ * there is simply nothing to spell, which the no-word check below reports far
+ * better than a complaint about characters it does not carry.
+ */
+const SPELLABLE_NAME = /^[A-Za-z0-9 _-]*$/;
 
 /**
  * One word of a PascalCase/camelCase name, in precedence order: a run of

--- a/packages/search/test/physical-name.test.ts
+++ b/packages/search/test/physical-name.test.ts
@@ -64,8 +64,29 @@ describe('physicalNameTokens', () => {
     expect(tokensOf('Rfc9110Header')).toEqual(['rfc9110', 'headers']);
   });
 
-  it('yields no tokens for a name carrying no alphanumerics, leaving the adapter to rule on it', () => {
-    expect(tokensOf('---')).toEqual([]);
-    expect(tokensOf('')).toEqual([]);
+  it.each(['Café', 'Musée', 'Straße', 'Creative@Work', 'Ω'])(
+    'refuses to name %s rather than silently drop what it cannot spell',
+    (name) => {
+      // Unmatched characters are skipped, so these would otherwise yield a
+      // legal name for the wrong container (`Café` gives `['cafs']`).
+      expect(() => tokensOf(name)).toThrow(
+        /carries characters outside ASCII words and word separators/,
+      );
+    },
+  );
+
+  it.each(['---', '', '   '])(
+    'refuses %s, which leaves no word to name anything after',
+    (name) => {
+      expect(() => tokensOf(name)).toThrow(
+        /carries no word to name a container/,
+      );
+    },
+  );
+
+  it('leaves engine legality to the adapter, naming what it can spell', () => {
+    // `123s` is spellable; whether a container may be named it is the
+    // adapter’s rule, not this one’s.
+    expect(tokensOf('123')).toEqual(['123s']);
   });
 });

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 97.27,
+          branches: 97.29,
           statements: 100,
         },
       },


### PR DESCRIPTION
Follow-up to #604, which left the question open: the guard that stops a type name being silently mangled into the wrong collection lived in the Typesense adapter, but the mangling happens in `@lde/search`.

## Why it moves up

`physicalNameTokens` drops whatever it cannot match. That is a feature – it lets `creative_work`, `creative-work` and `Creative Work` all tokenize like `CreativeWork` – but it would just as quietly turn `Café` into `['cafs']` and `Musée` into `['mus', 'es']`: a perfectly legal name for a container nobody meant.

Guarding that in each adapter is wrong twice over. Every adapter would need the identical check, and a separate `assertSpellable` export is one an adapter can **forget** – which is exactly the drift deriving names set out to end. So the rule now lives with the split it protects: going through `physicalNameTokens` is the only way to derive a name, so the check cannot be skipped.

It also lets the function own the empty case, so it never returns `[]` – one contract: tokens, or a clear error.

The layering this leaves is clean, and matches where each rule is actually known:

| | rule | lives in |
| --- | --- | --- |
| Can this name be spelled as words at all? | engine-neutral | `@lde/search` |
| Is the formatted result legal for this engine? | engine-specific | the adapter |

The Typesense adapter keeps only the second, and still has a job: `123` spells fine (`123s`), but a collection name should open with a letter.

Worth noting `SearchType.name` is validated nowhere else – `validateSearchType` rules on field names only.

## Breaking

`physicalNameTokens` now throws for a name it cannot spell, and for one leaving no word to name a container after, where it previously returned mangled tokens or `[]`. Marked `!` so `@lde/search` takes a minor bump rather than shipping the break as a patch. The only consumer today is `@lde/search-typesense`, which moves with it.

## Also in here

Two loose ends from the #604 review, both flagged there:

- `ResolvedRebuildOptions` carried the resolved `name` both at top level and inside `definitionOptions`. The duplicate is gone; `definitionOptions.name` is now the one place it lives, so the collection a writer talks to and the definition it creates cannot say different things. The type is internal, so this is not part of the break.
- The `Blue/green Rebuild` link in the search-typesense README was missing its closing paren (pre-existing). Both internal anchors now resolve.

The `search-typesense` branch-coverage threshold drops 93.61 → 93.57: the adapter lost a branch to the core, so the ratio shifted. `autoUpdate` only raises, so the honest baseline needed lowering by hand.
