### PR TITLE
feat(search-api-graphql)!: serve the API with a framework-agnostic handler and playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ await pipeline.run();
 <tr>
   <td><a href="packages/search-api-graphql">@lde/search-api-graphql</a></td>
   <td><a href="https://www.npmjs.com/package/@lde/search-api-graphql"><img src="https://img.shields.io/npm/v/@lde/search-api-graphql" alt="npm"></a></td>
-  <td>Engine- and domain-agnostic GraphQL surface for search: builds an executable GraphQL schema from a SearchSchema at runtime, one root query field per type</td>
+  <td>Engine- and domain-agnostic GraphQL surface for search: builds an executable GraphQL schema from a SearchSchema at runtime and serves it as a framework-agnostic fetch handler with a self-contained playground</td>
 </tr>
 <tr>
   <td><a href="packages/search-pipeline">@lde/search-pipeline</a></td>
@@ -267,11 +267,11 @@ graph TD
 
 ## Who uses LD Elements
 
-<a href="https://netwerkdigitaalerfgoed.nl/en/"><img src="https://github.com/netwerk-digitaal-erfgoed.png?size=40" width="20" valign="middle"></a>&ensp;<a href="https://netwerkdigitaalerfgoed.nl/en/">Netwerk Digitaal Erfgoed</a> — Dutch national digital heritage infrastructure, commissioned by the Ministry of Education, Culture and Science
+<a href="https://netwerkdigitaalerfgoed.nl/en/"><img src="https://github.com/netwerk-digitaal-erfgoed.png?size=40" width="20" valign="middle"></a>&ensp;<a href="https://netwerkdigitaalerfgoed.nl/en/">Netwerk Digitaal Erfgoed</a> – Dutch national digital heritage infrastructure, commissioned by the Ministry of Education, Culture and Science
 
-<a href="https://dc4eu.nl"><img src="https://dc4eu.nl/wp-content/uploads/2022/01/logo.png" width="20" valign="middle"></a>&ensp;<a href="https://dc4eu.nl">DC4EU</a> — Dutch Collections for Europe, the accredited national aggregator connecting Dutch heritage institutions with Europeana
+<a href="https://dc4eu.nl"><img src="https://dc4eu.nl/wp-content/uploads/2022/01/logo.png" width="20" valign="middle"></a>&ensp;<a href="https://dc4eu.nl">DC4EU</a> – Dutch Collections for Europe, the accredited national aggregator connecting Dutch heritage institutions with Europeana
 
-<a href="https://hklimburg.nl/nieuws/linked-open-limburg">Linked Open Limburg</a> — Coöperatie Erfgoed Limburg’s regional heritage programme, built on LDE’s pipeline components
+<a href="https://hklimburg.nl/nieuws/linked-open-limburg">Linked Open Limburg</a> – Coöperatie Erfgoed Limburg’s regional heritage programme, built on LDE’s pipeline components
 
 ## Comparison
 

