### PR TITLE
fix!: support current QLever data-dump imports (flag rename + missing mkdir)

### DIFF
--- a/packages/distribution-downloader/src/download.ts
+++ b/packages/distribution-downloader/src/download.ts
@@ -1,9 +1,9 @@
 import { Distribution } from '@lde/dataset';
 import filenamifyUrl from 'filenamify-url';
-import { join, resolve, sep } from 'node:path';
+import { dirname, join, resolve, sep } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { createWriteStream } from 'node:fs';
-import { access, rm, stat } from 'node:fs/promises';
+import { access, mkdir, rm, stat } from 'node:fs/promises';
 export interface Logger {
   fatal(msg: string, ...args: unknown[]): void;
   error(msg: string, ...args: unknown[]): void;
@@ -74,6 +74,7 @@ export class LastModifiedDownloader implements Downloader {
     }
 
     try {
+      await mkdir(dirname(filePath), { recursive: true });
       await pipeline(downloadResponse.body, createWriteStream(filePath));
     } catch (error) {
       await rm(filePath, { force: true });

--- a/packages/distribution-downloader/test/download.test.ts
+++ b/packages/distribution-downloader/test/download.test.ts
@@ -40,6 +40,26 @@ describe('LastModifiedDownloader', () => {
       expect(fileContent).toBe('mock file');
     });
 
+    it('creates the target directory if it does not exist', async () => {
+      const missingDir = join(os.tmpdir(), 'lde-download-test', 'nested');
+      await fs.rm(join(os.tmpdir(), 'lde-download-test'), {
+        recursive: true,
+        force: true,
+      });
+      nock('https://example.com').get('/file.nt').reply(200, 'mock file');
+
+      const missingDirDownloader = new LastModifiedDownloader(missingDir);
+      const result = await missingDirDownloader.download(distribution);
+
+      const fileContent = await fs.readFile(result.path, 'utf8');
+      expect(fileContent).toBe('mock file');
+
+      await fs.rm(join(os.tmpdir(), 'lde-download-test'), {
+        recursive: true,
+        force: true,
+      });
+    });
+
     it('does not download file again if it is up to date', async () => {
       nock('https://example.com')
         .get('/file.nt')

--- a/packages/distribution-downloader/vite.config.ts
+++ b/packages/distribution-downloader/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 90.9,
+          lines: 91.17,
           functions: 100,
           branches: 100,
-          statements: 90.9,
+          statements: 91.17,
         },
       },
     },

--- a/packages/sparql-qlever/README.md
+++ b/packages/sparql-qlever/README.md
@@ -22,7 +22,7 @@ Passed to `qlever-server` at startup.
 | ----------------------- | ------------------------------------------------ | ------- |
 | `memory-max-size`       | Maximum memory for query processing and caching. | `'4G'`  |
 | `default-query-timeout` | Default query timeout.                           | `'30s'` |
-| `cache-max-size`        | Maximum cache size for query results.            | —       |
+| `cache-max-size`        | Maximum cache size for query results.            | –       |
 
 Example:
 
@@ -46,5 +46,5 @@ Passed to `qlever-index` during import.
 | `ascii-prefixes-only`           | Enable faster parsing for well-behaved TTL files.                                             | `true`      |
 | `num-triples-per-batch`         | Triples per batch; lower values reduce memory usage.                                          | `3_000_000` |
 | `stxxl-memory`                  | Memory budget for sorting during the index build.                                             | `'10G'`     |
-| `parse-parallel`                | Parse input in parallel.                                                                      | `true`      |
+| `parallel-parsing`              | Parse input in parallel.                                                                      | `true`      |
 | `only-pso-and-pos-permutations` | Build only PSO and POS permutations. Faster, but queries with predicate variables won't work. | `false`     |

--- a/packages/sparql-qlever/src/importer.ts
+++ b/packages/sparql-qlever/src/importer.ts
@@ -19,7 +19,7 @@ export interface QleverIndexOptions {
   /** Memory budget for sorting during the index build. @default '10G' */
   'stxxl-memory'?: string;
   /** @default true */
-  'parse-parallel'?: boolean;
+  'parallel-parsing'?: boolean;
   /** Build only PSO and POS permutations. Faster, but queries with predicate variables won't work. Also disables pattern precomputation. @default false */
   'only-pso-and-pos-permutations'?: boolean;
 }
@@ -178,7 +178,7 @@ export class Importer implements ImporterInterface {
       const raw = await readFile(this.cacheInfoPath(dataFile), 'utf-8');
       cacheInfo = JSON.parse(raw) as CacheInfo;
     } catch {
-      return false; // No cache marker — first run.
+      return false; // No cache marker – first run.
     }
 
     if (cacheInfo.sourceFile !== basename(dataFile)) {
@@ -234,12 +234,14 @@ export class Importer implements ImporterInterface {
     // TODO: write index to named volume instead of bind mount for better performance.
 
     const parallel =
-      parseParallel ?? this.options.qleverOptions['parse-parallel'];
+      parseParallel ?? this.options.qleverOptions['parallel-parsing'];
     const flags = [
       `-i ${this.options.indexName}`,
       `-s ${settingsFile}`,
       `-F ${format}`,
-      `--parse-parallel ${parallel}`,
+      // Short flag because the long flag is version-dependent: current QLever
+      // spells it --parallel-parsing, older versions --parse-parallel.
+      `-p ${parallel}`,
       `-m ${this.options.qleverOptions['stxxl-memory']}`,
       this.options.qleverOptions['only-pso-and-pos-permutations']
         ? '-o --no-patterns'
@@ -265,9 +267,9 @@ export class Importer implements ImporterInterface {
  * POSIX-quote a value for safe interpolation into a shell command: wrap it in
  * single quotes and escape any embedded single quote as `'\''`.
  *
- * Without this, a data filename containing an apostrophe — e.g. a dataset
+ * Without this, a data filename containing an apostrophe – e.g. a dataset
  * titled `'s-Hertogenbosch`, whose distribution URL maps to a local file like
- * `…Erfgoed+'s-Hertogenbosch.nt` — would terminate the surrounding quotes, so
+ * `…Erfgoed+'s-Hertogenbosch.nt` – would terminate the surrounding quotes, so
  * `cat`/`gunzip` would read a non-existent path and feed `qlever-index` empty
  * input. The index then "succeeds" with 0 triples, the import is treated as
  * failed, and every distribution (and the JSON-LD fallback) fails the same way.
@@ -279,7 +281,7 @@ function shellQuote(value: string): string {
 type fileFormat = 'nt' | 'nq' | 'ttl';
 
 /**
- * Native QLever index formats — `qlever-index -F <flag>` consumes these
+ * Native QLever index formats – `qlever-index -F <flag>` consumes these
  * directly. JSON-LD is not here: it is preprocessed to N-Quads first (see
  * {@link preprocess}).
  */
@@ -295,7 +297,7 @@ const nativeFormats = new Map<string, fileFormat>([
  * skip the Node-side preprocessor; TriG comes last so a streaming native dump
  * is always preferred when a dataset offers both.
  *
- * `application/zip` is intentionally absent — the inner RDF format must be
+ * `application/zip` is intentionally absent – the inner RDF format must be
  * declared via `mediaType` with `application/zip` appearing only as the
  * `compressFormat`, so we know what is inside.
  */
@@ -312,7 +314,7 @@ const defaultQleverIndexOptions = {
   'ascii-prefixes-only': true,
   'num-triples-per-batch': 3_000_000,
   'stxxl-memory': '10G',
-  'parse-parallel': true,
+  'parallel-parsing': true,
   'only-pso-and-pos-permutations': false,
 } satisfies Required<QleverIndexOptions>;
 

--- a/packages/sparql-qlever/test/importer.test.ts
+++ b/packages/sparql-qlever/test/importer.test.ts
@@ -233,7 +233,7 @@ describe('Importer', () => {
       );
     });
 
-    it('retries with --parse-parallel false on multiline string literal error', async () => {
+    it('retries with parallel parsing disabled on multiline string literal error', async () => {
       let callCount = 0;
       const runner: TaskRunner<string> & { commands: string[] } = {
         commands: [],
@@ -260,8 +260,8 @@ describe('Importer', () => {
 
       expect(result).toBeInstanceOf(ImportSuccessful);
       expect(runner.commands.length).toBe(2);
-      expect(runner.commands[0]).toContain('--parse-parallel true');
-      expect(runner.commands[1]).toContain('--parse-parallel false');
+      expect(runner.commands[0]).toContain('-p true');
+      expect(runner.commands[1]).toContain('-p false');
     });
 
     it('does not retry non-multiline-literal errors', async () => {
@@ -336,7 +336,7 @@ describe('Importer', () => {
       // A dataset titled e.g. "'s-Hertogenbosch" maps to a local filename with
       // an apostrophe. Naive single-quoting (`cat '<name>'`) lets the apostrophe
       // terminate the quote, so cat/gunzip read a non-existent path and feed
-      // qlever-index empty input — silently indexing 0 triples.
+      // qlever-index empty input – silently indexing 0 triples.
       const trickyFile = join(
         tempDir,
         "Dataset+Beeldbank+Erfgoed+'s-Hertogenbosch.ttl",
@@ -366,7 +366,7 @@ describe('Importer', () => {
       expect(command).not.toContain("Erfgoed+'s"); // the broken, unescaped form
 
       // And the decompress sub-command actually reads the real file when a shell
-      // runs it — this is what produced empty input (0 triples) before the fix.
+      // runs it – this is what produced empty input (0 triples) before the fix.
       const decompress = command.slice(0, command.indexOf('| qlever-index'));
       const output = execFileSync('sh', ['-c', decompress], {
         cwd: tempDir,


### PR DESCRIPTION
Fix #633

Two bugs stopped the `createQlever` → `ImportResolver` (strategy `import`) path from indexing a data-dump dataset against a current QLever image.

## `qlever-index` rejects `--parse-parallel` on current QLever

Current QLever renamed the long flag to `--parallel-parsing`, so `qlever-index` exited with `unrecognised option '--parse-parallel'` and the whole import failed. The importer now emits the short flag `-p`, which is accepted by both spellings’ QLever versions (verified against `adfreiburg/qlever:commit-a14e0a0`, the pinned test image, and `adfreiburg/qlever:latest`), so no version detection is needed.

**Breaking:** the `QleverIndexOptions` key `parse-parallel` is renamed to `parallel-parsing` to match current QLever.

## `LastModifiedDownloader` fails with ENOENT when its target directory is missing

The downloader opened a write stream under its base path (default `imports/`) without ensuring the directory exists, so the first download in a fresh working directory failed with `ENOENT` unless the consumer pre-created it. It now creates the target directory recursively before saving, covered by a new regression test.
