### PR TITLE
docs(search): mark the inline reference strategy as implemented

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37959,7 +37959,7 @@
     },
     "packages/pipeline": {
       "name": "@lde/pipeline",
-      "version": "0.34.3",
+      "version": "0.34.4",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "^0.7.8",
@@ -37985,7 +37985,7 @@
     },
     "packages/pipeline-console-reporter": {
       "name": "@lde/pipeline-console-reporter",
-      "version": "0.25.3",
+      "version": "0.25.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -37996,7 +37996,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.3"
+        "@lde/pipeline": "^0.34.4"
       }
     },
     "packages/pipeline-console-reporter/node_modules/ansi-regex": {
@@ -38176,7 +38176,7 @@
     },
     "packages/pipeline-shacl-sampler": {
       "name": "@lde/pipeline-shacl-sampler",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -38187,7 +38187,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.3"
+        "@lde/pipeline": "^0.34.4"
       }
     },
     "packages/pipeline-shacl-sampler/node_modules/n3": {
@@ -38205,7 +38205,7 @@
     },
     "packages/pipeline-shacl-validator": {
       "name": "@lde/pipeline-shacl-validator",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -38219,7 +38219,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.3"
+        "@lde/pipeline": "^0.34.4"
       }
     },
     "packages/pipeline-shacl-validator/node_modules/n3": {
@@ -38238,7 +38238,7 @@
     },
     "packages/pipeline-void": {
       "name": "@lde/pipeline-void",
-      "version": "0.32.3",
+      "version": "0.32.4",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -38249,7 +38249,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.3"
+        "@lde/pipeline": "^0.34.4"
       }
     },
     "packages/pipeline-void/node_modules/n3": {
@@ -38321,7 +38321,7 @@
     },
     "packages/search-pipeline": {
       "name": "@lde/search-pipeline",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "@lde/search": "^0.12.0",
@@ -38331,7 +38331,7 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@lde/search-typesense": "^0.14.1",
+        "@lde/search-typesense": "^0.14.2",
         "@rdfjs/types": "^2.0.1",
         "n3": "^2.1.1",
         "testcontainers": "^12.0.3",
@@ -38339,7 +38339,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.3"
+        "@lde/pipeline": "^0.34.4"
       }
     },
     "packages/search-pipeline/node_modules/n3": {
@@ -38358,7 +38358,7 @@
     },
     "packages/search-typesense": {
       "name": "@lde/search-typesense",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "MIT",
       "dependencies": {
         "@lde/search": "^0.12.0",
@@ -38371,7 +38371,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.34.3"
+        "@lde/pipeline": "^0.34.4"
       }
     },
     "packages/search/node_modules/n3": {

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -181,11 +181,12 @@ export interface ReferenceField extends SearchFieldBase, Searchable {
      *  indexed root type (and until cross-collection references exist, it must
      *  not collide with one). */
     readonly typeName: string;
-    /** How much of the referenced entity the reference carries. Only
-     *  `labelOnly` (id + display label) is implemented; `idOnly` and `inline`
-     *  are forward declarations, so that declarations (and the SHACL
-     *  `search:nestedStrategy` mapping) keep their shape when those land, and
-     *  `inline` can then add fields to the reference type additively. */
+    /** How much of the referenced entity the reference carries. `labelOnly`
+     *  (id + display label, resolved from a label source) and `inline` (the
+     *  referent’s own projected fields, carried inline through a declared
+     *  {@link ReferenceType} – see {@link isInlineReference}) are implemented;
+     *  `idOnly` is a forward declaration, so that declarations (and the SHACL
+     *  `search:nestedStrategy` mapping) keep their shape when it lands. */
     readonly strategy: 'labelOnly' | 'idOnly' | 'inline';
   };
 }


### PR DESCRIPTION
Fix #642

The `ReferenceField.ref.strategy` JSDoc claimed only `labelOnly` was implemented, with `idOnly` and `inline` as forward declarations. But `inline` is fully implemented (projection via `applyInlineReference`, schema validation incl. cycle rejection, framing depth) and documented in the README. Update the comment so it matches: `labelOnly` and `inline` are implemented; only `idOnly` remains a forward declaration.

Also syncs `package-lock.json` with the workspace package versions from the latest release commit, which bumped the `package.json` versions without updating the lockfile.
