### PR TITLE
feat(search): add projectRoots, the roots-given projection primitive

### DIFF
--- a/packages/search/src/frame-by-type.ts
+++ b/packages/search/src/frame-by-type.ts
@@ -69,22 +69,24 @@ export function buildSubjectIndex(
 }
 
 /**
- * Frame every root subject of `rootType` from a prebuilt {@link SubjectIndex}
- * into one JSON-LD node – the reusable core behind {@link frameByType}. Each
- * root subject’s own triples plus the one-hop nodes it references (e.g. nested
- * publisher/distribution resources) are framed one subject at a time, so beyond
- * the shared subject index only a single subgraph is held (whole-graph
- * `jsonld.frame()` is ~O(N²)). The frame carries no `@context`, so framed keys
- * are full predicate IRIs.
+ * Frame each of the given `roots` from a prebuilt {@link SubjectIndex} into one
+ * JSON-LD node. Each root subject’s own triples plus the one-hop nodes it
+ * references (e.g. nested publisher/distribution resources) are framed one
+ * subject at a time, so beyond the shared subject index only a single subgraph
+ * is held (whole-graph `jsonld.frame()` is ~O(N²)). The frame carries no
+ * `@context`, so framed keys are full predicate IRIs.
+ *
+ * The roots are supplied explicitly rather than discovered from `rdf:type`: a
+ * caller with the roots already in hand ({@link projectRoots}, from the pipeline
+ * selector) passes them directly; a whole-graph caller ({@link frameByType},
+ * {@link projectGraph}) passes {@link SubjectIndex.rootsByType}. A root absent
+ * from the index simply frames nothing.
  */
 export async function* frameSubjects(
   index: SubjectIndex,
-  rootType: string,
+  roots: readonly string[],
 ): AsyncIterable<FramedNode> {
   const { bySubject } = index;
-  // A type the index was not built for has no roots, so it frames nothing; the
-  // `projectType`/`projectGraph` callers only pass types they registered.
-  const roots = index.rootsByType.get(rootType) ?? [];
   for (const rootIri of roots) {
     const owned = bySubject.get(rootIri) ?? [];
     const referenced = owned
@@ -99,7 +101,7 @@ export async function* frameSubjects(
     // Frame for THIS specific root subject by `@id`, not just by root type. A
     // one-hop reference can itself be of `rootType` (e.g. a terminology source
     // that is also a separately registered dataset), so framing by type alone
-    // returns several root nodes and `[0]` could be the referenced one — which
+    // returns several root nodes and `[0]` could be the referenced one – which
     // would emit it twice and drop this subject entirely.
     const framed = await jsonld.frame(
       expanded,
@@ -124,5 +126,6 @@ export async function* frameByType(
   quads: Iterable<Quad>,
   rootType: string,
 ): AsyncIterable<FramedNode> {
-  yield* frameSubjects(buildSubjectIndex(quads, [rootType]), rootType);
+  const index = buildSubjectIndex(quads, [rootType]);
+  yield* frameSubjects(index, index.rootsByType.get(rootType) ?? []);
 }

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -7,11 +7,17 @@
 // Projection: RDF CONSTRUCT quads → flat search documents, driven by the
 // unified SearchField/SearchType model. The IR readers (irisOf, …) are here
 // because `derive` functions are written against them.
-export { projectGraph, irisOf, literalsOf, firstLiteralOf } from './project.js';
+export {
+  projectGraph,
+  projectRoots,
+  irisOf,
+  literalsOf,
+  firstLiteralOf,
+} from './project.js';
 export type { SearchDocument, TypedSearchDocument } from './project.js';
 
 // Unified field model: one declaration drives projection, engine collection
-// schema, query semantics and the GraphQL surface — a discriminated union by
+// schema, query semantics and the GraphQL surface – a discriminated union by
 // `kind`, validated again at runtime when the schema is built.
 export {
   defineSearchType,

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -6,6 +6,7 @@ import {
   type FramedNode,
 } from './frame-by-type.js';
 import {
+  assertTypeInSchema,
   displayFieldName,
   isoToUnixSeconds,
   physicalFields,
@@ -80,9 +81,42 @@ export async function* projectGraph(
     types.map((searchType) => searchType.class),
   );
   for (const searchType of types) {
-    for await (const node of frameSubjects(index, searchType.class)) {
+    const roots = index.rootsByType.get(searchType.class) ?? [];
+    for await (const node of frameSubjects(index, roots)) {
       yield { searchType, document: projectDocument(node, searchType) };
     }
+  }
+}
+
+/**
+ * Project a single type over a known set of `roots` – the per-type, roots-given
+ * projection. Unlike {@link projectGraph}, the roots are supplied by the caller
+ * (the pipeline selector) rather than discovered from `rdf:type`, so `quads`
+ * need carry no type triples and the projection frames each distinct subject
+ * once. {@link assertTypeInSchema} guards that `searchType` belongs to `schema`
+ * – the port’s own membership check – so no schema is ever forged to scope a
+ * projection to one type. Yields a bare {@link SearchDocument}: tagging a
+ * document with its type is a routing concern, owned by the pipeline glue, not
+ * the projection.
+ *
+ * Consumes `quads` once, so it accepts any `Iterable` – a batch’s materialized
+ * array or a chained generator merging several readers.
+ */
+export async function* projectRoots(
+  quads: Iterable<Quad>,
+  roots: readonly string[],
+  schema: SearchSchema,
+  searchType: SearchType,
+): AsyncIterable<SearchDocument> {
+  assertTypeInSchema(schema, searchType);
+  const index = buildSubjectIndex(quads, []);
+  // Distinct roots only. A selector may return an IRI more than once – a
+  // non-`DISTINCT` `SELECT` over a one-to-many join yields the same subject per
+  // matched row – and a repeated root would otherwise frame and emit a
+  // duplicate document under the same `id`. (`projectGraph`’s roots come from
+  // `rootsByType`, which is inherently unique, so it never needs this.)
+  for await (const node of frameSubjects(index, [...new Set(roots)])) {
+    yield projectDocument(node, searchType);
   }
 }
 

--- a/packages/search/test/frame-by-type.test.ts
+++ b/packages/search/test/frame-by-type.test.ts
@@ -74,8 +74,8 @@ describe('frameByType', () => {
   it('keeps a root subject that references another root-typed subject', async () => {
     // A one-hop reference can itself be of the root type (e.g. a terminology
     // source that is also a separately registered dataset). The referencing
-    // subject must still be projected — and the referenced one must not be
-    // emitted twice — even though both match the frame’s `@type`.
+    // subject must still be projected – and the referenced one must not be
+    // emitted twice – even though both match the frame’s `@type`.
     const nodes = await collect(
       frameByType(
         quads(`
@@ -145,18 +145,38 @@ describe('buildSubjectIndex / frameSubjects', () => {
 
     // A single pass over the generator must still index both types.
     const index = buildSubjectIndex(once(), [DATASET, other]);
-    const datasets = await collect(frameSubjects(index, DATASET));
-    const others = await collect(frameSubjects(index, other));
+    const datasets = await collect(
+      frameSubjects(index, index.rootsByType.get(DATASET) ?? []),
+    );
+    const others = await collect(
+      frameSubjects(index, index.rootsByType.get(other) ?? []),
+    );
 
     expect(datasets.map((node) => node['@id'])).toEqual(['https://ex/d/1']);
     expect(others.map((node) => node['@id'])).toEqual(['https://ex/x/1']);
   });
 
-  it('frames nothing for a type the index was not built for', async () => {
+  it('frames each explicitly given root, ignoring rdf:type', async () => {
+    // No type triples at all: the roots are supplied directly, the way a
+    // pipeline selector supplies them.
+    const index = buildSubjectIndex(
+      quads(`
+        <https://ex/d/1> <${dcterms.title.value}> "Een"@nl .
+        <https://ex/d/2> <${dcterms.title.value}> "Twee"@nl .
+      `),
+      [],
+    );
+    const framed = await collect(frameSubjects(index, ['https://ex/d/1']));
+    expect(framed.map((node) => node['@id'])).toEqual(['https://ex/d/1']);
+  });
+
+  it('frames nothing for a root absent from the index', async () => {
     const index = buildSubjectIndex(
       quads(`<https://ex/d/1> <${rdf.type.value}> <${DATASET}> .`),
       [DATASET],
     );
-    expect(await collect(frameSubjects(index, 'urn:unregistered'))).toEqual([]);
+    expect(await collect(frameSubjects(index, ['urn:unregistered']))).toEqual(
+      [],
+    );
   });
 });

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -4,10 +4,12 @@ import { dcat, dcterms, rdf, xsd } from '@tpluscode/rdf-ns-builders';
 import {
   projectDocument,
   projectGraph,
+  projectRoots,
   irisOf,
   type SearchDocument,
 } from '../src/project.js';
 import {
+  defineSearchType,
   searchSchema,
   type SearchField,
   type SearchType,
@@ -590,5 +592,114 @@ describe('projectGraph', () => {
     expect(
       Object.fromEntries(tagged.map((entry) => [entry.id, entry.type])),
     ).toEqual({ 'https://ex/d/1': DATASET, 'https://ex/x/1': other });
+  });
+});
+
+describe('projectRoots', () => {
+  const dataset = defineSearchType({ name: 'Dataset', class: DATASET, fields });
+  const schema = searchSchema(dataset);
+
+  it('projects exactly the given roots, without any rdf:type', async () => {
+    // No type triples: the roots are supplied by the caller (the selector).
+    const quads = new Parser({ format: 'N-Triples' }).parse(`
+      <https://ex/d/1> <${dcterms.title.value}> "Titel"@nl .
+      <https://ex/d/2> <${dcterms.title.value}> "Andere"@nl .
+    `);
+
+    const documents: SearchDocument[] = [];
+    for await (const document of projectRoots(
+      quads,
+      ['https://ex/d/1', 'https://ex/d/2'],
+      schema,
+      dataset,
+    )) {
+      documents.push(document);
+    }
+
+    expect(documents.map((document) => document.id).sort()).toEqual([
+      'https://ex/d/1',
+      'https://ex/d/2',
+    ]);
+    const byId = Object.fromEntries(
+      documents.map((document) => [document.id, document]),
+    );
+    expect(byId['https://ex/d/1'].title_search_nl).toBe('titel');
+  });
+
+  it('frames a repeated root once (a non-DISTINCT selector may yield duplicates)', async () => {
+    const quads = new Parser({ format: 'N-Triples' }).parse(
+      `<https://ex/d/1> <${dcterms.title.value}> "Titel"@nl .`,
+    );
+
+    const documents: SearchDocument[] = [];
+    for await (const document of projectRoots(
+      quads,
+      ['https://ex/d/1', 'https://ex/d/1'],
+      schema,
+      dataset,
+    )) {
+      documents.push(document);
+    }
+
+    // One distinct root → one document, not one per occurrence.
+    expect(documents.map((document) => document.id)).toEqual([
+      'https://ex/d/1',
+    ]);
+  });
+
+  it('yields a bare document (no searchType tag)', async () => {
+    const quads = new Parser({ format: 'N-Triples' }).parse(
+      `<https://ex/d/1> <${dcterms.title.value}> "Titel"@nl .`,
+    );
+
+    const documents: SearchDocument[] = [];
+    for await (const document of projectRoots(
+      quads,
+      ['https://ex/d/1'],
+      schema,
+      dataset,
+    )) {
+      documents.push(document);
+    }
+
+    expect(documents).toHaveLength(1);
+    expect(documents[0]).not.toHaveProperty('searchType');
+    expect(documents[0]).not.toHaveProperty('document');
+    expect(documents[0].id).toBe('https://ex/d/1');
+  });
+
+  it('frames only the given roots, ignoring other subjects in the quads', async () => {
+    const quads = new Parser({ format: 'N-Triples' }).parse(`
+      <https://ex/d/1> <${dcterms.title.value}> "Een"@nl .
+      <https://ex/d/2> <${dcterms.title.value}> "Twee"@nl .
+    `);
+
+    const ids: string[] = [];
+    for await (const document of projectRoots(
+      quads,
+      ['https://ex/d/1'],
+      schema,
+      dataset,
+    )) {
+      ids.push(document.id);
+    }
+
+    expect(ids).toEqual(['https://ex/d/1']);
+  });
+
+  it('rejects a searchType not in the schema (no forged schema)', async () => {
+    const foreign: SearchType = {
+      name: 'Other',
+      class: 'http://example.org/Other',
+      fields,
+    };
+
+    // The membership guard runs before the first yield, so advancing the
+    // iterator once surfaces it.
+    await expect(
+      projectRoots([], ['https://ex/d/1'], schema, foreign)
+        [Symbol.asyncIterator]()
+        .next(),
+    ).rejects.toThrow(/not in this engine’s schema/);
   });
 });

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 97.29,
+          branches: 97.32,
           statements: 100,
         },
       },


### PR DESCRIPTION
The roots-given projection primitive for [ADR 13](https://github.com/ldelements/lde/blob/main/docs/decisions/0013-project-inside-the-batch-per-root-type.md). Additive: `projectGraph` is untouched and still the whole-schema entry point – it is retired later, together with its consumer (`@lde/search-pipeline`, #623), because deleting it there breaks `searchIndexWriter`.

## What it adds

- **`projectRoots(quads, roots, schema, searchType): AsyncIterable<SearchDocument>`** – project a single type over a caller-supplied set of root IRIs. The roots come from the pipeline selector, so `quads` need carry no `rdf:type` triples and the projection frames exactly those subjects. `assertTypeInSchema` guards membership – the port's own check – so **no schema is ever forged** to scope a projection to one type (the thing #579 rightly objected to). It yields a **bare `SearchDocument`**: tagging a document with its type is a routing concern the pipeline glue owns, not the projection.

## Internal refactor

- `frameSubjects(index, roots)` now takes explicit root IRIs instead of a root type. It is **not part of the package's public surface** (only `FramedNode` is exported from `frame-by-type.ts`), so this is invisible to consumers. `projectGraph` and `frameByType` pass `SubjectIndex.rootsByType`; `projectRoots` passes the roots it was given.

Non-breaking (`projectGraph` unchanged, the refactored functions are internal). Whole workspace type-checks; `@lde/search` tests green with new coverage for `projectRoots` and the explicit-roots framing.

Part of #606. Implements #622.