--- a/docs/decisions/0014-serve-the-search-graphql-api-with-graphql-yoga.md
+++ b/docs/decisions/0014-serve-the-search-graphql-api-with-graphql-yoga.md
@@ -1,0 +1,71 @@
+# 14. Serve the search GraphQL API with graphql-yoga
+
+Date: 2026-07-23
+
+## Status
+
+Accepted
+
+Extends [ADR 4 (Search API GraphQL surface)](./0004-search-api-graphql-surface.md),
+which deliberately stopped at `buildGraphQLSchema()` – an executable
+`GraphQLSchema`, no transport. Implements the served layer of
+[#600](https://github.com/ldelements/lde/issues/600).
+
+## Context
+
+Every consumer of `buildGraphQLSchema()` has to hand-roll the served endpoint:
+a request handler calling `graphql()`, `Accept-Language` parsing, error
+shaping – and gets no playground (`GET /graphql` is a blank page). The Dataset
+Register did exactly that in a bespoke `+server.ts`. A public, read-only search
+API also needs CORS for cross-origin browser clients and a guard against
+arbitrarily expensive queries, which no consumer should have to reinvent.
+
+The draft stack notes named Mercurius as the GraphQL server, but Mercurius is
+Fastify-coupled while LDE consumers serve from many hosts – the Dataset
+Register runs on SvelteKit (adapter-node), and future consumers may use Hono or
+plain `node:http`.
+
+## Decision
+
+Ship a **framework-agnostic Web-`fetch` handler** in `@lde/search-api-graphql`:
+
+```ts
+createSearchGraphQLHandler({ searchSchema | schema, engine, … })
+  → (request: Request) => Promise<Response>
+```
+
+built on **graphql-yoga** rather than Mercurius or hand-rolled plumbing – a
+deliberate deviation from the draft stack. Yoga is `fetch`-native (every host
+that speaks `Request`/`Response` mounts the handler in a few lines), serves any
+executable schema, and brings introspection, error shaping and a plugin system.
+
+- **Playground**: the self-contained GraphiQL that Yoga bundles
+  (`@graphql-yoga/render-graphiql`) – no external CDN, so it is acceptable for
+  a public service and `<iframe>`-embeddable in docs sites. The renderer is
+  swappable (`renderPlayground`) and disable-able per environment
+  (`playground: false`). Apollo Sandbox was rejected: its embed loads from
+  Apollo’s CDN and ships schema and queries to Apollo.
+- **Limits**: graphql-armor’s max-depth and cost-limit validation plugins guard
+  the public endpoint; introspection is exempt so the playground keeps working.
+- **Composability**: the handler takes either a `searchSchema` (it builds the
+  GraphQL schema itself) or a ready `GraphQLSchema` – a consumer merges custom
+  fields into `buildGraphQLSchema()`’s output and serves the union through the
+  same endpoint and playground.
+- **SDL**: `GET <endpoint>?sdl` returns `printSchema()` output, so consumers
+  can publish the contract and generate static docs in CI without a running
+  introspection query.
+- **`Accept-Language`**: parsed (via `negotiator`, q-values respected) into the
+  ordered list that `SearchContext.acceptLanguage` already expects.
+
+## Consequences
+
+- `@lde/search-api-graphql` now requires `graphql` ^16 (was ^15.8): the
+  graphql-armor plugins do not accept 15, and a mixed tree fails at runtime
+  with graphql-js’s realm check. Yoga supports 15 and 16, so 16 is the version
+  both agree on. Breaking for consumers still pinned to graphql 15.
+- The handler is the substrate for the prebuilt Docker image (#600 layer 3):
+  the image is a boot entrypoint around this handler, not a separate codebase.
+- The Dataset Register can retire its bespoke `+server.ts` and mount the
+  handler (downstream follow-up).
+- graphql-js prints SDL without a trailing newline from 16 on; the generator
+  stability snapshot moved accordingly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@swc/core": "1.15.8",
         "@swc/helpers": "0.5.23",
         "@testcontainers/postgresql": "^12.0.4",
+        "@types/negotiator": "^0.6.4",
         "@types/node": "^26.1.1",
         "@vitest/coverage-v8": "4.1.0",
         "@vitest/ui": "4.1.0",
@@ -19453,6 +19454,89 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@envelop/core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@envelop/core/-/core-5.5.1.tgz",
+      "integrity": "sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@envelop/instrumentation": "^1.0.0",
+        "@envelop/types": "^5.2.1",
+        "@whatwg-node/promise-helpers": "^1.2.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@envelop/instrumentation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
+      "integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@envelop/types": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@envelop/types/-/types-5.2.1.tgz",
+      "integrity": "sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-cost-limit": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-cost-limit/-/graphql-armor-cost-limit-2.4.3.tgz",
+      "integrity": "sha512-fLZTlJjrjinpNhbv5VP6f8Ce4MiQzbcHtCNaCPVaHqArTEbN7vDnlVLiH+VcmZBmOwU6Si97lKdlOXWNgB5ytw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphql": "^16.10.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^5.2.3",
+        "@escape.tech/graphql-armor-types": "0.7.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-max-depth": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-max-depth/-/graphql-armor-max-depth-2.4.2.tgz",
+      "integrity": "sha512-J9fbW1+W4u3GAcf19wwS0zrNGICCbWn/glvopCoC11Ga0reXvGwgr8EcyuHjTFLL7+pPvWAeVhP4qo6hybcB9w==",
+      "license": "MIT",
+      "dependencies": {
+        "graphql": "^16.10.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@envelop/core": "^5.2.3",
+        "@escape.tech/graphql-armor-types": "0.7.0"
+      }
+    },
+    "node_modules/@escape.tech/graphql-armor-types": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@escape.tech/graphql-armor-types/-/graphql-armor-types-0.7.0.tgz",
+      "integrity": "sha512-RHxyyp6PDgS6NAPnnmB6JdmUJ6oqhpSHFbsglGWeCcnNzceA5AkQFpir7VIDbVyS8LNC1xhipOtk7f9ycrIemQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graphql": "^16.0.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "dev": true,
@@ -19675,6 +19759,12 @@
         "fast-uri": "^3.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
       "dev": true,
@@ -19766,6 +19856,192 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@graphql-tools/executor": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.5.7.tgz",
+      "integrity": "sha512-UcXVClkBml+qyGEsQxfEaAkboqySVGFUd9ivn7pDc9jZSckgF6zL21cNxuRH5ZA2exneV3PTtcc0I0rDOdE0Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.2.2",
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "@repeaterjs/repeater": "^3.1.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+      "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.2.2.tgz",
+      "integrity": "sha512-DSLLAztOIQId7QE3m8Ehk5lV+0pjxNSSRDHPzlYQ9E4KJ9AoUMBprC4C+eX3v4srh05S2ujm5/veqAr5yEWFSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.2.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+      "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema": {
+      "version": "10.0.38",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.38.tgz",
+      "integrity": "sha512-Kckk2/vm+rELJ7ijvFaAn9ouWSVUTD0D4SJIvYF4rKeuQHAfCzE/jzMFonZVpTXleqJjPXLZjVbuaMorw7A5Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/merge": "^9.2.2",
+        "@graphql-tools/utils": "^11.2.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.2.tgz",
+      "integrity": "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+      "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-yoga/logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-Nv0BoDGLMg9QBKy9cIswQ3/6aKaKjlTh87x3GiBg2Z4RrjyrM48DvOOK0pJh1C1At+b0mUIM67cwZcFTDLN4sA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@graphql-yoga/render-graphiql": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/render-graphiql/-/render-graphiql-5.21.2.tgz",
+      "integrity": "sha512-m0Tw1lY1sOVxmnHK0epZF6tvmG3AqRRxoiCVwWTXqQIo5O2Za2dM8FJ5MqcGekEtN2hKU16OTHYS2OlNG1B2Aw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "graphql-yoga": "^5.21.2"
+      }
+    },
+    "node_modules/@graphql-yoga/subscription": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-5.0.5.tgz",
+      "integrity": "sha512-oCMWOqFs6QV96/NZRt/ZhTQvzjkGB4YohBOpKM4jH/lDT4qb7Lex/aGCxpi/JD9njw3zBBtMqxbaC22+tFHVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-yoga/typed-event-target": "^3.0.2",
+        "@repeaterjs/repeater": "^3.0.4",
+        "@whatwg-node/events": "^0.1.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@graphql-yoga/typed-event-target": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/typed-event-target/-/typed-event-target-3.0.2.tgz",
+      "integrity": "sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==",
+      "license": "MIT",
+      "dependencies": {
+        "@repeaterjs/repeater": "^3.0.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -21517,6 +21793,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@repeaterjs/repeater": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.1.0.tgz",
+      "integrity": "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.16",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
@@ -22582,6 +22864,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@types/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-elf6BsTq+AkyNsb2h5cGNst2Mc7dPliVoAPm1fXglC/BM3f2pFA40BaSSv3E5lyHteEawVKLP+8TwiY1DMNb3A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
@@ -23630,6 +23919,87 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@whatwg-node/disposablestack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
+      "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/events": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.2.tgz",
+      "integrity": "sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.13.tgz",
+      "integrity": "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.8.3",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.8.6.tgz",
+      "integrity": "sha512-BDMdYFcerLQkwA2RTldxOqRCs6ZQD1S7UgP3pUdGUkcbgTrP/V5ko77ZkCww9DHmC4lpoYuwigGfQYj285gMvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.1.1",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/server": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.11.0.tgz",
+      "integrity": "sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@envelop/instrumentation": "^1.0.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/fetch": "^0.10.13",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -25396,6 +25766,18 @@
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-inspect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -27621,12 +28003,12 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.2.tgz",
-      "integrity": "sha512-1PRqdDPAmViWr4h1GVBT8RoPZfWSGZa7kDzleTilOfVIslsgf+cia3Nl95v1KDmR4iERPaT7WzQ+tN4MJmbg3w==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 10.x"
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-to-sparql": {
@@ -27712,6 +28094,32 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/graphql-yoga": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/graphql-yoga/-/graphql-yoga-5.21.2.tgz",
+      "integrity": "sha512-IIRF/3xtjj2D6caAWL9177hQ8tV3mWB3hve1GRnz7njPhQ3iY1jFtSp98fNGv0yV9kaPh9kKQ8JWdJZnedVmDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@envelop/core": "^5.5.1",
+        "@envelop/instrumentation": "^1.0.0",
+        "@graphql-tools/executor": "^1.5.0",
+        "@graphql-tools/schema": "^10.0.11",
+        "@graphql-tools/utils": "^10.11.0",
+        "@graphql-yoga/logger": "^2.0.1",
+        "@graphql-yoga/subscription": "^5.0.5",
+        "@whatwg-node/fetch": "^0.10.6",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "@whatwg-node/server": "^0.11.0",
+        "lru-cache": "^10.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.2.0 || ^16.0.0"
+      }
     },
     "node_modules/grapoi": {
       "version": "1.1.4",
@@ -30179,7 +30587,6 @@
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -34600,6 +35007,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "license": "MIT"
+    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
@@ -35396,7 +35809,7 @@
     },
     "packages/distribution-downloader": {
       "name": "@lde/distribution-downloader",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "^0.7.8",
@@ -35406,11 +35819,11 @@
     },
     "packages/distribution-health": {
       "name": "@lde/distribution-health",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "@lde/distribution-probe": "^0.2.6",
-        "@lde/sparql-importer": "^0.6.6",
+        "@lde/sparql-importer": "^0.6.7",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -37546,14 +37959,14 @@
     },
     "packages/pipeline": {
       "name": "@lde/pipeline",
-      "version": "0.34.1",
+      "version": "0.34.3",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "^0.7.8",
         "@lde/dataset-registry-client": "^0.8.6",
-        "@lde/distribution-health": "^0.2.6",
+        "@lde/distribution-health": "^0.2.7",
         "@lde/distribution-probe": "^0.2.6",
-        "@lde/sparql-importer": "^0.6.6",
+        "@lde/sparql-importer": "^0.6.7",
         "@lde/sparql-server": "^0.4.12",
         "@rdfjs/namespace": "^2.0.1",
         "@rdfjs/types": "^2.0.1",
@@ -37572,7 +37985,7 @@
     },
     "packages/pipeline-console-reporter": {
       "name": "@lde/pipeline-console-reporter",
-      "version": "0.25.1",
+      "version": "0.25.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -37583,7 +37996,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.1"
+        "@lde/pipeline": "^0.34.3"
       }
     },
     "packages/pipeline-console-reporter/node_modules/ansi-regex": {
@@ -37763,7 +38176,7 @@
     },
     "packages/pipeline-shacl-sampler": {
       "name": "@lde/pipeline-shacl-sampler",
-      "version": "0.8.1",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -37774,7 +38187,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.1"
+        "@lde/pipeline": "^0.34.3"
       }
     },
     "packages/pipeline-shacl-sampler/node_modules/n3": {
@@ -37792,7 +38205,7 @@
     },
     "packages/pipeline-shacl-validator": {
       "name": "@lde/pipeline-shacl-validator",
-      "version": "0.17.1",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -37806,7 +38219,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.1"
+        "@lde/pipeline": "^0.34.3"
       }
     },
     "packages/pipeline-shacl-validator/node_modules/n3": {
@@ -37825,7 +38238,7 @@
     },
     "packages/pipeline-void": {
       "name": "@lde/pipeline-void",
-      "version": "0.32.1",
+      "version": "0.32.3",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -37836,7 +38249,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.1"
+        "@lde/pipeline": "^0.34.3"
       }
     },
     "packages/pipeline-void/node_modules/n3": {
@@ -37867,7 +38280,7 @@
     },
     "packages/search": {
       "name": "@lde/search",
-      "version": "0.8.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@lde/text-normalization": "^0.1.1",
@@ -37892,25 +38305,33 @@
     },
     "packages/search-api-graphql": {
       "name": "@lde/search-api-graphql",
-      "version": "0.7.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.8.0",
+        "@escape.tech/graphql-armor-cost-limit": "^2.4.3",
+        "@escape.tech/graphql-armor-max-depth": "^2.4.2",
+        "@graphql-yoga/render-graphiql": "^5.21.2",
+        "@lde/search": "^0.12.0",
         "dataloader": "^2.2.3",
-        "graphql": "^15.8.0",
+        "graphql": "^16.0.0",
+        "graphql-yoga": "^5.21.2",
+        "negotiator": "^0.6.4",
         "tslib": "^2.3.0"
       }
     },
     "packages/search-pipeline": {
       "name": "@lde/search-pipeline",
-      "version": "0.7.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.8.0",
+        "@lde/search": "^0.12.0",
+        "@traqula/generator-sparql-1-1": "^1.1.8",
+        "@traqula/parser-sparql-1-1": "^1.1.5",
+        "@traqula/rules-sparql-1-1": "^1.1.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@lde/search-typesense": "^0.10.0",
+        "@lde/search-typesense": "^0.14.1",
         "@rdfjs/types": "^2.0.1",
         "n3": "^2.1.1",
         "testcontainers": "^12.0.3",
@@ -37918,7 +38339,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.1"
+        "@lde/pipeline": "^0.34.3"
       }
     },
     "packages/search-pipeline/node_modules/n3": {
@@ -37937,10 +38358,10 @@
     },
     "packages/search-typesense": {
       "name": "@lde/search-typesense",
-      "version": "0.10.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
-        "@lde/search": "^0.8.0",
+        "@lde/search": "^0.12.0",
         "@lde/text-normalization": "^0.1.1",
         "tslib": "^2.3.0",
         "typesense": "^3.0.6"
@@ -37950,7 +38371,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.1"
+        "@lde/pipeline": "^0.34.3"
       }
     },
     "packages/search/node_modules/n3": {
@@ -37969,23 +38390,23 @@
     },
     "packages/sparql-importer": {
       "name": "@lde/sparql-importer",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/distribution-downloader": "^0.6.5",
-        "@lde/task-runner": "^0.2.11",
+        "@lde/distribution-downloader": "^0.6.7",
+        "@lde/task-runner": "^0.2.12",
         "tslib": "^2.3.0"
       }
     },
     "packages/sparql-qlever": {
       "name": "@lde/sparql-qlever",
-      "version": "0.14.12",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/distribution-downloader": "^0.6.6",
-        "@lde/sparql-importer": "^0.6.6",
+        "@lde/distribution-downloader": "^0.6.7",
+        "@lde/sparql-importer": "^0.6.7",
         "@lde/sparql-server": "^0.4.12",
         "@lde/task-runner": "^0.2.12",
         "@lde/task-runner-docker": "^0.2.14",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "*.ts": "eslint --fix",
     "*.{ts,json,md}": "prettier --write"
   },
