### PR TITLE
fix: exclude blank-node roots from selection and skip them in framing

### DIFF
--- a/packages/search-pipeline/README.md
+++ b/packages/search-pipeline/README.md
@@ -155,7 +155,10 @@ the CONSTRUCT’s subject yields a batch that is not root-complete, and projecti
 will then silently emit partial documents – a promise `@lde/pipeline` cannot
 check ([ADR 13](../../docs/decisions/0013-project-inside-the-batch-per-root-type.md)).
 `selectByClass(searchType)` is a convenience for the object grain (where the
-type’s `class` really is the source class), **not** a default.
+type’s `class` really is the source class), **not** a default. It excludes
+blank-node subjects (`FILTER(!isBlank(?root))`): a blank node has no stable
+document key, so it can never become a search document – a custom selector
+should exclude them too.
 
 ## Per-collection isolation
 

--- a/packages/search-pipeline/src/search-stages.ts
+++ b/packages/search-pipeline/src/search-stages.ts
@@ -152,6 +152,12 @@ export function searchStages(
  * all (their entry point – “registered, newest registration, has a title” – is a
  * deployment fact no schema states).
  *
+ * **Blank-node subjects are excluded** (`FILTER(!isBlank(?‹rootVariable›))`): a
+ * blank node has no stable document key, so it can never become a search
+ * document – framing skips it. Excluding it at the endpoint keeps result pages
+ * full, so pagination walks the whole class instead of stopping at the first
+ * page a client-side drop would leave short.
+ *
  * `rootVariable` defaults to `root` and must match the stage’s
  * {@link SearchStageType.rootVariable}; it must not be `dataset` (reserved by the
  * SPARQL reader).
@@ -161,6 +167,6 @@ export function selectByClass(
   rootVariable = 'root',
 ): ItemSelector {
   return new SparqlItemSelector({
-    query: `SELECT ?${rootVariable} WHERE { ?${rootVariable} a <${searchType.class}> }`,
+    query: `SELECT ?${rootVariable} WHERE { ?${rootVariable} a <${searchType.class}> FILTER(!isBlank(?${rootVariable})) }`,
   });
 }

--- a/packages/search-pipeline/test/extraction-roundtrip.integration.test.ts
+++ b/packages/search-pipeline/test/extraction-roundtrip.integration.test.ts
@@ -123,6 +123,8 @@ describe('extraction round-trip: generate → read → frame → project', () =>
     const byId = Object.fromEntries(
       received.map((item) => [item.document.id, item.document]),
     );
+    // Exactly the two IRI-rooted works: the fixture’s blank-node CreativeWork
+    // is never selected as a root – a blank node has no stable document key.
     expect(Object.keys(byId).sort()).toEqual([
       'https://ex/cw/1',
       'https://ex/cw/2',

--- a/packages/search-pipeline/test/fixtures/drapo-sample.ttl
+++ b/packages/search-pipeline/test/fixtures/drapo-sample.ttl
@@ -2,7 +2,9 @@
 
 # A Drapo-shaped SCHEMA-AP-NDE sample: CreativeWork roots typed in the source
 # (so selectByClass selects them), each with localized name/description and a
-# labelOnly creator reference resolving a typed Person.
+# labelOnly creator reference resolving a typed Person. The blank-node
+# CreativeWork mirrors Drapo’s blank-node instances: it has no stable document
+# key, so selectByClass must never select it as a root.
 
 <https://ex/cw/1> a schema:CreativeWork ;
   schema:name "Het meisje met de parel"@nl, "Girl with a Pearl Earring"@en ;
@@ -11,6 +13,9 @@
 
 <https://ex/cw/2> a schema:CreativeWork ;
   schema:name "De nachtwacht"@nl .
+
+_:anonymousWork a schema:CreativeWork ;
+  schema:name "Naamloos werk"@nl .
 
 <https://ex/p/1> a schema:Person ;
   schema:name "Johannes Vermeer" .

--- a/packages/search-pipeline/test/search-stages.test.ts
+++ b/packages/search-pipeline/test/search-stages.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import nock from 'nock';
 import { DataFactory } from 'n3';
 import type { Quad } from '@rdfjs/types';
 import { Dataset, Distribution } from '@lde/dataset';
@@ -206,6 +207,30 @@ describe('selectByClass', () => {
 
   it('accepts a custom root variable', () => {
     expect(() => selectByClass(person, 'subject')).not.toThrow();
+  });
+
+  it('excludes blank-node subjects at the endpoint', async () => {
+    // A blank node has no stable document key, so it can never become a search
+    // document (framing skips it). Filtering at the endpoint also keeps result
+    // pages full, so pagination is not cut short by client-side dropped rows.
+    let query = '';
+    nock('http://example.org')
+      .post('/sparql')
+      .reply(
+        200,
+        (_uri, requestBody) => {
+          query = decodeURIComponent(String(requestBody).replace(/\+/g, ' '));
+          return { head: { vars: ['root'] }, results: { bindings: [] } };
+        },
+        { 'Content-Type': 'application/sparql-results+json' },
+      );
+
+    const selector = selectByClass(person);
+    for await (const row of selector.select(distribution, 10)) {
+      void row;
+    }
+
+    expect(query.replace(/\s+/g, '')).toMatch(/isblank\(\?root\)/i);
   });
 });
 

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -264,6 +264,12 @@ statement of what the projection reads. `assertTypeInSchema` guards that
 the passed `SearchType` is a member of the schema – the port’s own membership
 check – so no schema is ever forged to scope a projection to one type.
 
+**Blank-node roots are not indexable**: a blank node has no stable document
+key, so framing skips a blank-node root (and any root absent from the index)
+rather than crash. Blank-node subjects still embed fine when _referenced_ from
+a root; they just cannot _be_ one – select roots accordingly
+(`selectByClass` in `@lde/search-pipeline` already excludes them).
+
 `projectRoots` yields a **bare** `SearchDocument`. Pairing each document with the
 `SearchType` it belongs to, so the write side can fan a mixed stream out to
 per-type collections, is a routing concern owned by the pipeline glue – see

--- a/packages/search/src/frame-by-type.ts
+++ b/packages/search/src/frame-by-type.ts
@@ -66,7 +66,12 @@ export function buildSubjectIndex(quads: Iterable<Quad>): SubjectIndex {
  *
  * The roots are supplied explicitly rather than discovered from `rdf:type`: the
  * caller ({@link projectRoots}, from the pipeline selector) already holds them
- * and passes them directly. A root absent from the index simply frames nothing.
+ * and passes them directly. A root absent from the index simply frames nothing –
+ * without ever reaching `jsonld.frame`, whose `@id` validation would otherwise
+ * throw on a root that is not an IRI (a blank-node label). A **blank-node root
+ * is skipped** even when its label is in the index: a blank node has no stable
+ * document key, so it can never become a search document – blank-node subjects
+ * are embeddable through a reference, never indexable as roots.
  */
 export async function* frameSubjects(
   index: SubjectIndex,
@@ -75,6 +80,10 @@ export async function* frameSubjects(
 ): AsyncIterable<FramedNode> {
   const { bySubject } = index;
   for (const rootIri of roots) {
+    const owned = bySubject.get(rootIri);
+    if (owned === undefined || owned[0].subject.termType === 'BlankNode') {
+      continue;
+    }
     const subgraph = collectSubgraph(bySubject, rootIri, depth);
     const expanded = await jsonld.fromRDF(subgraph);
     // Frame for THIS specific root subject by its `@id`. The subgraph embeds the

--- a/packages/search/test/frame-by-type.test.ts
+++ b/packages/search/test/frame-by-type.test.ts
@@ -218,4 +218,41 @@ describe('frameSubjects', () => {
       ),
     ).toEqual([]);
   });
+
+  it('skips a blank-node root, framing the remaining roots', async () => {
+    // A selector can bind a blank-node subject (e.g. 149 blank-node
+    // schema:Place in the Drapo dataset). A blank node has no stable document
+    // key, so it can never become a document – and its label is not a valid
+    // frame `@id`, so without the skip `jsonld.frame` would throw and abort
+    // the whole stage.
+    const parsed = quads(`
+      _:place <${foaf.name.value}> "Naamloos"@nl .
+      <https://ex/d/1> <${dcterms.title.value}> "Titel"@nl .
+    `);
+    const blankSubject = parsed
+      .map((quad) => quad.subject)
+      .find((subject) => subject.termType === 'BlankNode');
+    expect(blankSubject).toBeDefined();
+
+    const nodes = await collect(
+      frameSubjects(buildSubjectIndex(parsed), [
+        String(blankSubject?.value),
+        'https://ex/d/1',
+      ]),
+    );
+
+    expect(nodes.map((node) => node['@id'])).toEqual(['https://ex/d/1']);
+  });
+
+  it('frames nothing for a blank-node label absent from the index', async () => {
+    // Blank-node labels are not stable across queries, so a selector-bound
+    // label usually matches nothing in the extraction’s index. It must still
+    // skip rather than reach `jsonld.frame`, whose `@id` validation throws on
+    // a non-IRI root.
+    expect(
+      await collect(
+        frame(`<https://ex/d/1> <${rdf.type.value}> <${DATASET}> .`, ['b42']),
+      ),
+    ).toEqual([]);
+  });
 });

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 98.87,
+          branches: 98.88,
           statements: 100,
         },
       },


### PR DESCRIPTION
Fix #641

Implements both the ergonomic and the deep fix from the issue:

- **`@lde/search-pipeline`** – `selectByClass` now emits `FILTER(!isBlank(?root))`, so blank-node subjects (e.g. Drapo’s 149 blank-node `schema:Place`) are never selected as roots. Filtering at the endpoint rather than client-side also keeps result pages full: `SparqlItemSelector` drops non-`NamedNode` bindings after fetching, and a short page terminates pagination – with many blank-node instances, the rest of the class would silently never be selected.
- **`@lde/search`** – `frameSubjects` skips a blank-node root (and short-circuits a root absent from the index) instead of reaching `jsonld.frame`, whose `@id` validation throws on a non-IRI root and aborted the whole stage. A blank node has no stable document key, so it can never become a search document; blank-node subjects still embed fine when referenced from a root.

Both READMEs now document that blank-node roots are not indexable. The round-trip integration test gains a blank-node `CreativeWork` in the fixture, proving end to end that only IRI roots are indexed.

Note: the pagination interaction between `SparqlItemSelector`’s client-side row filtering and its page-size-based termination affects any selector query that binds blank nodes, not just `selectByClass` – worth a separate look in `@lde/pipeline`.
