### PR TITLE
feat(pipeline): add Stage<Out> and the project seam

### DIFF
--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -65,7 +65,7 @@ export interface BeforeStageWriteContext {
 /**
  * Context handed to a {@link PipelinePlugin.beforeDatasetWrite} transform: the
  * `dataset` whose complete, cross-stage output is being written. Unlike
- * {@link BeforeStageWriteContext} there is no `stage` — the transform sees one
+ * {@link BeforeStageWriteContext} there is no `stage` – the transform sees one
  * dataset's quads from every stage as a single stream.
  */
 export interface BeforeDatasetWriteContext {
@@ -79,7 +79,7 @@ export interface PipelinePlugin {
    * Transform a single stage's merged output before writing (extension point
    * 2: per stage, post-merge). Runs once per stage per dataset, carrying the
    * stage identity so it can mint stable per-`(dataset, stage)` IRIs. The home
-   * of stage-scoped concerns — provenance stamping, namespace rewriting of a
+   * of stage-scoped concerns – provenance stamping, namespace rewriting of a
    * stage's own quads.
    */
   beforeStageWrite?: QuadTransform<BeforeStageWriteContext>;
@@ -88,7 +88,7 @@ export interface PipelinePlugin {
    * dataset, cross-stage). Runs once over the concatenation of every stage's
    * output for one dataset, after all stages complete and before the write is
    * flushed. The home of concerns that need to reconcile quads *across* stages
-   * — deduplication, cross-stage roll-ups, or merging partition nodes that
+   * – deduplication, cross-stage roll-ups, or merging partition nodes that
    * different stages contribute to.
    *
    * The transform is a streaming {@link QuadTransform}: the pipeline pipes each
@@ -99,11 +99,19 @@ export interface PipelinePlugin {
   beforeDatasetWrite?: QuadTransform<BeforeDatasetWriteContext>;
 }
 
-export interface PipelineOptions {
+export interface PipelineOptions<Out = Quad> {
   datasetSelector: DatasetSelector;
-  stages: Stage[];
-  writers: Writer | Writer[];
-  plugins?: PipelinePlugin[];
+  stages: Stage<Out>[];
+  writers: Writer<Out> | Writer<Out>[];
+  /**
+   * Quad-level plugins ({@link PipelinePlugin}). Available only to a plain quad
+   * pipeline: a projecting pipeline's write-side data is already the projected
+   * item, and both plugin points are `QuadTransform`s with no quads to act on,
+   * so the type forbids them (`never`). Reader-attached quad transforms are
+   * unaffected – they run before the projection seam. See
+   * {@link https://github.com/ldelements/lde/blob/main/docs/decisions/0013-project-inside-the-batch-per-root-type.md | ADR 13}.
+   */
+  plugins?: [Out] extends [Quad] ? PipelinePlugin[] : never;
   name?: string;
   distributionResolver?: DistributionResolver;
   chaining?: {
@@ -192,14 +200,14 @@ function tee<T>(source: AsyncIterable<T>, count: number): AsyncIterable<T>[] {
   }));
 }
 
-class FanOutWriter implements Writer {
-  constructor(private readonly writers: Writer[]) {}
+class FanOutWriter<Item> implements Writer<Item> {
+  constructor(private readonly writers: Writer<Item>[]) {}
 
-  async openRun(context: RunContext): Promise<RunWriter> {
+  async openRun(context: RunContext): Promise<RunWriter<Item>> {
     // Opening a writer's run can have side effects (a cross-pod lock, a fresh
     // collection). If one writer opens but a sibling then fails, the pipeline
     // never gets a RunWriter to abort, so roll the opened ones back here
-    // before rethrowing — otherwise their locks and collections leak.
+    // before rethrowing – otherwise their locks and collections leak.
     const results = await Promise.allSettled(
       this.writers.map((writer) => writer.openRun(context)),
     );
@@ -213,7 +221,7 @@ class FanOutWriter implements Writer {
       await Promise.allSettled(opened.map((run) => run.abort(failure.reason)));
       throw failure.reason;
     }
-    return new FanOutRunWriter(opened);
+    return new FanOutRunWriter<Item>(opened);
   }
 }
 
@@ -229,11 +237,11 @@ async function settleBranches(tasks: readonly Promise<void>[]): Promise<void> {
   if (failed) throw failed.reason;
 }
 
-class FanOutRunWriter implements RunWriter {
-  constructor(private readonly runs: RunWriter[]) {}
+class FanOutRunWriter<Item> implements RunWriter<Item> {
+  constructor(private readonly runs: RunWriter<Item>[]) {}
 
-  async write(dataset: Dataset, quads: AsyncIterable<Quad>): Promise<void> {
-    const branches = tee(quads, this.runs.length);
+  async write(dataset: Dataset, items: AsyncIterable<Item>): Promise<void> {
+    const branches = tee(items, this.runs.length);
     await Promise.all(
       this.runs.map((run, index) => run.write(dataset, branches[index])),
     );
@@ -274,7 +282,7 @@ class TransformWriter implements DatasetWriter {
     );
   }
   // Only write(): the Pipeline flushes the underlying run writer directly, once
-  // per dataset after all stages — a TransformWriter only wraps a single write.
+  // per dataset after all stages – a TransformWriter only wraps a single write.
 }
 
 /** Discards a dataset's queued output; used to unblock the transform on reset. */
@@ -378,21 +386,21 @@ class DatasetTransformWriter implements RunWriter {
   }
 }
 
-export class Pipeline {
+export class Pipeline<Out = Quad> {
   private readonly name: string;
   private readonly datasetSelector: DatasetSelector;
-  private readonly stages: Stage[];
-  private readonly writer: Writer;
+  private readonly stages: Stage<Out>[];
+  private readonly writer: Writer<Out>;
   private readonly beforeStageWrite?: QuadTransform<BeforeStageWriteContext>;
   private readonly beforeDatasetWrite?: QuadTransform<BeforeDatasetWriteContext>;
   private readonly distributionResolver: DistributionResolver;
-  private readonly chaining?: PipelineOptions['chaining'];
+  private readonly chaining?: PipelineOptions<Out>['chaining'];
   private readonly reporter?: ProgressReporter;
   private readonly timeoutFactory: () => TimeoutPolicy;
   private readonly provenanceStore?: ProvenanceStore;
   private readonly pipelineVersion?: string;
 
-  constructor(options: PipelineOptions) {
+  constructor(options: PipelineOptions<Out>) {
     const hasSubStages = options.stages.some(
       (stage) => stage.stages.length > 0,
     );
@@ -414,10 +422,14 @@ export class Pipeline {
     // transforms wrap it per stage (see stageWriter) so each carries the stage
     // identity it needs to mint stable, non-fusing IRIs.
     this.writer = Array.isArray(options.writers)
-      ? new FanOutWriter(options.writers)
+      ? new FanOutWriter<Out>(options.writers)
       : options.writers;
 
-    const transforms = options.plugins
+    // Plugins are quad-typed and only reachable when `Out` is `Quad` (the
+    // `plugins` field is `never` otherwise), but inside the class body `Out` is
+    // opaque, so the conditional-typed field is read as a plain plugin array.
+    const plugins = options.plugins as PipelinePlugin[] | undefined;
+    const transforms = plugins
       ?.map((p) => p.beforeStageWrite)
       .filter(
         (t): t is QuadTransform<BeforeStageWriteContext> => t !== undefined,
@@ -426,7 +438,7 @@ export class Pipeline {
       ? (quads, context) => transforms.reduce((q, fn) => fn(q, context), quads)
       : undefined;
 
-    const datasetTransforms = options.plugins
+    const datasetTransforms = plugins
       ?.map((p) => p.beforeDatasetWrite)
       .filter(
         (t): t is QuadTransform<BeforeDatasetWriteContext> => t !== undefined,
@@ -471,9 +483,15 @@ export class Pipeline {
     };
     const openedWriter = await this.writer.openRun(context);
     // Wrap the run writer so a whole-dataset transform sees every stage's
-    // output for a dataset as one stream before it is written.
-    const runWriter = this.beforeDatasetWrite
-      ? new DatasetTransformWriter(openedWriter, this.beforeDatasetWrite)
+    // output for a dataset as one stream before it is written. The transform is
+    // quad-typed and only present when `Out` is `Quad` (a projecting pipeline
+    // has no plugins), so narrowing the run writer to `RunWriter<Quad>` here is
+    // sound – tsc cannot see that invariant.
+    const runWriter: RunWriter<Out> = this.beforeDatasetWrite
+      ? (new DatasetTransformWriter(
+          openedWriter as unknown as RunWriter<Quad>,
+          this.beforeDatasetWrite,
+        ) as unknown as RunWriter<Out>)
       : openedWriter;
 
     try {
@@ -497,7 +515,7 @@ export class Pipeline {
 
   private async processDataset(
     dataset: Dataset,
-    runWriter: RunWriter,
+    runWriter: RunWriter<Out>,
     context: RunContext,
   ): Promise<void> {
     this.reporter?.datasetStart?.(dataset);
@@ -750,7 +768,11 @@ export class Pipeline {
     }
   }
 
-  private *collectStages(stages: readonly Stage[]): Iterable<Stage> {
+  // Walks every stage and sub-stage to collect validators; it reads only
+  // `validator`/`stages`, never output, so it is agnostic to the item type.
+  private *collectStages(
+    stages: readonly Stage<unknown>[],
+  ): Iterable<Stage<unknown>> {
     for (const stage of stages) {
       yield stage;
       if (stage.stages.length > 0) yield* this.collectStages(stage.stages);
@@ -763,9 +785,19 @@ export class Pipeline {
    * transforms, carrying this `stage`'s identity so a transform can mint stable
    * per-`(dataset, stage)` IRIs rather than blank nodes.
    */
-  private stageWriter(runWriter: RunWriter, stage: string): DatasetWriter {
+  private stageWriter(
+    runWriter: RunWriter<Out>,
+    stage: string,
+  ): DatasetWriter<Out> {
+    // `beforeStageWrite` is quad-typed and only present when `Out` is `Quad` (a
+    // projecting pipeline has no plugins), so the `TransformWriter` wrap is
+    // reached only in that case; tsc cannot see the invariant, hence the casts.
     return this.beforeStageWrite
-      ? new TransformWriter(runWriter, this.beforeStageWrite, stage)
+      ? (new TransformWriter(
+          runWriter as unknown as DatasetWriter<Quad>,
+          this.beforeStageWrite,
+          stage,
+        ) as unknown as DatasetWriter<Out>)
       : runWriter;
   }
 
@@ -816,7 +848,7 @@ export class Pipeline {
     dataset: Dataset,
     distribution: Distribution,
     timeout: TimeoutPolicy,
-    runWriter: RunWriter,
+    runWriter: RunWriter<Out>,
     context: RunContext,
   ): Promise<boolean> {
     let stageFailed = false;
@@ -855,11 +887,11 @@ export class Pipeline {
    * Run a stage with reporting and return whether it was supported.
    * Returns `true` if the stage produced results, `false` if NotSupported.
    */
-  private async runStage(
+  private async runStage<Item>(
     dataset: Dataset,
     distribution: Distribution,
-    stage: Stage,
-    writer: DatasetWriter,
+    stage: Stage<Item>,
+    writer: DatasetWriter<Item>,
     timeout?: TimeoutPolicy,
   ): Promise<boolean> {
     this.reporter?.stageStart?.(stage.name);
@@ -898,11 +930,11 @@ export class Pipeline {
   }
 
   /** Run a stage in chained mode, throwing if the stage is not supported. */
-  private async runChainedStage(
+  private async runChainedStage<Item>(
     dataset: Dataset,
     distribution: Distribution,
-    stage: Stage,
-    writer: DatasetWriter,
+    stage: Stage<Item>,
+    writer: DatasetWriter<Item>,
     timeout?: TimeoutPolicy,
   ): Promise<void> {
     const supported = await this.runStage(
@@ -922,20 +954,22 @@ export class Pipeline {
   private async runChain(
     dataset: Dataset,
     distribution: Distribution,
-    stage: Stage,
-    runWriter: RunWriter,
+    stage: Stage<Out>,
+    runWriter: RunWriter<Out>,
     context: RunContext,
     timeout?: TimeoutPolicy,
   ): Promise<void> {
     const { stageOutputResolver, outputDir } = this.chaining!;
     const outputFiles: string[] = [];
 
-    // Run one chained stage into its scratch FileWriter and flush it, so the
-    // output file exists on its final path before the resolver reads it. The
-    // scratch run is bracketed like any other: committed on success, aborted
-    // on failure so no half-written temp file is left behind.
+    // Chaining is a quad-only concern: every stage in a chain writes N-Triples
+    // to a scratch FileWriter (a `Writer<Quad>`), and a chained parent cannot
+    // project (a stage with `stages` forbids `project`), so it emits quads. The
+    // requirement "sub-stages imply `Out` is `Quad`" is not expressible – `stages`
+    // and `chaining` are independent options – so it is a runtime contract, and
+    // the scratch machinery treats the parent stage as `Stage<Quad>`.
     const runScratchStage = async (
-      chainedStage: Stage,
+      chainedStage: Stage<Quad>,
       stageDistribution: Distribution,
     ): Promise<string> => {
       const scratchWriter = new FileWriter({
@@ -961,8 +995,11 @@ export class Pipeline {
     };
 
     try {
-      // 1. Run parent stage → scratch FileWriter.
-      const parentOutput = await runScratchStage(stage, distribution);
+      // 1. Run parent stage → scratch FileWriter (quad-only, per above).
+      const parentOutput = await runScratchStage(
+        stage as unknown as Stage<Quad>,
+        distribution,
+      );
       outputFiles.push(parentOutput);
 
       // 2. Chain through children.
@@ -981,9 +1018,11 @@ export class Pipeline {
 
       // 3. Concatenate all output files → the open run, applying the plugins'
       // beforeStageWrite transforms once for the chain under the parent stage.
+      // The concatenation is quads (per the quad-only contract above), written
+      // to the `Out`-typed run writer – sound because chaining implies `Quad`.
       await this.stageWriter(runWriter, stage.name).write(
         dataset,
-        this.readFiles(outputFiles),
+        this.readFiles(outputFiles) as unknown as AsyncIterable<Out>,
       );
     } finally {
       await stageOutputResolver.cleanup();

--- a/packages/pipeline/src/stage.ts
+++ b/packages/pipeline/src/stage.ts
@@ -35,6 +35,28 @@ export interface ReaderContext {
 }
 
 /**
+ * The pipeline's one type-changing seam: turn a root-complete batch of quads
+ * into a stage's output items. The only extension point whose output is not
+ * `Quad` – a quad enrichment is a {@link QuadTransform} attached to a reader
+ * (extension point 1), which runs *before* this. See
+ * {@link https://github.com/ldelements/lde/blob/main/docs/decisions/0013-project-inside-the-batch-per-root-type.md | ADR 13}.
+ */
+export type BatchTransform<Out> = (
+  quads: readonly Quad[],
+  context: BatchContext,
+) => Iterable<Out> | AsyncIterable<Out>;
+
+/**
+ * Context handed to a {@link BatchTransform}: {@link ReaderContext} plus the
+ * batch's selected roots. `bindings` are the item-selector rows the readers were
+ * given as a `VALUES` block, so the batch is root-complete by construction – the
+ * projection frames exactly these roots rather than discovering them.
+ */
+export interface BatchContext extends ReaderContext {
+  bindings: readonly VariableBindings[];
+}
+
+/**
  * An {@link Reader} with zero or more {@link QuadTransform}s attached as data.
  *
  * The stage runner applies the transform(s) in order to **this reader's
@@ -64,10 +86,27 @@ interface NormalizedReader {
   transforms: QuadTransform<ReaderContext>[];
 }
 
-export interface StageOptions {
+export interface StageOptions<Out = Quad> {
   name: string;
   readers: StageReaders;
   itemSelector?: ItemSelector;
+  /**
+   * Turn each root-complete batch into this stage's output items – the one seam
+   * whose output type differs from `Quad` ({@link BatchTransform}). Requires
+   * {@link StageOptions.itemSelector} (a batch only exists under a selector) and
+   * forbids {@link StageOptions.stages} (a chained stage serializes to
+   * N-Triples, which a projected item cannot). Omit for a plain quad stage.
+   */
+  project?: BatchTransform<Out>;
+  /**
+   * Capacity of the bounded queue funnelling this stage's concurrent batches
+   * into the single write. The queue applies backpressure at this many items,
+   * so it bounds memory – set it where the cost per item is large (a projected
+   * document is far heavier than a quad). Only meaningful with an item selector.
+   *
+   * @default 128
+   */
+  queueCapacity?: number;
   /**
    * Maximum number of bindings per reader call.
    *
@@ -93,7 +132,7 @@ export interface StageOptions {
    * Treat a supported stage that produces no quads as a hard failure (throws),
    * rather than a legitimately empty result.
    *
-   * Set this for stages whose query must yield output — typically a scalar
+   * Set this for stages whose query must yield output – typically a scalar
    * aggregate such as `SELECT (COUNT(*) AS ?n)`, which always returns exactly
    * one row, so zero quads can only mean the endpoint truncated or aborted the
    * response (e.g. a timeout surfaced as an empty `HTTP 200`). The resulting
@@ -131,7 +170,7 @@ export interface SelectOptions {
   timeout?: TimeoutPolicy;
 }
 
-export class Stage {
+export class Stage<Out = Quad> {
   readonly name: string;
   readonly stages: readonly Stage[];
   /** Whether an empty result is treated as a hard failure. @see {@link StageOptions.expectsOutput} */
@@ -140,9 +179,21 @@ export class Stage {
   private readonly itemSelector?: ItemSelector;
   private readonly batchSize: number;
   private readonly maxConcurrency: number;
-  private readonly validation?: StageOptions['validation'];
+  private readonly validation?: StageOptions<Out>['validation'];
+  private readonly project?: BatchTransform<Out>;
+  private readonly queueCapacity?: number;
 
-  constructor(options: StageOptions) {
+  constructor(options: StageOptions<Out>) {
+    if (options.project && !options.itemSelector) {
+      throw new Error(
+        `Stage '${options.name}': 'project' requires an 'itemSelector' – without one there is no batch to project, only the readers' whole output.`,
+      );
+    }
+    if (options.project && (options.stages?.length ?? 0) > 0) {
+      throw new Error(
+        `Stage '${options.name}': 'project' cannot combine with chained 'stages' – a chained stage serializes to N-Triples, which a projected item cannot.`,
+      );
+    }
     this.name = options.name;
     this.stages = options.stages ?? [];
     this.readers = normalizeReaders(options.readers);
@@ -151,6 +202,8 @@ export class Stage {
     this.maxConcurrency = options.maxConcurrency ?? 10;
     this.validation = options.validation;
     this.expectsOutput = options.expectsOutput ?? false;
+    this.project = options.project;
+    this.queueCapacity = options.queueCapacity;
   }
 
   /** The validator for this stage, if configured. */
@@ -161,7 +214,7 @@ export class Stage {
   async run(
     dataset: Dataset,
     distribution: Distribution,
-    writer: DatasetWriter,
+    writer: DatasetWriter<Out>,
     options?: RunOptions,
   ): Promise<NotSupported | void> {
     const timeout = options?.timeout;
@@ -182,6 +235,12 @@ export class Stage {
       return streams;
     }
 
+    // The non-selector path has no batch, so `project` is forbidden here (the
+    // constructor rejects `project` without an `itemSelector`). It therefore
+    // only ever writes quads, and `Out` is `Quad` at runtime – tsc cannot see
+    // that invariant, so the writer is narrowed once.
+    const quadWriter = writer as unknown as DatasetWriter<Quad>;
+
     // Quads the readers produced (before any validation filtering); used to
     // enforce `expectsOutput` below.
     let produced = 0;
@@ -197,7 +256,7 @@ export class Stage {
       const onInvalid = this.validation.onInvalid ?? 'write';
       if (onInvalid === 'write') {
         await Promise.all([
-          writer.write(
+          quadWriter.write(
             dataset,
             (async function* () {
               yield* buffer;
@@ -208,7 +267,7 @@ export class Stage {
       } else {
         const accepted = await this.validateBuffer(buffer, dataset);
         if (accepted.length > 0) {
-          await writer.write(
+          await quadWriter.write(
             dataset,
             (async function* () {
               yield* accepted;
@@ -219,14 +278,14 @@ export class Stage {
     } else if (this.expectsOutput) {
       // Only thread the per-quad counter through when the count is actually
       // needed; the default path stays a plain streaming write with no overhead.
-      await writer.write(
+      await quadWriter.write(
         dataset,
         countQuads(mergeStreams(streams), (count) => {
           produced = count;
         }),
       );
     } else {
-      await writer.write(dataset, mergeStreams(streams));
+      await quadWriter.write(dataset, mergeStreams(streams));
     }
 
     this.assertProduced(produced);
@@ -234,7 +293,7 @@ export class Stage {
 
   /**
    * Throw when {@link StageOptions.expectsOutput} is set but the stage produced
-   * no quads — a supported-but-empty result that signals a truncated or aborted
+   * no quads – a supported-but-empty result that signals a truncated or aborted
    * endpoint response rather than a legitimately empty one.
    */
   private assertProduced(produced: number): void {
@@ -247,7 +306,7 @@ export class Stage {
     selector: AsyncIterable<VariableBindings>,
     dataset: Dataset,
     distribution: Distribution,
-    writer: DatasetWriter,
+    writer: DatasetWriter<Out>,
     options?: RunOptions,
   ): Promise<NotSupported | void> {
     // Peek the first batch to detect an empty selector before starting the
@@ -270,8 +329,11 @@ export class Stage {
       }
     })();
 
-    const queue = new AsyncQueue<Quad>();
+    const queue = new AsyncQueue<Out>(this.queueCapacity);
     let itemsProcessed = 0;
+    // Output items written this run. Equals quads written for a plain stage;
+    // for a projecting stage it counts projected items (documents), one or more
+    // – or fewer – per root, which is what `expectsOutput`/`onProgress` report.
     let quadsGenerated = 0;
     let hasResults = false;
 
@@ -339,28 +401,42 @@ export class Stage {
               );
               const batchQuads = readerOutputs.flat();
 
+              // Validation runs on the quads, before projection – validators are
+              // quad-typed. 'skip'/'halt' must resolve it before writing; 'write'
+              // validates concurrently, below, without blocking.
+              let acceptedQuads = batchQuads;
               if (
                 this.validation &&
                 batchQuads.length > 0 &&
                 onInvalid !== 'write'
               ) {
-                // 'skip' or 'halt': must await validation before deciding to write.
-                const accepted = await this.validateBuffer(batchQuads, dataset);
-                for (const quad of accepted) {
-                  await queue.push(quad);
-                  quadsGenerated++;
-                }
-              } else {
-                for (const quad of batchQuads) {
-                  await queue.push(quad);
-                  quadsGenerated++;
-                }
-                if (this.validation && batchQuads.length > 0) {
-                  // 'write' mode: validate concurrently without blocking the write path.
-                  pendingValidations.push(
-                    this.validation.validator.validate(batchQuads, dataset),
-                  );
-                }
+                acceptedQuads = await this.validateBuffer(batchQuads, dataset);
+              }
+
+              // The one type-changing seam: project the root-complete batch into
+              // output items, or pass the quads through for a plain stage (`Out`
+              // is `Quad` at runtime when there is no projection).
+              const items: Iterable<Out> | AsyncIterable<Out> = this.project
+                ? this.project(acceptedQuads, {
+                    dataset,
+                    distribution,
+                    stage: this.name,
+                    bindings,
+                  })
+                : (acceptedQuads as unknown as Out[]);
+              for await (const item of items) {
+                await queue.push(item);
+                quadsGenerated++;
+              }
+
+              if (
+                this.validation &&
+                batchQuads.length > 0 &&
+                onInvalid === 'write'
+              ) {
+                pendingValidations.push(
+                  this.validation.validator.validate(batchQuads, dataset),
+                );
               }
 
               itemsProcessed += bindings.length;
@@ -513,7 +589,7 @@ async function* mergeStreams(
  * via `onCount` once the stream is exhausted. Lets a streaming write enforce
  * {@link StageOptions.expectsOutput} without buffering.
  *
- * `onCount` fires only when the consumer drains the stream — which the pipeline
+ * `onCount` fires only when the consumer drains the stream – which the pipeline
  * writers do. A writer that stops early would leave the count short; callers
  * relying on it for `expectsOutput` must consume the stream fully.
  */

--- a/packages/pipeline/test/stage-generic-out.test.ts
+++ b/packages/pipeline/test/stage-generic-out.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { Pipeline, Stage } from '../src/index.js';
+import type { DatasetSelector, Writer } from '../src/index.js';
+
+/**
+ * Compile-time guarantees for `Stage<Out>` / `Pipeline<Out>`. These are checked
+ * by the `typecheck` target, which compiles `test/**\/*.test.ts`: a wrong
+ * assertion turns its `@ts-expect-error` into an "unused directive" error and
+ * fails typecheck. The function is never called – the constructions exist only
+ * to be type-checked, not run. See
+ * {@link ../../../docs/decisions/0013-project-inside-the-batch-per-root-type.md | ADR 13}.
+ */
+function typeAssertions(): void {
+  const selector = {} as DatasetSelector;
+  const quadStage = {} as Stage; // Stage<Quad>
+  const documentStage = {} as Stage<string>;
+  const quadWriter = {} as Writer; // Writer<Quad>
+  const documentWriter = {} as Writer<string>;
+
+  // Homogeneous pipelines are well-typed.
+  void new Pipeline({
+    datasetSelector: selector,
+    stages: [quadStage],
+    writers: quadWriter,
+  });
+  void new Pipeline<string>({
+    datasetSelector: selector,
+    stages: [documentStage],
+    writers: documentWriter,
+  });
+
+  void new Pipeline({
+    datasetSelector: selector,
+    // @ts-expect-error a quad pipeline cannot hold a document-producing stage
+    stages: [quadStage, documentStage],
+    writers: quadWriter,
+  });
+
+  void new Pipeline<string>({
+    datasetSelector: selector,
+    stages: [documentStage],
+    // @ts-expect-error a document pipeline cannot take a quad writer
+    writers: quadWriter,
+  });
+
+  void new Pipeline<string>({
+    datasetSelector: selector,
+    stages: [documentStage],
+    writers: documentWriter,
+    // @ts-expect-error a projecting pipeline has no quad plugins
+    plugins: [],
+  });
+}
+
+describe('Stage<Out> / Pipeline<Out> type safety', () => {
+  it('rejects a mixed pipeline at compile time (checked by nx typecheck)', () => {
+    // The assertions live in `typeAssertions`, verified when the test file is
+    // type-checked; this keeps the module a runnable, non-empty spec.
+    expect(typeof typeAssertions).toBe('function');
+  });
+});

--- a/packages/pipeline/test/stage.test.ts
+++ b/packages/pipeline/test/stage.test.ts
@@ -1007,7 +1007,7 @@ describe('Stage', () => {
   describe('expectsOutput', () => {
     it('throws when a supported stage produces no quads', async () => {
       // A scalar aggregate (e.g. COUNT) always returns a row; zero output means
-      // the endpoint truncated the response — a hard failure, not an empty result.
+      // the endpoint truncated the response – a hard failure, not an empty result.
       const stage = new Stage({
         name: 'triples-count',
         readers: mockExecutor([]),
@@ -1071,6 +1071,157 @@ describe('Stage', () => {
       await expect(stage.run(dataset, distribution, writer)).rejects.toThrow(
         /per-class-count/,
       );
+    });
+  });
+
+  describe('project seam', () => {
+    // A writer over an arbitrary item type, so a projecting stage can be driven
+    // without any search dependency.
+    function collectingItemWriter<Item>(): DatasetWriter<Item> & {
+      items: Item[];
+    } {
+      const items: Item[] = [];
+      return {
+        items,
+        async write(_dataset, data) {
+          for await (const item of data) {
+            items.push(item);
+          }
+        },
+      };
+    }
+
+    it('projects each batch of quads into output items', async () => {
+      const stage = new Stage<string>({
+        name: 'project',
+        itemSelector: mockItemSelector([{ s: namedNode('http://x') }]),
+        readers: mockExecutor([q1, q2]),
+        project: (quads) => quads.map((quad) => quad.subject.value),
+      });
+
+      const writer = collectingItemWriter<string>();
+      const result = await stage.run(dataset, distribution, writer);
+
+      expect(result).not.toBeInstanceOf(NotSupported);
+      expect(writer.items).toEqual([
+        'http://example.org/s1',
+        'http://example.org/s2',
+      ]);
+    });
+
+    it('hands the batch its selected roots (bindings) in the context', async () => {
+      const seen: string[] = [];
+      const stage = new Stage<string>({
+        name: 'project',
+        batchSize: 1,
+        itemSelector: mockItemSelector([
+          { s: namedNode('http://root/1') },
+          { s: namedNode('http://root/2') },
+        ]),
+        readers: mockExecutor([q1]),
+        project: (_quads, context) => {
+          for (const row of context.bindings) seen.push(row.s.value);
+          return [];
+        },
+      });
+
+      await stage.run(dataset, distribution, collectingItemWriter<string>());
+
+      expect(seen).toEqual(['http://root/1', 'http://root/2']);
+    });
+
+    it('invokes project once per batch (ceil(roots / batchSize))', async () => {
+      const project = vi.fn((quads: readonly Quad[]) =>
+        quads.map((quad) => quad.object.value),
+      );
+      const stage = new Stage<string>({
+        name: 'project',
+        batchSize: 2,
+        itemSelector: mockItemSelector([
+          { s: namedNode('http://root/1') },
+          { s: namedNode('http://root/2') },
+          { s: namedNode('http://root/3') },
+          { s: namedNode('http://root/4') },
+          { s: namedNode('http://root/5') },
+        ]),
+        readers: mockExecutor([q1]),
+        project,
+      });
+
+      await stage.run(dataset, distribution, collectingItemWriter<string>());
+
+      // 5 roots at batchSize 2 → 3 batches.
+      expect(project).toHaveBeenCalledTimes(3);
+    });
+
+    it('supports an async-iterable projection', async () => {
+      const stage = new Stage<string>({
+        name: 'project',
+        itemSelector: mockItemSelector([{ s: namedNode('http://x') }]),
+        readers: mockExecutor([q1, q2]),
+        project: async function* (quads) {
+          for (const quad of quads) yield quad.predicate.value;
+        },
+      });
+
+      const writer = collectingItemWriter<string>();
+      await stage.run(dataset, distribution, writer);
+
+      expect(writer.items).toEqual([
+        'http://example.org/p',
+        'http://example.org/p',
+      ]);
+    });
+
+    it('projects only quads that pass validation (skip mode)', async () => {
+      const nonConforming: ValidationResult = {
+        conforms: false,
+        violations: 1,
+      };
+      const stage = new Stage<string>({
+        name: 'project',
+        itemSelector: mockItemSelector([{ s: namedNode('http://x') }]),
+        readers: mockExecutor([q1]),
+        project: (quads) => quads.map((quad) => quad.subject.value),
+        validation: {
+          validator: {
+            validate: async (): Promise<ValidationResult> => nonConforming,
+            report: async (): Promise<ValidationReport> => ({}) as never,
+          },
+          onInvalid: 'skip',
+        },
+      });
+
+      const writer = collectingItemWriter<string>();
+      await stage.run(dataset, distribution, writer);
+
+      // The batch failed validation and was skipped, so nothing is projected.
+      expect(writer.items).toEqual([]);
+    });
+
+    it('rejects project without an itemSelector at construction', () => {
+      expect(
+        () =>
+          new Stage<string>({
+            name: 'no-selector',
+            readers: mockExecutor([q1]),
+            project: (quads) => quads.map((quad) => quad.subject.value),
+          }),
+      ).toThrow(/requires an 'itemSelector'/);
+    });
+
+    it('rejects project combined with chained stages at construction', () => {
+      const child = new Stage({ name: 'child', readers: mockExecutor([]) });
+      expect(
+        () =>
+          new Stage<string>({
+            name: 'chained',
+            itemSelector: mockItemSelector([{ s: namedNode('http://x') }]),
+            readers: mockExecutor([q1]),
+            project: (quads) => quads.map((quad) => quad.subject.value),
+            stages: [child],
+          }),
+      ).toThrow(/cannot combine with chained 'stages'/);
     });
   });
 });

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -12,9 +12,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 97.38,
-          lines: 96.84,
-          branches: 91.55,
-          statements: 96.38,
+          lines: 97.04,
+          branches: 91.73,
+          statements: 96.58,
         },
       },
     },


### PR DESCRIPTION
Foundation for [ADR 13](https://github.com/ldelements/lde/blob/main/docs/decisions/0013-project-inside-the-batch-per-root-type.md): give `Stage`/`Pipeline` an output type parameter and a per-batch projection seam, so a later change can project a root-complete batch of quads into engine documents *inside the stage* rather than buffering a whole dataset in the writer. No consumer moves onto it yet – this only makes it possible.

## What it adds

- **`Stage<Out = Quad>`**, `StageOptions<Out = Quad>`, `Pipeline<Out = Quad>`, `PipelineOptions<Out = Quad>`. The `Quad` default keeps every existing consumer and test **source-compatible**.
- **The `project` seam** (`StageOptions.project`): a `BatchTransform<Out>` turning each root-complete batch into output items, with the batch's selected roots handed in via `BatchContext.bindings`. Requires an `itemSelector` (no selector → no batch) and forbids chained `stages` – both enforced at construction.
- **`queueCapacity`** on `StageOptions`, exposing the bounded write queue's size so a deployment can tune memory where the cost per item is large (a document versus a quad). `AsyncQueue`'s capacity was hard-coded to 128.
- **Quad plugins typed away from a projecting pipeline**: `plugins?: [Out] extends [Quad] ? PipelinePlugin[] : never`. The write-side transforms are `QuadTransform`s with no quads to act on once the batch is projected. Reader-attached quad transforms are unaffected – they run before the seam.
- **`RunWriter` JSDoc fix**: a run is not "bracketed by exactly one commit or abort" – `Pipeline.run` aborts a run whose `commit` throws, so a writer must tolerate `abort` after `commit`. Docs only; already true today.

## Cost, stated plainly

The `QuadTransform` surface (both plugin points and the two writers wrapping them) stays `Quad`-typed. That it *can* stay `Quad` is a runtime fact tsc cannot see (a projecting pipeline never reaches it), so the boundary where a generic `RunWriter<Out>` meets it is bridged by **8 unchecked casts**, each commented. Chaining likewise stays quad-only as a runtime contract – "sub-stages imply `Out = Quad`" is not expressible, since `stages` and `chaining` are independent options.

## Verification

- **The type parameter rejects a mixed pipeline** – `test/stage-generic-out.test.ts` asserts, via `@ts-expect-error` checked by the `typecheck` target, that a mixed `stages` array, a `Pipeline<Document>` given a `Writer<Quad>`, and quad plugins on a projecting pipeline are all compile errors. Removing any guard fails typecheck (`TS2322`).
- **`Out = Quad` is free for existing code**: whole-workspace `typecheck` green (27/27), and all pipeline tests pass unchanged. New behavioural tests cover the seam (batching, roots-in-context, async projection, validation-before-projection, construction guards) over a non-search fake writer.

Part of #606. Fix #621.