-  "dependencies": {},
   "devDependencies": {
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
@@ -33,6 +32,7 @@
     "@swc/core": "1.15.8",
     "@swc/helpers": "0.5.23",
     "@testcontainers/postgresql": "^12.0.4",
+    "@types/negotiator": "^0.6.4",
     "@types/node": "^26.1.1",
     "@vitest/coverage-v8": "4.1.0",
     "@vitest/ui": "4.1.0",

--- a/packages/search-api-graphql/README.md
+++ b/packages/search-api-graphql/README.md
@@ -59,6 +59,60 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON), {
 Shared types (`LanguageString`, the facet buckets, filter inputs and reference
 types such as a common `Agent`) are created once and reused across root types.
 
+## Serving the API
+
+`createSearchGraphQLHandler` turns the schema into a **served API**: one
+framework-agnostic `(request: Request) => Promise<Response>` handler (built on
+[graphql-yoga](https://the-guild.dev/graphql/yoga-server), see
+[ADR 14](../../docs/decisions/0014-serve-the-search-graphql-api-with-graphql-yoga.md))
+covering POST execution, introspection, error shaping and per-request
+`Accept-Language` parsing:
+
+```ts
+import { createSearchGraphQLHandler } from '@lde/search-api-graphql';
+
+const handler = createSearchGraphQLHandler({
+  searchSchema: searchSchema(DATASET, PERSON),
+  engine, // e.g. createTypesenseSearchEngine(…)
+});
+
+// SvelteKit (src/routes/graphql/+server.ts):
+export const GET = ({ request }) => handler(request);
+export const POST = GET;
+
+// Plain node:http:
+import { createServerAdapter } from '@whatwg-node/server';
+createServer(createServerAdapter(handler)).listen(4000);
+```
+
+Every host that speaks `Request`/`Response` (SvelteKit, Hono, Fastify via a
+bridge, plain Node) mounts it the same way. Batteries included:
+
+- **Playground**: `GET /graphql` serves the bundled GraphiQL –
+  self-contained (no external CDN) and sent without framing headers, so a docs
+  site can `<iframe>` the deployed playground as a live client. Disable it per
+  environment (`playground: false`) or swap the renderer (`renderPlayground`).
+- **SDL**: `GET /graphql?sdl` returns the schema contract as SDL – publish it
+  or generate static docs in CI without a running introspection query.
+- **CORS** for cross-origin browser clients (configurable via `cors`).
+- **Depth and cost limits** ([graphql-armor](https://escape.tech/graphql-armor/);
+  `maxDepth`, default 15, and `maxCost`, default 5000) guard the public
+  endpoint against arbitrarily expensive queries; introspection stays exempt.
+
+To serve **custom fields next to the generated search API**, merge your own
+schema with `buildGraphQLSchema()`’s output (e.g. `@graphql-tools/schema`’s
+`mergeSchemas`) and pass the union as `schema` instead of `searchSchema`; the
+same endpoint and playground serve both:
+
+```ts
+const handler = createSearchGraphQLHandler({
+  schema: mergeSchemas({
+    schemas: [buildGraphQLSchema(searchSchema(DATASET)), myCustomSchema],
+  }),
+  engine,
+});
+```
+
 ## Serving a subset of the schema
 
 `types` never filters: every `SearchType` in the schema you pass gets a root

--- a/packages/search-api-graphql/package.json
+++ b/packages/search-api-graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lde/search-api-graphql",
   "version": "0.11.0",
-  "description": "Engine- and domain-agnostic GraphQL surface for @lde/search: builds an executable GraphQLSchema from a whole SearchSchema at runtime (no codegen) — one root query field per SearchType — served by generic resolvers over any SearchEngine. You supply the schema and per-type typeNames; it names neither your domain nor your engine.",
+  "description": "Engine- and domain-agnostic GraphQL surface for @lde/search: builds an executable GraphQLSchema from a whole SearchSchema at runtime (no codegen) – one root query field per SearchType – served by generic resolvers over any SearchEngine – and serves it as a framework-agnostic fetch handler with a self-contained playground, SDL endpoint, CORS and depth/cost limits. You supply the schema and per-type typeNames; it names neither your domain nor your engine.",
   "repository": {
     "url": "git+https://github.com/ldelements/lde.git",
     "directory": "packages/search-api-graphql"
@@ -25,9 +25,14 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
+    "@escape.tech/graphql-armor-cost-limit": "^2.4.3",
+    "@escape.tech/graphql-armor-max-depth": "^2.4.2",
+    "@graphql-yoga/render-graphiql": "^5.21.2",
     "@lde/search": "^0.12.0",
     "dataloader": "^2.2.3",
-    "graphql": "^15.8.0",
+    "graphql": "^16.0.0",
+    "graphql-yoga": "^5.21.2",
+    "negotiator": "^0.6.4",
     "tslib": "^2.3.0"
   }
 }

--- a/packages/search-api-graphql/src/handler.ts
+++ b/packages/search-api-graphql/src/handler.ts
@@ -1,0 +1,145 @@
+import { printSchema, type GraphQLSchema } from 'graphql';
+import {
+  createYoga,
+  type CORSOptions,
+  type GraphiQLOptions,
+} from 'graphql-yoga';
+import { renderGraphiQL } from '@graphql-yoga/render-graphiql';
+import { maxDepthPlugin } from '@escape.tech/graphql-armor-max-depth';
+import { costLimitPlugin } from '@escape.tech/graphql-armor-cost-limit';
+import Negotiator from 'negotiator';
+import type { SearchEngine, SearchSchema } from '@lde/search';
+import {
+  buildGraphQLSchema,
+  type BuildGraphQLSchemaOptions,
+  type SearchContext,
+} from './build-schema.js';
+
+/**
+ * A framework-agnostic request handler: SvelteKit, Fastify (via a
+ * `Request`/`Response` bridge), Hono and plain `node:http` (via
+ * `@whatwg-node/server`, which graphql-yoga uses internally) all mount it
+ * directly.
+ */
+export type SearchGraphQLHandler = (request: Request) => Promise<Response>;
+
+/**
+ * Renders the playground page served on `GET` requests to the endpoint.
+ * The default is the self-contained GraphiQL bundled with graphql-yoga
+ * (no external CDN); supply your own to swap the renderer (e.g. Altair).
+ */
+export type PlaygroundRenderer = (
+  options?: GraphiQLOptions,
+) => BodyInit | Promise<BodyInit>;
+
+export interface SearchGraphQLHandlerOptions {
+  /**
+   * The search schema to serve; the handler builds the GraphQL schema from it
+   * with {@link buildGraphQLSchema}. Provide either this or {@link schema}.
+   */
+  readonly searchSchema?: SearchSchema;
+  /**
+   * A ready {@link GraphQLSchema} to serve instead – bring your own fields by
+   * merging a custom schema with {@link buildGraphQLSchema}’s output (e.g.
+   * `@graphql-tools/schema` `mergeSchemas`) and passing the union here.
+   * Provide either this or {@link searchSchema}.
+   */
+  readonly schema?: GraphQLSchema;
+  /** The engine every request’s resolvers search with. */
+  readonly engine: SearchEngine;
+  /** Options for {@link buildGraphQLSchema} when {@link searchSchema} is given. */
+  readonly schemaOptions?: BuildGraphQLSchemaOptions;
+  /** Endpoint path the handler serves. @default '/graphql' */
+  readonly graphqlEndpoint?: string;
+  /**
+   * Serve the playground on `GET` requests to the endpoint. The page is
+   * self-contained (no external CDN) and sends no framing headers, so a docs
+   * site can `<iframe>` it as a live client. Disable per environment.
+   * @default true
+   */
+  readonly playground?: boolean;
+  /** Custom playground renderer; defaults to the bundled GraphiQL. */
+  readonly renderPlayground?: PlaygroundRenderer;
+  /**
+   * CORS headers for cross-origin browser clients. Defaults to graphql-yoga’s
+   * permissive default (reflects the request origin); pass `false` to send no
+   * CORS headers.
+   */
+  readonly cors?: CORSOptions | boolean;
+  /**
+   * Reject queries nested deeper than this – a public playground invites
+   * arbitrary queries. Introspection is exempt. @default 15
+   */
+  readonly maxDepth?: number;
+  /**
+   * Reject queries costlier than this (graphql-armor cost limit; introspection
+   * is exempt). @default 5000
+   */
+  readonly maxCost?: number;
+  /** Forwarded to {@link SearchContext.onFacetError} on every request. */
+  readonly onFacetError?: SearchContext['onFacetError'];
+}
+
+/**
+ * The served search API: one `fetch` handler covering POST execution, the GET
+ * playground, introspection, CORS, depth/cost limits, `Accept-Language`
+ * parsing, and the SDL (`GET <endpoint>?sdl` – the schema contract without a
+ * running introspection query).
+ */
+export function createSearchGraphQLHandler(
+  options: SearchGraphQLHandlerOptions,
+): SearchGraphQLHandler {
+  if ((options.searchSchema === undefined) === (options.schema === undefined)) {
+    throw new Error('Provide exactly one of searchSchema or schema.');
+  }
+  const schema =
+    options.schema ??
+    buildGraphQLSchema(options.searchSchema!, options.schemaOptions);
+  const graphqlEndpoint = options.graphqlEndpoint ?? '/graphql';
+
+  const yoga = createYoga({
+    schema,
+    graphqlEndpoint,
+    landingPage: false,
+    graphiql: options.playground !== false,
+    renderGraphiQL: options.renderPlayground ?? renderGraphiQL,
+    cors: options.cors,
+    plugins: [
+      maxDepthPlugin({ n: options.maxDepth ?? 15 }),
+      costLimitPlugin({ maxCost: options.maxCost ?? 5000 }),
+    ],
+    context: ({ request }): SearchContext => ({
+      engine: options.engine,
+      acceptLanguage: parseAcceptLanguage(
+        request.headers.get('accept-language'),
+      ),
+      onFacetError: options.onFacetError,
+    }),
+  });
+  const sdl = printSchema(schema);
+
+  return async (request: Request): Promise<Response> => {
+    const url = new URL(request.url);
+    if (
+      request.method === 'GET' &&
+      url.pathname === graphqlEndpoint &&
+      url.searchParams.has('sdl')
+    ) {
+      return new Response(sdl, {
+        headers: { 'content-type': 'application/graphql; charset=utf-8' },
+      });
+    }
+    return await yoga.fetch(request, {});
+  };
+}
+
+/** Ordered languages from an `Accept-Language` header (best first, by q-value). */
+function parseAcceptLanguage(header: string | null): readonly string[] {
+  if (header === null) {
+    return [];
+  }
+  const negotiator = new Negotiator({
+    headers: { 'accept-language': header },
+  });
+  return negotiator.languages().filter((language) => language !== '*');
+}

--- a/packages/search-api-graphql/src/index.ts
+++ b/packages/search-api-graphql/src/index.ts
@@ -1,4 +1,10 @@
 export { buildGraphQLSchema, printGraphQLSchema } from './build-schema.js';
+export { createSearchGraphQLHandler } from './handler.js';
+export type {
+  SearchGraphQLHandler,
+  SearchGraphQLHandlerOptions,
+  PlaygroundRenderer,
+} from './handler.js';
 export type {
   SearchContext,
   BuildGraphQLSchemaOptions,

--- a/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
+++ b/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
@@ -96,6 +96,5 @@ enum ThingSortField {
 enum SortDirection {
   ASC
   DESC
-}
-"
+}"
 `;

--- a/packages/search-api-graphql/test/handler.test.ts
+++ b/packages/search-api-graphql/test/handler.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest';
+import { extendSchema, getIntrospectionQuery, parse } from 'graphql';
+import {
+  searchSchema,
+  type FacetsOutcome,
+  type SearchEngine,
+  type SearchQuery,
+  type SearchResult,
+  type SearchType,
+} from '@lde/search';
+import { buildGraphQLSchema } from '../src/build-schema.js';
+import { createSearchGraphQLHandler } from '../src/handler.js';
+
+const schema: SearchType = {
+  name: 'Dataset',
+  class: 'http://www.w3.org/ns/dcat#Dataset',
+  fields: [
+    {
+      name: 'title',
+      kind: 'text',
+      locales: ['nl', 'en'],
+      output: true,
+      searchable: { weight: 5 },
+    },
+    {
+      name: 'keyword',
+      kind: 'keyword',
+      array: true,
+      facetable: true,
+      filterable: true,
+      output: true,
+    },
+  ],
+};
+
+const canned: SearchResult = {
+  total: 1,
+  hits: [
+    {
+      id: 'https://d/1',
+      document: {
+        title: { nl: ['Titel'], en: ['Title'] },
+        keyword: ['kaarten'],
+      },
+    },
+  ],
+  facets: {},
+};
+
+function fakeEngine(): { engine: SearchEngine; received: () => SearchQuery } {
+  let captured: SearchQuery;
+  return {
+    engine: {
+      schema: searchSchema(schema),
+      async search(_searchType, query) {
+        captured = query;
+        return canned;
+      },
+      async searchFacets(_searchType, queries) {
+        return queries.map((): FacetsOutcome => ({ facets: {} }));
+      },
+    },
+    received: () => captured,
+  };
+}
+
+function post(
+  handler: (request: Request) => Promise<Response>,
+  query: string,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return handler(
+    new Request('http://localhost/graphql', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        ...headers,
+      },
+      body: JSON.stringify({ query }),
+    }),
+  );
+}
+
+describe('createSearchGraphQLHandler', () => {
+  it('executes a POST query against the engine', async () => {
+    const { engine, received } = fakeEngine();
+    const handler = createSearchGraphQLHandler({
+      searchSchema: searchSchema(schema),
+      engine,
+    });
+
+    const response = await post(
+      handler,
+      '{ datasets(query: "kaart") { total items { id keyword } } }',
+    );
+    expect(response.status).toBe(200);
+    const { data, errors } = await response.json();
+
+    expect(errors).toBeUndefined();
+    expect(data.datasets.total).toBe(1);
+    expect(data.datasets.items[0].id).toBe('https://d/1');
+    expect(received().text).toBe('kaart');
+  });
+
+  it('orders output languages by the Accept-Language header', async () => {
+    const { engine, received } = fakeEngine();
+    const handler = createSearchGraphQLHandler({
+      searchSchema: searchSchema(schema),
+      engine,
+    });
+
+    const response = await post(
+      handler,
+      '{ datasets { items { title { language value } } } }',
+      { 'accept-language': 'en;q=0.8, nl' },
+    );
+    const { data } = await response.json();
+
+    expect(data.datasets.items[0].title).toEqual([
+      { language: 'nl', value: 'Titel' },
+      { language: 'en', value: 'Title' },
+    ]);
+    expect(received().locale).toBe('nl');
+  });
+
+  it('serves a self-contained playground on GET', async () => {
+    const { engine } = fakeEngine();
+    const handler = createSearchGraphQLHandler({
+      searchSchema: searchSchema(schema),
+      engine,
+    });
+
+    const response = await handler(
+      new Request('http://localhost/graphql', {
+        headers: { accept: 'text/html' },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    const html = await response.text();
+    expect(html).toContain('GraphiQL');
+    // Self-contained: no assets loaded from an external CDN.
+    expect(html).not.toContain('unpkg.com');
+    expect(html).not.toContain('cdn.jsdelivr.net');
+    // Embeddable: no anti-framing headers.
+    expect(response.headers.get('x-frame-options')).toBeNull();
+  });
+
+  it('disables the playground when playground is false', async () => {
+    const { engine } = fakeEngine();
+    const handler = createSearchGraphQLHandler({
+      searchSchema: searchSchema(schema),
+      engine,
+      playground: false,
+    });
+
+    const response = await handler(
+      new Request('http://localhost/graphql', {
+        headers: { accept: 'text/html' },
+      }),
+    );
+
+    expect(response.headers.get('content-type') ?? '').not.toContain(
+      'text/html',
+    );
+  });
+
+  it('serves the SDL on GET ?sdl without introspection', async () => {
+    const { engine } = fakeEngine();
+    const handler = createSearchGraphQLHandler({
+      searchSchema: searchSchema(schema),
+      engine,
+    });
+
+    const response = await handler(new Request('http://localhost/graphql?sdl'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain(
+      'application/graphql',
+    );
+    const sdl = await response.text();
+    expect(sdl).toContain('type Query');
+    expect(sdl).toContain('datasets(');
+  });
+
+  it('sends CORS headers for cross-origin browser clients', async () => {
+    const { engine } = fakeEngine();
+    const handler = createSearchGraphQLHandler({
+      searchSchema: searchSchema(schema),
+      engine,
+    });
+
+    const preflight = await handler(
+      new Request('http://localhost/graphql', {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'https://docs.example.org',
+          'access-control-request-method': 'POST',
+        },
+      }),
+    );
+
+    expect(preflight.headers.get('access-control-allow-origin')).not.toBeNull();
+  });
+
+  it('rejects a query deeper than maxDepth', async () => {
+    const { engine } = fakeEngine();
+    const handler = createSearchGraphQLHandler({
+      searchSchema: searchSchema(schema),
+      engine,
+      maxDepth: 1,
+    });
+
+    const response = await post(handler, '{ datasets { total } }');
+    const { data, errors } = await response.json();
+
+    expect(data).toBeUndefined();
+    expect(JSON.stringify(errors)).toContain('depth');
+  });
+
+  it('rejects a query costlier than maxCost', async () => {
+    const { engine } = fakeEngine();
+    const handler = createSearchGraphQLHandler({
+      searchSchema: searchSchema(schema),
+      engine,
+      maxCost: 1,
+    });
+
+    const response = await post(
+      handler,
+      '{ datasets { total items { id keyword } } }',
+    );
+    const { data, errors } = await response.json();
+
+    expect(data).toBeUndefined();
+    expect(JSON.stringify(errors)).toContain('Cost');
+  });
+
+  it('answers introspection within the default limits', async () => {
+    const { engine } = fakeEngine();
+    const handler = createSearchGraphQLHandler({
+      searchSchema: searchSchema(schema),
+      engine,
+    });
+
+    const response = await post(handler, getIntrospectionQuery());
+    const { data, errors } = await response.json();
+
+    expect(errors).toBeUndefined();
+    expect(data.__schema.queryType.name).toBe('Query');
+  });
+
+  it('serves a supplied schema with custom fields merged in', async () => {
+    const { engine } = fakeEngine();
+    const merged = extendSchema(
+      buildGraphQLSchema(searchSchema(schema)),
+      parse('extend type Query { hello: String }'),
+    );
+    merged.getQueryType()!.getFields().hello.resolve = () => 'world';
+    const handler = createSearchGraphQLHandler({ schema: merged, engine });
+
+    const response = await post(handler, '{ hello datasets { total } }');
+    const { data, errors } = await response.json();
+
+    expect(errors).toBeUndefined();
+    expect(data.hello).toBe('world');
+    expect(data.datasets.total).toBe(1);
+  });
+
+  it('requires exactly one of searchSchema and schema', () => {
+    const { engine } = fakeEngine();
+
+    expect(() => createSearchGraphQLHandler({ engine })).toThrow(/exactly one/);
+    expect(() =>
+      createSearchGraphQLHandler({
+        searchSchema: searchSchema(schema),
+        schema: buildGraphQLSchema(searchSchema(schema)),
+        engine,
+      }),
+    ).toThrow(/exactly one/);
+  });
+});

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -7,6 +7,14 @@ export default mergeConfig(
   defineConfig({
     root: __dirname,
     cacheDir: '../../node_modules/.vite/packages/search-api-graphql',
+    resolve: {
+      // graphql ships both CJS and ESM builds without an `exports` map. Vite
+      // transforms our sources against the ESM build while the externalized
+      // graphql-yoga loads the CJS build in Node, and graphql rejects schemas
+      // crossing the two realms. Pin every import to the CJS build that Node
+      // resolves, so tests exercise one graphql instance.
+      alias: { graphql: 'graphql/index.js' },
+    },
     test: {
       coverage: {
         thresholds: {
@@ -14,7 +22,7 @@ export default mergeConfig(
           lines: 100,
           // Full-suite baseline, re-anchored when covered branches are
           // deleted (autoUpdate only ever raises; see AGENTS.md).
-          branches: 93.04,
+          branches: 94.02,
           statements: 100,
         },
       },


### PR DESCRIPTION
Part of #600 (layer 2 of 3: the served handler; the prebuilt Docker image, layer 3, follows separately).

Makes `@lde/search-api-graphql` batteries-included: `createSearchGraphQLHandler({ searchSchema | schema, engine, … })` returns a framework-agnostic `(request: Request) => Promise<Response>` handler built on graphql-yoga, so every `Request`/`Response` host (SvelteKit, Hono, plain Node via `@whatwg-node/server`) mounts the served search API in a few lines instead of hand-rolling it.

## What the handler covers

- **POST execution, introspection, error shaping**, and `Accept-Language` parsed (via `negotiator`, q-values respected) into the ordered `SearchContext.acceptLanguage`.
- **Self-contained playground** on GET: the GraphiQL build bundled with Yoga – no external CDN, no framing headers, so a docs site can `<iframe>` the deployed playground as a live client. Disable with `playground: false`; swap the renderer with `renderPlayground`.
- **SDL endpoint**: `GET /graphql?sdl` returns `printSchema()` output – the contract without a running introspection query.
- **CORS** for cross-origin browser clients (Yoga’s CORS handling, configurable).
- **Depth and cost limits** (graphql-armor `maxDepth`/`maxCost`, defaults 15/5000, introspection exempt) to cap abuse on a public endpoint.
- **Bring-your-own schema**: pass a merged `GraphQLSchema` instead of a `searchSchema` and custom fields are served through the same endpoint and playground (covered by a test).

## Decisions

- **graphql-yoga over Mercurius** (which is Fastify-coupled) – recorded in [ADR 14](docs/decisions/0014-serve-the-search-graphql-api-with-graphql-yoga.md), as the issue proposed.
- **Breaking: `graphql` ^15.8 → ^16.** The graphql-armor validation plugins do not accept graphql 15, and a mixed tree fails at runtime with graphql-js’s realm check; Yoga supports both 15 and 16, so 16 is the version everything agrees on. Only this package declared graphql in the workspace. Side effect: graphql 16’s `printSchema` drops the trailing newline, which moved the generator-stability snapshot by one blank line.
- The package’s vitest config aliases `graphql` to its CJS build: graphql ships dual CJS/ESM without an `exports` map, and vitest otherwise loads the ESM build for our sources while externalized Yoga loads CJS in Node – two realms, instant failure. Runtime consumers are unaffected (Node resolution and bundlers each pick one build consistently).

## Acceptance criteria covered (of #600)

- [x] Framework-agnostic fetch handler (POST, playground, introspection, error shaping, `Accept-Language`) from a `searchSchema` or a supplied `GraphQLSchema`
- [x] Self-contained playground, renderer configurable, disable-able
- [x] Playground iframe-embeddable (no anti-framing headers; same stable URL as the endpoint)
- [x] CORS + depth/cost limits
- [x] Custom fields merged into the served schema, same endpoint and playground
- [x] SDL retrievable without introspection
- [ ] Prebuilt Docker image (layer 3) – follow-up
- [ ] Dataset Register drops its hand-rolled `+server.ts` – downstream follow-up
