### PR TITLE
docs: project inside the batch, per root type (ADR 13)

### DIFF
--- a/docs/decisions/0009-route-a-whole-schema-projection-to-per-type-collections.md
+++ b/docs/decisions/0009-route-a-whole-schema-projection-to-per-type-collections.md
@@ -15,8 +15,9 @@ updates the catalog grain of search as a Configurable Pipeline instance
 several ([#590](https://github.com/ldelements/lde/issues/590)).
 
 **Partly superseded by
-[ADR 12 (Bound memory by the unit of work, not the input)](./0012-bound-memory-by-the-unit-of-work-not-the-input.md)**,
-which reverses this ADR by halves:
+[ADR 12 (Bound memory by the unit of work, not the input)](./0012-bound-memory-by-the-unit-of-work-not-the-input.md)
+and [ADR 13 (Project inside the batch, per root type)](./0013-project-inside-the-batch-per-root-type.md)**,
+which reverse this ADR by halves:
 
 - **Still current** – the fan-out’s _placement_: composed in
   `@lde/search-pipeline` over N single-collection engine writers (option (a)
@@ -24,13 +25,21 @@ which reverses this ADR by halves:
   committing, sweeping and failing in isolation; `abort` finalizing only the
   collections that did not go live. That is what this ADR set out to decide, and
   it stands.
+
+- **Still current** – the per-document `searchType` (`TypedSearchDocument`). N
+  stages still write to **one** terminal (`source → transform → sink`), and
+  `write(dataset, items)` carries no stage identity, so the type must travel with
+  the item. What changes is that a stage _mints_ it – it was constructed for one
+  type – rather than `projectGraph` _discovering_ it from `rdf:type`.
+  `searchIndexWriter` remains the router this ADR made it; it loses projection
+  and buffering, nothing else.
+
 - **Superseded** – the _projection mechanism_: the whole-schema single-scan
-  mixed stream, the per-document type tag (`TypedSearchDocument`), and the
-  buffer-until-flush. Each is a structure sized by the input rather than by a
-  configured unit. Bounding forces one stage per root type, so a batch belongs to
-  exactly one type – leaving no mixed stream to tag and nothing to route. What
-  survives of `searchIndexWriter` is run coordination, not projection.
-  Implemented by [#606](https://github.com/ldelements/lde/issues/606).
+  mixed stream, and the buffer-until-flush. Both are structures sized by the
+  input rather than by a bounded unit. Projection happens per type, per batch,
+  over roots the selector supplied ([ADR 13](./0013-project-inside-the-batch-per-root-type.md)).
+
+Implemented by [#606](https://github.com/ldelements/lde/issues/606).
 
 For the record: the buffering was never this ADR’s subject. It arrived two PRs
 earlier, in `@lde/search-pipeline`’s first commit
@@ -43,12 +52,12 @@ Consequences below never weigh memory – memory was not on the table.
 
 One validated `SearchSchema` declares several root types. The Dataset Register
 indexes four: `datasets` plus the Organization / Class / TerminologySource label
-collections its references resolve against (ADR 8). Each type derives its own
+collections its references resolve against ([ADR 8](./0008-resolve-reference-labels-from-per-reference-label-sources.md)). Each type derives its own
 Typesense collection definition, so the types cannot share a collection – they are
 four independent blue/green rebuilds, each with its own versioned collection,
 alias and single-flight lock.
 
-ADR 6 made the engine `Writer` a transactional, **single-collection** rebuild
+[ADR 6](./0006-make-the-writer-transaction-aware.md) made the engine `Writer` a transactional, **single-collection** rebuild
 (`BlueGreenRebuild` / `InPlaceRebuild`), bound to one `SearchType`. `projectGraph`
 already projects the **whole** schema in one pass – a single scan of the quads
 builds the subject index every type frames off – yielding one mixed stream of
@@ -77,7 +86,7 @@ it unchanged), so the routing is a pipeline-glue concern, not an engine one.
   quads are buffered until its flush, projected once (whole schema), then split
   by type and dispatched to each type’s run. The pipeline still drives one
   uniform `openRun → write* → commit/abort` and never branches on the
-  multi-collection shape – consistent with ADR 6’s single lifecycle. A
+  multi-collection shape – consistent with [ADR 6](./0006-make-the-writer-transaction-aware.md)’s single lifecycle. A
   single-collection deployment is just the N = 1 case.
 
 - **Each collection commits, sweeps and fails in isolation.** A type whose
@@ -91,7 +100,7 @@ it unchanged), so the routing is a pipeline-glue concern, not an engine one.
   stale collection is never silent.
 
 - **`abort` finalizes only the collections that did not go live.** The pipeline
-  aborts a run whose `commit` throws (ADR 6), so a partial commit reaches
+  aborts a run whose `commit` throws ([ADR 6](./0006-make-the-writer-transaction-aware.md)), so a partial commit reaches
   `abort`. Because a committed blue/green rebuild’s `abort` would drop its
   now-live collection, `abort` skips the collections that already committed and
   drops only the half-built ones (and releases their locks). A failure while

--- a/docs/decisions/0012-bound-memory-by-the-unit-of-work-not-the-input.md
+++ b/docs/decisions/0012-bound-memory-by-the-unit-of-work-not-the-input.md
@@ -12,9 +12,11 @@ this invariant without stating it.
 
 **Partly supersedes
 [ADR 9 (Route a whole-schema projection to per-type collections)](./0009-route-a-whole-schema-projection-to-per-type-collections.md)** –
-its projection mechanism (the whole-schema single-scan mixed stream, the
-per-document type tag, the buffer-until-flush), each of which is sized by the
-input. ADR 9’s fan-out placement is untouched and still current.
+its whole-schema single-scan mixed stream and its buffer-until-flush, both sized
+by the input. [ADR 9](./0009-route-a-whole-schema-projection-to-per-type-collections.md)’s fan-out placement and its per-document `searchType` are
+untouched and still current;
+[ADR 13](./0013-project-inside-the-batch-per-root-type.md) works out what
+replaces the mechanism.
 
 ## Context
 
@@ -57,14 +59,26 @@ code, and the bound evaporated when the _unit_ changed meaning underneath it.
 
 ## Decision
 
-**Memory is bounded by a configured unit of work, never by the size of the
-input.**
+**Memory is bounded by the unit of work, never by the size of the input.**
 
-- **A bound must name a unit the operator configures, not one the data defines.**
-  `batchSize`, `capacity`, `maxResults` are bounds. “One dataset”, “one
-  distribution”, “one graph”, “one run” are inputs wearing a bound’s clothes.
-  If the only way to shrink a structure is to be handed less data, it is not
+- **A bound must be independent of the input.** “One dataset”, “one
+  distribution”, “one graph”, “one run” are inputs wearing a bound’s clothes. If
+  the only way to shrink a structure is to be handed less data, it is not
   bounded.
+
+- **Tunability is a second property, not this one.** `batchSize` and
+  `maxResults` are configured by the operator; `AsyncQueue`’s `capacity` is a
+  fixed 128, never passed at either call site (`stage.ts:273`,
+  `pipeline.ts:348`) – **still a bound**, because a constant does not track the
+  input, but not one anyone can trade against throughput. Configure a bound where
+  the cost per item varies by deployment: 128 quads is tens of kilobytes, 128
+  documents is orders of magnitude more. A fixed constant satisfies this ADR; an
+  unconfigurable one may still be the wrong size.
+
+- **The atom is one root’s quads** – data-defined and irreducible, because a
+  document needs its root’s complete quads. Every bound here is expressed in
+  whole roots; a single pathological root is unbounded and nothing removes that
+  floor.
 
 - **Bounded is not the same as streaming.** A step may be _grouped_ – projection
   takes a batch and emits its documents – provided the group is the configured
@@ -74,10 +88,13 @@ input.**
   array of every document, no `jsonld.frame()` over a graph, no index built from
   a whole input. Whatever a unit allocates is released when the unit completes.
 
-- **Every read or write path states its bound and tests it.** A bound in a JSDoc
-  is not a bound – it is the thing this ADR exists because we tried. The test
-  asserts memory stays flat as input grows, which is the only form that fails
-  when the claim quietly stops being true.
+- **Every read or write path states its bound and tests it – by counting, not
+  measuring.** A bound in a JSDoc is not a bound: that is the thing this ADR
+  exists because we tried. Run the same path at two input sizes an order of
+  magnitude apart and assert the peak live item count is **identical at both**.
+  That is an assertion about a bound, and it fails deterministically the moment a
+  structure grows with input. A `process.memoryUsage()` assertion is both flakier
+  and _weaker_ – GC timing can hide a leak that a count cannot.
 
 ## Consequences
 
@@ -85,7 +102,7 @@ input.**
   per-type × per-batch queries instead of one scan. `batchSize` is the dial:
   high where the input is small (the catalog), low where it is not (objects).
 
-- **It forecloses whole-input optimizations, permanently.** ADR 9’s whole-schema
+- **It forecloses whole-input optimizations, permanently.** [ADR 9](./0009-route-a-whole-schema-projection-to-per-type-collections.md)’s whole-schema
   single-scan projection, whole-graph framing, and one-pass deduplication across
   a run are each cheaper than the bounded version and each unavailable. Proposals
   to reintroduce them should be read as proposals to reintroduce an unbounded
@@ -96,11 +113,21 @@ input.**
   fixed or small by construction. The rule targets structures that grow with the
   data, not every allocation.
 
-- **Cross-cutting bounds need an owner.** `deduplicateQuads` and
-  `buildSubjectIndex` independently keep a `Set<string>` over the same content –
-  each roughly a textual copy of the graph – for the same reason (QLever does not
-  deduplicate CONSTRUCT output). Two enforcements of one quirk cost two copies.
-  When a bound is everyone’s job it is paid for twice.
+- **Cross-cutting bounds need an owner _per path_.** `deduplicateQuads`
+  (`reader.ts:394`) and `buildSubjectIndex`’s `seen` (`frame-by-type.ts:45`) each
+  keep a `Set<string>` for the same reason – QLever does not deduplicate
+  CONSTRUCT output – but they are **not interchangeable**: `deduplicateQuads` is
+  scoped to one `read()` call, so one reader, one batch; `buildSubjectIndex` sees
+  `readerOutputs.flat()`, the merged batch, and is the only one that catches
+  cross-reader duplicates. So: `buildSubjectIndex` owns it on the projecting path
+  (readers set `deduplicate: false`); the reader owns it where no subject index
+  exists. “Each roughly a textual copy of the graph” is true of `deduplicateQuads`
+  only on an **unbounded** global stage – which is the catalog today, and what
+  #606 fixes.
 
-- **Known violation:** `searchIndexWriter` (#606), which is the forcing function
-  for writing this down.
+- **Known violations:** `searchIndexWriter` (#606) – the forcing function for
+  writing this down – and `RunContext.selectedSources()` (`pipeline.ts:464-471`),
+  which accumulates one IRI per selected dataset for the whole run.
+  `InPlaceRebuild.commit` needs it for the membership sweep, and #534 requires
+  it, so it is _arguably_ right at ~100 bytes × N datasets. But this ADR’s own
+  rule is that unbounded must be **argued**, and it has not been.

--- a/docs/decisions/0013-project-inside-the-batch-per-root-type.md
+++ b/docs/decisions/0013-project-inside-the-batch-per-root-type.md
@@ -1,0 +1,224 @@
+# 13. Project inside the batch, per root type
+
+Date: 2026-07-17
+
+## Status
+
+Proposed
+
+Applies [ADR 12 (Bound memory by the unit of work, not the input)](./0012-bound-memory-by-the-unit-of-work-not-the-input.md)
+to the search projection. Amends
+[ADR 2](./0002-unify-pipeline-extension-on-quad-transforms.md); supersedes gap 1
+of [#579](https://github.com/ldelements/lde/issues/579).
+[ADR 9](./0009-route-a-whole-schema-projection-to-per-type-collections.md)’s
+fan-out is **untouched** – only the buffering [ADR 12](./0012-bound-memory-by-the-unit-of-work-not-the-input.md) already superseded goes.
+Implemented by [#606](https://github.com/ldelements/lde/issues/606).
+
+## Context
+
+`searchIndexWriter` buffers every quad of a dataset, then every projected
+document – [ADR 12](./0012-bound-memory-by-the-unit-of-work-not-the-input.md)’s known violation, and why object indexing is impossible. It
+buffers for a real reason: projection needs a root’s **complete** quads, and a
+flat `AsyncIterable<Quad>` carries no completion signal.
+
+The root-complete group already exists. `stage.ts:340`’s `batchQuads` is one per
+in-flight batch, bounded by `batchSize × maxConcurrency`, and is then destroyed
+quad-by-quad at `queue.push`. Nothing needs recovering; it is thrown away one
+layer above the step that needs it.
+
+Two prior decisions block the obvious fix. Neither survives the code:
+
+- **#579** ruled per-type projection out: _“a projection always operates over a
+  resolvable whole.”_ The projection resolves nothing – `applyFacet`
+  (`project.ts:206-220`) stores bare IRIs, and `labelSource` occurs only in
+  declaration-time validation (`schema.ts:346`) and the query-time engine
+  (`search.ts:156`). The guarantee binds the **port**, not the projection
+  ([ADR 8](./0008-resolve-reference-labels-from-per-reference-label-sources.md)).
+  #579 was right that the **forge** (`as unknown as SearchSchema`) must die –
+  it bypasses the only validating constructor – but went from _the cast is bad_
+  to _the primitive is bad_.
+- **[ADR 2](./0002-unify-pipeline-extension-on-quad-transforms.md)** forbids a contract on a mechanical batch, because _“its aggregation
+  window depends on `batchSize`.”_ Under a **root-bound** selector the window is
+  a whole number of complete roots: `batchSize` moves memory and request count,
+  never output.
+
+Two constraints then fix the shape, and they converge from different premises:
+
+- **Writing happens at the end.** `source → transform → sink`; #534 makes the
+  `Writer` the pipeline’s single transaction-aware terminal. A `Writer` per stage
+  would make every stage a terminal – N pipelines wearing one name.
+- **Imports must not be duplicated.** `pipeline.ts:569` resolves each dataset’s
+  distribution _inside the per-dataset loop_, and with an `ImportResolver` that
+  means download + QLever index + server start (`importResolver.ts:195`).
+  Indexing is slow and the importer caches **one** index, so a pipeline per root
+  type re-imports every dataset N times with zero cache hits. Sharing the import
+  requires sharing the dataset loop – which is one pipeline.
+
+So: **one pipeline, N stages, one terminal.**
+
+## Decision
+
+**Project inside the batch, per root type, over the roots the selector
+supplied.**
+
+- **One seam.** `Stage<Out = Quad>` gains
+  `project?: (quads, ctx) => Iterable<Out>`, applied to the root-complete batch.
+  It requires `itemSelector` – no selector means no batch, and the only
+  remaining group is the readers’ whole output, an input-sized unit [ADR 12](./0012-bound-memory-by-the-unit-of-work-not-the-input.md)
+  forbids by name. It is the pipeline’s **only** type-changing extension point.
+  `Out = Quad` is the default, so every pipeline that does not project is
+  unchanged.
+
+- **The write-side plugins have no quads to touch, so a projecting pipeline has
+  none.** `beforeStageWrite` and `beforeDatasetWrite` are `QuadTransform`s
+  (`AsyncIterable<Quad> → AsyncIterable<Quad>`), and they run _after_ the stage
+  output – where a projecting pipeline’s data is already `SearchDocument`. There
+  is nothing for a quad transform to bite on; the exclusion is a semantic fact,
+  not a type convenience. (`beforeStageWrite` is also displaced outright:
+  `provenanceTransform` (`plugin/provenance.ts:24-32`) is a tail aggregator that
+  wants the last post-merge slot, and projection took it, because projection
+  needs the group.) The current plugins confirm it – provenance, namespace
+  normalization, cross-stage dedup are all RDF operations, and a projecting
+  pipeline’s product is a search index, not a graph. Because the constraint is on
+  the plugin’s _input type_, it is a **compile error**, not a runtime guard:
+  `plugins?: [Out] extends [Quad] ? PipelinePlugin[] : never`, so a projecting
+  pipeline cannot even name `plugins`. **Reader-attached `QuadTransform`s are
+  unaffected** ([ADR 2](./0002-unify-pipeline-extension-on-quad-transforms.md)):
+  they run on the reader output, _before_ the seam, where quads still exist. The
+  `never` is _“no quad plugins here”_, not _“no plugins here”_: a write-side
+  **document** transform is a clean additive extension (widen the conditional to
+  a `DocumentTransform` branch) if a need appears – but none does today, since
+  the obvious candidate, cross-dataset URI dedup, is deferred to query-time
+  grouping (#534). Deferred as YAGNI.
+
+- **No automated `rdf:type` handling – the selector owns it.** The projection is
+  handed its batch’s roots rather than scanning the extracted quads to discover
+  them, so `projectRoots(quads, roots, schema, searchType)` replaces
+  `projectGraph(quads, schema)`; `rootsByType` and `frameByType` go, and
+  `frameSubjects` frames by `@id` – all it ever really did.
+  `assertTypeInSchema` – the port’s own guard – enforces membership, so no schema
+  is ever forged. The selector may well ask for `?x a <class>`; that is its
+  business. The Dataset Register’s **injected** `rdf:type` triples and its
+  **minted** `a dcat:Dataset` exist only to feed the discovery, and both stop
+  being necessary.
+
+- **One stage per root type**, with its own selector and extraction. Forced
+  twice: a stage hands its bindings to _every_ reader, and whole-schema
+  projection over a per-type batch emits a spurious half-populated document the
+  moment a referent carries a type – which is the modelling #579 itself
+  recommends.
+
+- **`selectByClass(searchType)` is a helper, not a default.** Root selection is
+  a deployment concern; `SearchType.class` is the IR/API class, and three of the
+  Dataset Register’s four types have no source class at all. Where the two
+  coincide (SCHEMA-AP objects) the deployment says so in one word.
+
+- **One terminal, at the end.** All stages write to the pipeline’s `Writer`.
+  `searchIndexWriter` stays exactly what [ADR 9](./0009-route-a-whole-schema-projection-to-per-type-collections.md) made it – the engine-agnostic
+  per-collection fan-out – and **stops projecting and stops buffering**. A
+  `Writer` per stage is rejected: it breaks `source → transform → sink`, and the
+  N run lifecycles it needs are pure cost.
+
+- **`SearchDocument` carries its `SearchType`.** N stages write to one terminal
+  and `write(dataset, items)` has no stage identity, so the type travels with
+  the item. A stage mints the pair itself – it was constructed for one type.
+  `TypedSearchDocument` **moves to `@lde/search-pipeline`**: it exists only
+  because a pipeline terminal routes, which is glue, not projection.
+  `@lde/search` yields a bare `SearchDocument` and stays pipeline-free.
+
+## Consequences
+
+- **Memory is bounded by `batchSize` roots** at every structure on the path. The
+  atom is **one root’s quads**: irreducible, data-defined, and unbounded for a
+  pathological root. Nothing here fixes that; say it out loud rather than hide
+  it inside the bound.
+
+- **`Pipeline<Out = Quad>` becomes generic**, but narrowly: `PipelineOptions`’
+  `stages`/`writers`, `FanOutWriter`/`FanOutRunWriter`, `stageWriter`,
+  `runStages`/`runStage`, `runChain` and `collectStages`. The `QuadTransform`
+  surface – both plugin points and the two writers wrapping them –
+  **stays `Quad`**. That the surface _can_ stay `Quad` is a runtime fact tsc
+  cannot see (a projecting pipeline never reaches it), so the boundary where a
+  generic `RunWriter<Out>` meets a `Quad`-typed transform writer is bridged by a
+  small number of unchecked casts (~8 in the spike). Not free, and not net-zero:
+  measured at **+69 lines across the two files**, of which the `project` seam is
+  ~20 and the rest is those casts, the generic threading, and their justifying
+  comments. Confirmed against `tsc`: the whole workspace (27 projects) and every
+  existing test compile unchanged under the `Out = Quad` default.
+
+- **The type parameter earns its keep: a mixed pipeline is a compile error.**
+  Verified – `stages: [Stage<Quad>, Stage<SearchDocument>]`, and a
+  `Pipeline<SearchDocument>` handed a `Writer<Quad>`, are both rejected
+  (`TS2322`). This holds despite `Out` appearing in a method parameter (checked
+  bivariantly): bivariance only relaxes _subtype_ relationships, and `Quad` and a
+  document are unrelated, so the check fails as if invariant. One rough edge –
+  inference does not union candidates, so a mixed array with no writer to pin
+  `Out` falls back to the default and points the error at the projecting stage
+  rather than naming the mix. The rejection is sound; the diagnostic is imperfect.
+
+- **`runChain` stays quad-only, as a runtime contract.** A chained stage
+  serializes its output to N-Triples (`pipeline.ts:941-944`), which a
+  `SearchDocument` cannot do – but “sub-stages imply `Out = Quad`” is not
+  expressible, because `chaining` and `stages` are independent options. So it is
+  a construction guard, not a type. (`project` and `stages` on the _same_ stage,
+  by contrast, are mutually exclusive and _are_ typed.)
+
+- **Stages stay sequential** (`pipeline.ts:823`), each already running
+  `maxConcurrency` batches internally, and a stage’s failure is already isolated
+  to that stage. Running stages in parallel is safe – [ADR 8](./0008-resolve-reference-labels-from-per-reference-label-sources.md) resolves labels at
+  query time, so the label stages have no ordering dependency on the Dataset
+  stage – but it multiplies both the load on the one shared endpoint and the
+  memory bound. If it is ever wanted it is an additive, configured knob.
+
+- **[ADR 2](./0002-unify-pipeline-extension-on-quad-transforms.md) is amended, not discarded.** Its two quad extension points,
+  transforms-as-data, and _“non-RDF ingestion lives inside a reader”_ all stand.
+  Superseded: _“RDF is the narrow waist”_ – RDF is the waist **from reader to
+  batch**; a stage may declare one type-changing seam at the batch, and only
+  there. Restated: _“never a mechanical batch”_ → **a contract’s window is
+  always a whole number of complete roots.** ([ADR 2](./0002-unify-pipeline-extension-on-quad-transforms.md) also still says there are
+  exactly two extension points; `beforeDatasetWrite` made that three before this
+  ADR made it four.)
+
+- **`RunWriter`’s JSDoc is corrected – not [ADR 6](./0006-make-the-writer-transaction-aware.md).** `writer.ts:59` claims a run
+  is _“bracketed by exactly one `commit` or `abort`”_, and `writer.ts:95` that
+  `commit` is _“called exactly once”_. Both are already false:
+  `pipeline.ts:479-487` aborts a run whose `commit` throws. [ADR 6](./0006-make-the-writer-transaction-aware.md) itself says
+  only that `Pipeline.run` drives `openRun → write* → commit/abort` uniformly,
+  which is true and needs no amendment. A writer must tolerate `abort` after
+  `commit`; `searchIndexWriter`’s `committed` set is why that works today.
+
+- **[ADR 12](./0012-bound-memory-by-the-unit-of-work-not-the-input.md) is corrected in the same change**, by applying it here. Its rule read
+  _“a bound must name a unit the operator configures, not one the data defines”_ –
+  a false dichotomy: `AsyncQueue`’s `capacity = 128` is neither, and is a
+  perfectly good bound, because a constant does not track the input. The
+  invariant is **independence from the input**; configurability is a separate
+  property, worth having where cost per item varies (128 quads vs 128 documents
+  differ by orders of magnitude) but not the rule. It also gains the atom (one
+  root’s quads), `selectedSources()` as a second known violation, the counting
+  form of its test, and a corrected dedup consequence – `deduplicateQuads` and
+  `buildSubjectIndex` are scoped differently and are not interchangeable.
+
+- **Most selectors are generable; the residue is the entry point.** A **Label
+  Source**’s roots are already determined by the schema – they are the values of
+  the references that name it, so `Organization`’s roots are the objects of
+  whatever path `Dataset.publisher` declares, and `TerminologySource`’s the
+  objects of `Dataset.terminology_source`’s. `selectByClass` covers the object
+  grain, where `class` really is the source class. What is **not** derivable is
+  the **entry point** – the Dataset Register’s “registered, newest registration,
+  and has a title” is a deployment fact no schema states. So the Register
+  hand-writes **one** selector, not four, and the extraction generator
+  ([#548](https://github.com/ldelements/lde/issues/548)) emits the rest: a
+  generator that emits CONSTRUCTs but leaves their roots hand-written is half a
+  win. (`Dataset.class` is a `derive` with no `path` today, so its Label Source’s
+  roots only become derivable once
+  [#607](https://github.com/ldelements/lde/issues/607) gives it one – one more
+  thing that issue buys.)
+
+- **The Dataset Register’s extraction becomes root-bound**, which is what the
+  catalog needs to realise any of this, and its `rdf:type` injection and minted
+  `a dcat:Dataset` become unnecessary. Separate change, separate repo.
+
+- **Root-boundedness is a promise `@lde/pipeline` cannot check.** A selector
+  that does not bind the CONSTRUCT’s subject yields a batch that is not
+  root-complete, and projection will silently emit partial documents. It joins
+  `expectsOutput` as a documented contract.

--- a/packages/search/CONTEXT.md
+++ b/packages/search/CONTEXT.md
@@ -54,9 +54,9 @@ A capability a Search Field opts into: `output`, `searchable`, `filterable`,
 _Avoid_: flag, capability
 
 **Internal Field**:
-A Search Field declaring no Role. Projected into the Document so later Derives
-can read it, then pruned before the writer sees it. Never stored, never indexed,
-absent from the collection definition.
+A Search Field declaring no Role. Projected into the Search Document so later
+Derives can read it, then pruned before the writer sees it. Never stored, never
+indexed, absent from the collection definition.
 _Avoid_: hidden field, scratch field, private field
 
 **Path**:
@@ -68,7 +68,7 @@ _Avoid_: sh:path, predicate, selector
 
 **Derive**:
 A Search Field’s computation – what to compute from what was already read. Runs
-in declaration order over the Document; never touches the graph.
+in declaration order over the Search Document; never touches the graph.
 _Avoid_: transform, resolver, mapper
 
 A field has a Path or a Derive, never both. **Path says what to read; Derive
@@ -117,14 +117,18 @@ Mechanical, per field; never hand-written, never a public vocabulary.
 _Avoid_: dr: predicate, intermediate vocabulary, internal namespace
 
 **Projection**:
-Turning one root’s framed quads into a **Document**. The one type-changing step
-(quad → document); shared across all engines.
+Turning one root’s framed quads into a **Search Document**. The one
+type-changing step (quad → document); shared across all engines.
 _Avoid_: mapping, serialization
 
-**Document**:
+**Search Document**:
 The engine-agnostic logical record the projection emits and a writer consumes.
 The shared contract between the engine-agnostic side and every engine adapter.
-_Avoid_: record, row, hit
+Prefixed like its siblings – `Search Field`, `Search Type`, `Search Schema` –
+because the prefix is this family’s namespace, not a claim that the record is
+only for searching: retrieval (`output`) is as much its job. Bare `Document`
+would also shadow the DOM global, and the browser query path reads this package.
+_Avoid_: document (unqualified), record, row, hit
 
 **Physical Field**:
 A field the engine actually stores – `title_search_nl`, `title_sort_nl`,
@@ -166,7 +170,7 @@ several stored fields, so the two are never one-to-one. Qualify which you mean.
 > **Dev:** The compatibility booleans read `quadsValidated`. Is that a field?
 >
 > **Expert:** An Internal Field. It declares no Role, so it’s projected into the
-> Document for the Derives to read and pruned before the writer. It never
+> Search Document for the Derives to read and pruned before the writer. It never
 > reaches the engine – not stored, not indexed, not in the collection
 > definition.
 >


### PR DESCRIPTION
Docs only. The decision behind #606, plus corrections to ADR 12 (still Proposed) and ADR 9 that fall out of applying it.

## ADR 13: Project inside the batch, per root type (new, Proposed)

`searchIndexWriter` buffers every quad of a dataset, then every projected document, before writing any of them. ADR 12’s known violation, and why object indexing is impossible.

**Two constraints fix the shape, and they converge from unrelated premises:**

- **Writing happens at the end.** `source → transform → sink`; #534 makes the `Writer` the pipeline’s single transaction-aware terminal. A `Writer` per stage would make every stage a terminal.
- **Imports must not be duplicated.** The import is a `DistributionResolver` called per dataset (`pipeline.ts:569` → `importResolver.ts:195`) against a **one-index** cache. A pipeline per root type re-imports every dataset N times with zero cache hits – and sharing the import requires sharing the dataset loop, which *is* one pipeline.

→ **one pipeline, N stages, one terminal.**

Also settled:

- **The real argument for projection-as-a-Stage is `provenanceTransform`** (`plugin/provenance.ts:24-32`): a tail aggregator applied once per `write()` call. Projection and `beforeStageWrite` both want the last post-merge slot; only one can have it. (#606 previously argued “needs root-complete groups, therefore a Stage” – a non-sequitur: a Writer called per batch is *in* the loop.)
- **Roots come from the selector, not `rdf:type`.** `projectRoots` replaces `projectGraph`; `rootsByType` and `frameByType` go, and so does DR’s `rdf:type` injection.
- **`selectByClass(searchType)` is a helper, not a default** – `SearchType.class` is the IR/API class, and three of DR’s four types have no source class at all.

## Refutes gap 1 of #579

#579 (closed) ruled per-type projection out: *“a projection always operates over a resolvable whole”*. **The projection resolves nothing** – `applyFacet` stores bare IRIs, and `labelSource` occurs only in declaration-time validation (`schema.ts:346`) and the query-time engine (`search.ts:156`); **zero** occurrences in `project.ts`/`frame-by-type.ts`. The guarantee binds the port, not the projection (ADR 8).

What #579 was right about – never forge the schema brand (`as unknown as SearchSchema`) – is honoured: `projectRoots` takes a real `SearchSchema` and calls `assertTypeInSchema`, the port’s own guard. #579 went from *the cast is bad* to *the primitive is bad*; ADR 9 inherited the conclusion.

## ADR 12: corrected in place (still Proposed)

Its rule read *“a bound must name a unit the operator configures, not one the data defines”* – **a false dichotomy**. `AsyncQueue`’s `capacity = 128` is neither, and is a perfectly good bound: a constant does not track the input. The invariant is **independence from the input**; **configurability is a separate property**, worth having where cost per item varies (128 quads is tens of KB; 128 documents is orders of magnitude more) but not the rule.

Also gains: the atom (one root’s quads – data-defined, irreducible); `selectedSources()` as a second known violation; the **counting** form of its test (assert peak live item count is identical at two input sizes – deterministic, where `process.memoryUsage()` is flakier *and* weaker, since GC timing can hide a leak a count cannot); and a corrected dedup consequence – `deduplicateQuads` and `buildSubjectIndex` are scoped differently (one `read()` vs the merged batch) and are **not** interchangeable, so “pick one owner” was the wrong fix.

## ADR 9: halves re-cut

- **Still current**: the fan-out’s placement (unchanged), *and* the per-document `searchType`. N stages write to one terminal and `write(dataset, items)` carries no stage identity, so the type must travel with the item – a stage now *mints* it rather than `projectGraph` *discovering* it. `searchIndexWriter` stays the router; it loses projection and buffering, nothing else.
- **Superseded**: the whole-schema single-scan mixed stream, and the buffer-until-flush.

## `packages/search/CONTEXT.md`

`Document` → **Search Document**: prefixed like `Search Field` / `Search Type` / `Search Schema`, because the prefix is the family’s namespace rather than a claim that the record is only for searching – retrieval (`output`) is as much its job. Bare `Document` would also shadow the DOM global, and the browser query path reads this package.

## Not in this PR

`RunWriter`’s JSDoc (`writer.ts:59, 95`) claims a run is “bracketed by exactly one `commit` or `abort`”; `pipeline.ts:479-487` already aborts a run whose `commit` throws, so it is false today. ADR 6 itself says nothing false. That correction is slice 3 of #606.
