### PR TITLE
docs: search model glossary and the RDF-depth decoupling decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Uses TypeScript with ESNext modules and Vite for building/testing.
 - We’re pre-release, so be aggressive about removing dead code. Do not yet care about backward compatibility.
 - All exported/public APIs must have JSDoc comments for a good developer experience.
 - With all code changes, ensure all README.md files (including diagrams) are still accurate.
+- Memory must be bounded by a configured unit of work (`batchSize`, `capacity`, …), never by the size of the input – LDE processes data it cannot hold. A bound stated in the data’s own units (“one dataset”, “one graph”) is not a bound. See [ADR 12](docs/decisions/0012-bound-memory-by-the-unit-of-work-not-the-input.md).
 
 ## Development Commands
 
@@ -97,16 +98,16 @@ The `@nx/js:library` generator’s output diverges from the conventions in this 
 2. **Copy the package directory.** `cp -R packages/<sibling> packages/<new-name>`.
 3. **Update `package.json`:**
    - `name` → `@lde/<new-name>`
-   - `description` — write something useful
+   - `description` – write something useful
    - `repository.directory` → `packages/<new-name>`
    - `version` → `0.0.0` (do NOT keep the sibling’s version). The first CI release bumps from the manifest over the package’s full history, so `0.0.0` lands it at `0.1.0` (observed with `search-typesense` and `text-normalization`), while a manifest pre-set to `0.1.0` shipped `0.2.0` (`pipeline-shacl-sampler`). This must be in place before the PR merges – see [Releasing a new package](#releasing-a-new-package).
-   - `dependencies` and `peerDependencies` — replace with what the new package actually needs
+   - `dependencies` and `peerDependencies` – replace with what the new package actually needs
 4. **Replace the source.** Empty out `src/` and `test/`, write the new code.
 5. **Update `tsconfig.lib.json` `references`** to match the new package’s actual `@lde/*` peers.
 6. **Reset coverage thresholds.** In `vite.config.ts`, drop the explicit numbers to `0`; the first test run with `autoUpdate: true` will set the real baseline.
 7. **Update the root README.md** packages table with a row for the new package.
 8. **Run `npx nx sync`** to add the new package’s path to the workspace root `tsconfig.json` references array.
-9. **Configure Nx in `package.json`** (not `project.json`) — already enforced by copying a sibling.
+9. **Configure Nx in `package.json`** (not `project.json`) – already enforced by copying a sibling.
 10. **For CLIs**, expose the version from `package.json` (the existing CLI packages do this via Commander).
 
 For releasing the new package’s first version, see [Releasing a new package](#releasing-a-new-package) below.

--- a/docs/decisions/0009-route-a-whole-schema-projection-to-per-type-collections.md
+++ b/docs/decisions/0009-route-a-whole-schema-projection-to-per-type-collections.md
@@ -14,6 +14,31 @@ updates the catalog grain of search as a Configurable Pipeline instance
 ([#534](https://github.com/ldelements/lde/issues/534)) from one collection to
 several ([#590](https://github.com/ldelements/lde/issues/590)).
 
+**Partly superseded by
+[ADR 12 (Bound memory by the unit of work, not the input)](./0012-bound-memory-by-the-unit-of-work-not-the-input.md)**,
+which reverses this ADR by halves:
+
+- **Still current** – the fan-out’s _placement_: composed in
+  `@lde/search-pipeline` over N single-collection engine writers (option (a)
+  below), not a multi-collection writer inside an engine adapter; each collection
+  committing, sweeping and failing in isolation; `abort` finalizing only the
+  collections that did not go live. That is what this ADR set out to decide, and
+  it stands.
+- **Superseded** – the _projection mechanism_: the whole-schema single-scan
+  mixed stream, the per-document type tag (`TypedSearchDocument`), and the
+  buffer-until-flush. Each is a structure sized by the input rather than by a
+  configured unit. Bounding forces one stage per root type, so a batch belongs to
+  exactly one type – leaving no mixed stream to tag and nothing to route. What
+  survives of `searchIndexWriter` is run coordination, not projection.
+  Implemented by [#606](https://github.com/ldelements/lde/issues/606).
+
+For the record: the buffering was never this ADR’s subject. It arrived two PRs
+earlier, in `@lde/search-pipeline`’s first commit
+([#565](https://github.com/ldelements/lde/pull/565)), as a documented deferral
+of “bounded entity batches within one huge dataset”; this ADR inherited it as
+background and restated it while deciding the fan-out. Which is why the
+Consequences below never weigh memory – memory was not on the table.
+
 ## Context
 
 One validated `SearchSchema` declares several root types. The Dataset Register

--- a/docs/decisions/0011-decouple-rdf-depth-from-the-api-surface.md
+++ b/docs/decisions/0011-decouple-rdf-depth-from-the-api-surface.md
@@ -1,0 +1,126 @@
+# 11. Decouple RDF depth from the API surface
+
+Date: 2026-07-16
+
+## Status
+
+Proposed
+
+Extends the reference model of
+[ADR 8 (Resolve reference labels from per-reference label sources)](./0008-resolve-reference-labels-from-per-reference-label-sources.md)
+by realising the `inline` strategy it forward-declared. Depends on the
+`path`/`derive` split ([#607](https://github.com/ldelements/lde/issues/607));
+implemented by [#608](https://github.com/ldelements/lde/issues/608) and consumed
+by the extraction generator ([#548](https://github.com/ldelements/lde/issues/548)).
+
+## Context
+
+A `SearchField.path` addresses a value from the node of the type that declares
+it. Some values cannot be addressed at all.
+
+The obstacle is the **qualified hop** – one whose intermediate node must be
+filtered to identify the value. The sharpest case in the Dataset Register:
+`quadsValidated`, `schemaApNdeConformant`, `subjectUrisSampled`,
+`subjectUrisResolved` and `subjectNamespaceDurable` are **five fields sharing one
+path** (`dqv:hasQualityMeasurement/dqv:value`), differing _only_ by the
+intermediate node’s `dqv:isMeasurementOf`. No path expression tells them apart:
+SPARQL property paths cannot constrain an intermediate node, and SHACL does not
+either – it needs `sh:qualifiedValueShape`, a **constraint**, not a path. The
+IIIF measurements need two such hops; the terminology-source linkset needs one
+plus an inverse.
+
+The Dataset Register works around this with a private `dr:` vocabulary: a
+hand-written CONSTRUCT flattens each awkward value onto the dataset under a
+minted predicate, and the schema declares `path: 'urn:dr:quadsValidated'`. That
+is the debt #548 retires, and it cannot be retired without answering: **how does
+a declaration address a value behind a qualified hop?**
+
+Two answers:
+
+- **(a) Grow the path grammar** – admit `[predicate = value]` filters on
+  intermediate nodes.
+- **(b) Inline the intermediate node** with its discriminator, and let a
+  `derive` select from it.
+
+(a) is a query language wearing an address’s clothes. `@lde/search` would own a
+path expression language and its SPARQL compiler; every declaration would carry
+the shape of the source graph; and the “generator” would be a compiler. It also
+does not reach the aggregate cases at any expressiveness – newest-registration-
+wins is a selection over a set, not a path.
+
+(b) needs no new mechanism. The `path`/`derive` split (#607) already says _path
+says what to read; derive says what to compute from what was read_ – and a
+qualified hop’s filter is a computation over what was read, not part of the
+address.
+
+The apparent cost of (b) is that inlining puts a nested structure in the
+document, while the deployment wants `Dataset.quadsValidated: Int` in GraphQL,
+not `Dataset.measurements { isMeasurementOf value }`. Were that true, (b) would
+trade a path language for an unreadable API, and (a) would look attractive again
+purely to keep the surface flat. It is not true, because **roles decide what
+surfaces**, and that is what makes (b) viable.
+
+## Decision
+
+**Reach a qualified or deep value by inlining an internal reference and deriving
+from it – never by extending the path grammar.**
+
+- **An inline reference declaring no role is a reading device.** It is an
+  internal field (#607): projected into the in-memory document so later derives
+  can read it, then pruned before the writer. It reaches neither the engine
+  (not stored, not indexed, absent from the collection definition) nor the API.
+  The five DQV fields inline `dqv:hasQualityMeasurement` once and derive from
+  it – which is exactly what the Dataset Register’s `qualityMeasurements`
+  `WeakMap` memo hand-rolls today, made structural.
+
+- **The same mechanism declaring `output` is an API device.** It deliberately
+  surfaces a nested reference type. Same construct; the roles, not the strategy,
+  decide.
+
+- **`path` stays a plain address** – a SPARQL property path for a SPARQL reader,
+  opaque to `@lde/search`, which never learns a filter language.
+
+- **Therefore RDF depth and API shape are independent.** Inline as deep as the
+  source demands; expose exactly the flat fields you want. Three tools, and the
+  surface is chosen per field:
+
+  | RDF shape                                                        | Tool                       | Surface |
+  | ---------------------------------------------------------------- | -------------------------- | ------- |
+  | simple deep value (`dct:publisher/foaf:name`)                    | property path              | flat    |
+  | qualified/selected deep value (`…[isMeasurementOf X]/dqv:value`) | internal inline + `derive` | flat    |
+  | nesting is wanted (`creator { name }`)                           | inline + `output`          | nested  |
+
+## Consequences
+
+- **The GraphQL surface is free of the source’s shape.** A future reader who
+  finds a reference field declaring no roles, resolving to a type with no
+  `class`, and apparently going nowhere, should read this ADR before deleting it
+  or marking it `output`: either silently re-couples RDF depth to the public
+  contract.
+
+- **Filtering has one home.** A `where` clause on a reference declaration would
+  be a qualified path wearing a hat, and re-opens option (a) by increments. If a
+  deployment wants less boilerplate than five near-identical
+  `find(m => m.isMeasurementOf === X)?.value` derives, it factors a helper of
+  its own – the declaration stays an address.
+
+- **Framing keeps `jsonld` and gains depth.** A flat-only schema could replace
+  framing with a group-by-subject; inline genuinely needs the one-hop embed, and
+  the Dataset Register needs two levels. Depth follows the reference graph, so it
+  is a property of the declaration – `searchSchema` rejects inline cycles, the
+  only way it could be unbounded. Bounded per batch
+  ([#606](https://github.com/ldelements/lde/issues/606)), so the O(N²)
+  whole-graph framing cost `frame-by-type` warns about applies to `batchSize`
+  roots, not to the graph.
+
+- **Extraction must reassemble the nesting.** An inline reference’s referent is a
+  second subject, so extraction emits both the edge and the referent’s values,
+  and the framer joins them by node identity. How many queries that takes is the
+  generator’s concern ([#548](https://github.com/ldelements/lde/issues/548)), not
+  this ADR’s: the decision here is where filtering lives, and it holds whatever
+  shape the queries end up in.
+
+- **`sh:qualifiedValueShape` stays available as an upstream source.** Since a
+  qualified hop is expressed in SHACL as a constraint rather than a path, a
+  future SHACL → `SearchSchema` generator (#325) maps it to an inline reference
+  plus a derive – the same target this ADR chooses by hand.

--- a/docs/decisions/0012-bound-memory-by-the-unit-of-work-not-the-input.md
+++ b/docs/decisions/0012-bound-memory-by-the-unit-of-work-not-the-input.md
@@ -1,0 +1,106 @@
+# 12. Bound memory by the unit of work, not the input
+
+Date: 2026-07-16
+
+## Status
+
+Proposed
+
+Underpins [ADR 11 (Decouple RDF depth from the API surface)](./0011-decouple-rdf-depth-from-the-api-surface.md)
+and [#606](https://github.com/ldelements/lde/issues/606), both of which depend on
+this invariant without stating it.
+
+**Partly supersedes
+[ADR 9 (Route a whole-schema projection to per-type collections)](./0009-route-a-whole-schema-projection-to-per-type-collections.md)** –
+its projection mechanism (the whole-schema single-scan mixed stream, the
+per-document type tag, the buffer-until-flush), each of which is sized by the
+input. ADR 9’s fan-out placement is untouched and still current.
+
+## Context
+
+LDE processes data it cannot hold. The Dataset Register’s catalog is a few
+hundred megabytes of dataset _descriptions_; a single registered dataset’s
+_contents_ are millions of objects. A library that must be told how much data it
+is about to see is not usable for the second case.
+
+**This is not a new rule. It is an invariant most of the workspace already obeys,
+which nothing states – so nothing enforces it.** Six packages converged on it
+independently, each inventing its own name:
+
+- `@lde/pipeline` – `AsyncQueue` is a bounded, back-pressured channel
+  (`capacity`); `Stage` reads one `batchSize` of selector bindings at a time,
+  with `maxConcurrency` batches in flight; `SparqlSelector` paginates under
+  `maxResults`.
+- `@lde/search-typesense` – `BatchImporter` holds one `batchSize` of documents.
+- `@lde/distribution-probe` – shipped as _“bounded-stream reads”_ (`aabcd08`).
+- `@lde/pipeline-shacl-sampler` – sampling is bounding.
+
+One package did not, and there was nothing to point at:
+`@lde/search-pipeline`’s `searchIndexWriter` accumulates a whole dataset’s quads
+and then every projected document. It has honestly declared its bound in a JSDoc
+since its first commit – _“Memory is bounded by one dataset’s extraction”_ – and
+that sentence went unchallenged through review, an epic and an ADR.
+
+Two things made it invisible, and the decision below targets both.
+
+**“Streaming” is not the invariant.** `searchIndexWriter` _is_ streaming: it
+consumes an `AsyncIterable<Quad>`, yields an `AsyncIterable<Document>`, and never
+blocks the queue. It would pass a “must be fully streaming” rule and is still
+O(input). Worse, the rule cannot be honestly obeyed everywhere: projection cannot
+be quad-streaming, because a document needs a root’s **complete** quads. Grouping
+is forced, not a compromise.
+
+**A bound stated in the data’s own units is not a bound.** “One dataset’s
+extraction” is true, and useless: for the catalog grain a dataset is a ~15-quad
+description, for the object grain it is the entire input. Same sentence, same
+code, and the bound evaporated when the _unit_ changed meaning underneath it.
+
+## Decision
+
+**Memory is bounded by a configured unit of work, never by the size of the
+input.**
+
+- **A bound must name a unit the operator configures, not one the data defines.**
+  `batchSize`, `capacity`, `maxResults` are bounds. “One dataset”, “one
+  distribution”, “one graph”, “one run” are inputs wearing a bound’s clothes.
+  If the only way to shrink a structure is to be handed less data, it is not
+  bounded.
+
+- **Bounded is not the same as streaming.** A step may be _grouped_ – projection
+  takes a batch and emits its documents – provided the group is the configured
+  unit. Per-quad streaming is one way to satisfy this rule, not the rule.
+
+- **No data-sized structure outlives its unit.** No `Set` over every quad, no
+  array of every document, no `jsonld.frame()` over a graph, no index built from
+  a whole input. Whatever a unit allocates is released when the unit completes.
+
+- **Every read or write path states its bound and tests it.** A bound in a JSDoc
+  is not a bound – it is the thing this ADR exists because we tried. The test
+  asserts memory stays flat as input grows, which is the only form that fails
+  when the claim quietly stops being true.
+
+## Consequences
+
+- **It costs round-trips, and that is the trade.** Bounded extraction means
+  per-type × per-batch queries instead of one scan. `batchSize` is the dial:
+  high where the input is small (the catalog), low where it is not (objects).
+
+- **It forecloses whole-input optimizations, permanently.** ADR 9’s whole-schema
+  single-scan projection, whole-graph framing, and one-pass deduplication across
+  a run are each cheaper than the bounded version and each unavailable. Proposals
+  to reintroduce them should be read as proposals to reintroduce an unbounded
+  structure.
+
+- **Unbounded is occasionally right, and must be argued.** A scalar aggregate
+  (`SELECT (COUNT(*) AS ?n)`), a schema, a configuration, a selector’s page: all
+  fixed or small by construction. The rule targets structures that grow with the
+  data, not every allocation.
+
+- **Cross-cutting bounds need an owner.** `deduplicateQuads` and
+  `buildSubjectIndex` independently keep a `Set<string>` over the same content –
+  each roughly a textual copy of the graph – for the same reason (QLever does not
+  deduplicate CONSTRUCT output). Two enforcements of one quirk cost two copies.
+  When a bound is everyone’s job it is paid for twice.
+
+- **Known violation:** `searchIndexWriter` (#606), which is the forcing function
+  for writing this down.

--- a/packages/search/CONTEXT.md
+++ b/packages/search/CONTEXT.md
@@ -1,0 +1,178 @@
+# Search
+
+The engine- and domain-agnostic search model: one declarative schema drives
+extraction, projection, the engine collection definition, the query semantics
+and the GraphQL surface, so they cannot drift. LDE ships the capabilities; a
+**Deployment** supplies every domain semantic.
+
+Every term here is one `@lde/search` itself has an opinion about. Terms owned by
+another context – `Reader`, `Writer` and root selection (`@lde/pipeline`), grain
+and substrate (a Deployment’s choice of what to index, see
+[#534](https://github.com/ldelements/lde/issues/534)) – are used, never
+redefined: a second definition is a second thing to drift.
+
+## Language
+
+### The declaration
+
+**Deployment**:
+The consumer that supplies every domain semantic – which types exist, which
+fields are references, what each resolves against, what is worth indexing. LDE
+ships capabilities and names no domain; a Deployment names them all. The Dataset
+Register is one.
+_Avoid_: consumer, client, application, tenant
+
+**Search Schema**:
+The complete search declaration of a Deployment: every Root Type, keyed by its
+class IRI. Nominal – `searchSchema()` is the only constructor.
+_Avoid_: shapes graph, index config
+
+**Search Type**:
+One type’s declaration: a logical API name, the RDF class its instances carry,
+and its fields. Either a **Root Type** or a **Reference Type**.
+_Avoid_: shape, entity, model
+
+**Root Type**:
+A Search Type that is indexed: it declares a `class`, roots are selected for it,
+and a Writer owns a collection for it. The Search Schema is keyed by it.
+_Avoid_: top-level type, indexed type
+
+**Reference Type**:
+A Search Type reached only through a reference. Declares **no `class`** – never
+selected, never framed by type, never indexed; its identity is its name. The
+shape an **Inline Reference** carries.
+_Avoid_: nested type, sub-type, embedded type
+
+**Search Field**:
+One projected value: read from the graph via a **Path** or computed via a
+**Derive**, exposing exactly the **Roles** it declares – possibly none.
+_Avoid_: property, attribute, column
+
+**Role**:
+A capability a Search Field opts into: `output`, `searchable`, `filterable`,
+`facetable`, `sortable`. Independent; a field exposes exactly what it declares.
+_Avoid_: flag, capability
+
+**Internal Field**:
+A Search Field declaring no Role. Projected into the Document so later Derives
+can read it, then pruned before the writer sees it. Never stored, never indexed,
+absent from the collection definition.
+_Avoid_: hidden field, scratch field, private field
+
+**Path**:
+A Search Field’s **source address** – what to read from the graph, **relative to
+the node of the type that declares it** (a Root Type’s root, a Reference Type’s
+referent). Opaque to `@lde/search`; the read-side adapter owns its grammar (for
+a SPARQL reader, a property path).
+_Avoid_: sh:path, predicate, selector
+
+**Derive**:
+A Search Field’s computation – what to compute from what was already read. Runs
+in declaration order over the Document; never touches the graph.
+_Avoid_: transform, resolver, mapper
+
+A field has a Path or a Derive, never both. **Path says what to read; Derive
+says what to compute from what was read.**
+
+Two absences declare intent, and both are load-bearing: **a field without a Role
+is an Internal Field; a type without a `class` is a Reference Type.**
+
+### References
+
+**Label Source**:
+The Search Type whose collection resolves a reference’s labels. Must declare an
+`output`, `searchable` text field named `label`.
+_Avoid_: labels collection, lookup table
+
+**Reference Strategy**:
+How much of a referenced entity a reference carries: `idOnly` (the IRI),
+`labelOnly` (+ its Label Source’s label, resolved at query time), `inline`
+(+ its Reference Type’s projected fields).
+
+**Inline Reference**:
+A reference carrying its referent’s projected fields. Serves two jobs, told
+apart only by Roles:
+
+- _reading device_ (no Roles → an **Internal Field**): reach a value behind a
+  _qualified_ hop by inlining the intermediate node with its discriminator, then
+  let a **Derive** select and flatten it. Pruned before the writer – nothing
+  nested reaches the engine or the API.
+- _API device_ (`output`): deliberately surface a nested Reference Type.
+
+RDF depth and API shape are therefore independent: inline as deep as the source
+demands, expose exactly the flat fields you want
+([ADR 11](../../docs/decisions/0011-decouple-rdf-depth-from-the-api-surface.md)).
+
+### Reading and writing
+
+**Extraction**:
+Producing a Deployment’s quads for one root. Emits **IR Aliases**, not the
+source vocabulary.
+_Avoid_: fetch, crawl, source query
+
+**IR Alias**:
+The minted `urn:lde:‹Type›/‹field›` predicate an extraction CONSTRUCT emits for
+a Search Field’s value, and the key the projection reads it back under.
+Mechanical, per field; never hand-written, never a public vocabulary.
+_Avoid_: dr: predicate, intermediate vocabulary, internal namespace
+
+**Projection**:
+Turning one root’s framed quads into a **Document**. The one type-changing step
+(quad → document); shared across all engines.
+_Avoid_: mapping, serialization
+
+**Document**:
+The engine-agnostic logical record the projection emits and a writer consumes.
+The shared contract between the engine-agnostic side and every engine adapter.
+_Avoid_: record, row, hit
+
+**Physical Field**:
+A field the engine actually stores – `title_search_nl`, `title_sort_nl`,
+`title_nl`. One Search Field fans out into several; `physicalFields()` owns the
+convention, so the projection, the collection definition and the query compiler
+cannot disagree.
+_Avoid_: column, engine field
+
+## Flagged ambiguities
+
+**Field**: unqualified, ambiguous between a **Search Field** (the declaration)
+and a **Physical Field** (what the engine stores). One declaration becomes
+several stored fields, so the two are never one-to-one. Qualify which you mean.
+
+## Example dialogue
+
+> **Dev:** The Dataset type has `publisherName` _and_ `publisher`. Isn’t one of
+> them redundant?
+>
+> **Expert:** No – different jobs. `publisher` is a reference: it holds the
+> organization’s IRI, so we can facet on it, and the label gets resolved at
+> query time from the Organization collection. That’s its Label Source.
+> `publisherName` is text flattened onto the dataset itself, so the
+> organization’s name lands in the dataset’s own free-text search.
+>
+> **Dev:** So `publisherName`’s Path is `dct:publisher/foaf:name`. But then what
+> predicate does the extraction emit?
+>
+> **Expert:** An IR Alias – `urn:lde:Dataset/publisherName`. It has to mint one:
+> you can’t put a property path in a CONSTRUCT template. The projection reads
+> the value back under that alias.
+>
+> **Dev:** And nobody writes that alias by hand?
+>
+> **Expert:** Nobody. It’s a function of the field name. The day someone
+> hand-writes one, it can drift from the schema – that’s exactly what we’re
+> getting rid of.
+>
+> **Dev:** The compatibility booleans read `quadsValidated`. Is that a field?
+>
+> **Expert:** An Internal Field. It declares no Role, so it’s projected into the
+> Document for the Derives to read and pruned before the writer. It never
+> reaches the engine – not stored, not indexed, not in the collection
+> definition.
+>
+> **Dev:** Why not just read it off the graph inside the Derive?
+>
+> **Expert:** Because then the extraction generator can’t see it. Path says what
+> to read; Derive says what to compute from what was read. If a Derive reaches
+> into the graph, the schema stops being the whole story and the CONSTRUCT can
+> drift again.


### PR DESCRIPTION
Docs only. The shared vocabulary and decision record behind the search-extraction work – #606, #607, #608 and #548. Those issues carry the reasoning; this is what they lean on, and what someone picking one of them up needs to read first.

## ADR 12: Bound memory by the unit of work, not the input (new, Proposed)

**Memory is bounded by a configured unit of work, never by the size of the input.**

Not a new rule – an invariant most of the workspace already obeys and nothing states, so nothing enforces. Six packages converged on it independently, each naming it differently: `AsyncQueue`’s `capacity`, `Stage`’s `batchSize`, `SparqlSelector`’s pagination, `BatchImporter`, `@lde/distribution-probe`’s “bounded-stream reads”, the SHACL sampler. One package didn’t, and there was nothing to point at.

Two things the ADR is careful about, because both are why the violation stayed invisible:

- **“Fully streaming” is the wrong invariant.** `searchIndexWriter` *is* streaming – `AsyncIterable` in, `AsyncIterable` out, never blocks the queue – and is still O(input). It would pass that rule. And the rule can’t be honestly obeyed anyway: projection can’t be quad-streaming, because a document needs a root’s **complete** quads. Grouping is forced, not a compromise.
- **A bound in the data’s own units is not a bound.** `searchIndexWriter` has honestly declared *“Memory is bounded by one dataset’s extraction”* in a JSDoc since its first commit, and that sentence survived review, an epic and an ADR. It’s true. It’s also useless: a dataset is ~15 quads at the catalog grain and the entire input at the object grain.

So the rule that actually bites: **a bound must name a unit the operator configures, not one the data defines.** Linked from `AGENTS.md`, which is what gets read before code is written.

## ADR 11: Decouple RDF depth from the API surface (new, Proposed)

**Reach a qualified or deep value by inlining an internal reference and deriving from it – never by extending the path grammar.**

A *qualified hop* – one whose intermediate node must be filtered to identify the value – cannot be addressed by a path. Five Dataset Register fields (`quadsValidated`, `schemaApNdeConformant`, `subjectUris{Sampled,Resolved}`, `subjectNamespaceDurable`) share `dqv:hasQualityMeasurement/dqv:value` and differ *only* by the intermediate node’s `dqv:isMeasurementOf`. SPARQL property paths can’t constrain an intermediate node; SHACL needs `sh:qualifiedValueShape`, a constraint rather than a path.

The rejected alternative – growing `path` into a filter language – makes the core own a query language, puts the source graph’s shape into every declaration, and still can’t express aggregate selection. It’s recorded because it’s the option someone will re-propose.

What makes the chosen option viable is that **roles decide what surfaces**: an inline reference declaring no role reaches neither the engine nor the API. So RDF depth and API shape stay independent – inline as deep as the source demands, expose exactly the flat fields you want.

## `packages/search/CONTEXT.md` (new)

A glossary for `@lde/search`, scoped to the package rather than the repo root – these terms are the search model’s, and a root `CONTEXT.md` would claim more about the monorepo than is true. If pipeline or docgen grow glossaries later, a root `CONTEXT-MAP.md` follows.

The load-bearing distinction: **Path says what to read from the graph; Derive says what to compute from what was read.** Everything else in the extraction design follows from it. It also pins two absences that both declare intent – a field without a Role is an Internal Field, a type without a `class` is a Reference Type – and defines **Deployment**, the thing that supplies every domain semantic LDE refuses to name.

The scoping test it has to pass: **every term is one `@lde/search` itself has an opinion about.** So `Reader`, `Writer` and root selection are used but not defined – they belong to `@lde/pipeline`, and a second definition is a second thing to drift. Grain and substrate are out entirely: nothing in `@lde/search` branches on a grain, and per #534’s own discipline nothing may – which grain to index is a Deployment’s choice, already defined in #534.

Only one live ambiguity is flagged: unqualified “field”, which is either a **Search Field** (the declaration) or a **Physical Field** (`title_search_nl` – what the engine stores). Both are now defined, so the warning has two terms to point at.

## ADR 9 status amendment

ADR 9 is **superseded by halves**, so it’s amended rather than replaced:

- **Still current** – the fan-out’s *placement*: composed in `@lde/search-pipeline` over N single-collection engine writers, not a multi-collection writer inside an engine adapter, plus the commit/abort isolation. That’s what ADR 9 set out to decide, and #606 keeps it.
- **Superseded** – the *projection mechanism*: the whole-schema single-scan stream, the `TypedSearchDocument` tag, and the buffer-until-flush.

The amendment also records something the git history makes clear and the ADR doesn’t: **the buffering was never ADR 9’s subject.** It arrived two PRs earlier, in `@lde/search-pipeline`’s first commit (#565), as an explicitly documented deferral of “bounded entity batches within one huge dataset”. ADR 9 inherited it as background and restated it while deciding the fan-out – which is why its Consequences never weigh memory. Without that note, a future reader finds ADR 9 asserting the exact thing #606 removes, with no clue why.

---

Note: a formatting hook converted three pre-existing EM dashes to EN dashes in an untouched `AGENTS.md` section (package creation). Cosmetic, and consistent with the repo’s dash preference, but unrelated to this PR.
