### PR TITLE
feat(search-api-server): serve the search API as a bootable process and Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,11 @@ jobs:
       # - run: npx nx-cloud record -- echo Hello World
       # Nx Affected runs only tasks affected by the changes in this PR/commit. Learn more: https://nx.dev/ci/features/affected
       - run: npx nx affected -t lint test typecheck build
+
+      # docker:smoke builds each affected Docker image and boots it, so a
+      # runtime-only failure (e.g. a dependency missing from the pruned image)
+      # cannot pass a green build. A separate step, AFTER the test suites:
+      # image builds are heavy enough to starve timing-sensitive tests when
+      # they share the runner (its build/stage prerequisites replay from the
+      # cache of the previous step).
+      - run: npx nx affected -t docker:smoke

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '@lde/search-api-server@*'
+      - '@lde/search-indexer@*'
   workflow_dispatch:
     inputs:
       ref:
@@ -31,14 +32,17 @@ jobs:
       # The image is built from this tagged commit's own workspace outputs
       # (nx docker:build stages the compiled package, its workspace
       # dependencies and a pruned lockfile), so it needs no npm publish to
-      # have happened – the release tag alone identifies the version.
-      - name: Determine version
+      # have happened – the release tag alone identifies the package and
+      # version (e.g. "@lde/search-indexer@0.1.0").
+      - name: Determine package and version
         id: version
         # The ref reaches the shell via env, never inline interpolation, so a
         # crafted dispatch input cannot inject shell syntax.
         env:
           REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}
         run: |
+          package="${REF#@lde/}"
+          echo "package=${package%@*}" >> "$GITHUB_OUTPUT"
           echo "version=${REF##*@}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v7
@@ -49,7 +53,7 @@ jobs:
       - run: npm ci
 
       - name: Build and smoke-test the image
-        run: npx nx run @lde/search-api-server:docker:smoke
+        run: npx nx run "@lde/${{ steps.version.outputs.package }}:docker:smoke"
 
       - uses: docker/login-action@v3
         with:
@@ -59,7 +63,9 @@ jobs:
 
       - name: Push the image
         run: |
-          docker tag packages-search-api-server "ghcr.io/ldelements/search-api-server:${{ steps.version.outputs.version }}"
-          docker tag packages-search-api-server ghcr.io/ldelements/search-api-server:latest
-          docker push "ghcr.io/ldelements/search-api-server:${{ steps.version.outputs.version }}"
-          docker push ghcr.io/ldelements/search-api-server:latest
+          package="${{ steps.version.outputs.package }}"
+          version="${{ steps.version.outputs.version }}"
+          docker tag "packages-${package}" "ghcr.io/ldelements/${package}:${version}"
+          docker tag "packages-${package}" "ghcr.io/ldelements/${package}:latest"
+          docker push "ghcr.io/ldelements/${package}:${version}"
+          docker push "ghcr.io/ldelements/${package}:latest"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,65 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - '@lde/search-api-server@*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or ref to build the image from (e.g. @lde/search-api-server@0.1.0)'
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+# Release runs tag several packages in quick succession; serialize the image
+# pushes so :latest cannot land out of order.
+concurrency:
+  group: docker-publish
+  cancel-in-progress: false
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      # The image is built from this tagged commit's own workspace outputs
+      # (nx docker:build stages the compiled package, its workspace
+      # dependencies and a pruned lockfile), so it needs no npm publish to
+      # have happened – the release tag alone identifies the version.
+      - name: Determine version
+        id: version
+        # The ref reaches the shell via env, never inline interpolation, so a
+        # crafted dispatch input cannot inject shell syntax.
+        env:
+          REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}
+        run: |
+          echo "version=${REF##*@}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Build and smoke-test the image
+        run: npx nx run @lde/search-api-server:docker:smoke
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push the image
+        run: |
+          docker tag packages-search-api-server "ghcr.io/ldelements/search-api-server:${{ steps.version.outputs.version }}"
+          docker tag packages-search-api-server ghcr.io/ldelements/search-api-server:latest
+          docker push "ghcr.io/ldelements/search-api-server:${{ steps.version.outputs.version }}"
+          docker push ghcr.io/ldelements/search-api-server:latest

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ vite.base.config.d.ts.map
 .nx/polygraph
 .nx/self-healing
 .nx/migrate-runs
+dist-docker

--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,3 @@
+# The Docker staging output contains copies of workspace packages
+# (copy-workspace-modules), which must not be detected as Nx projects.
+packages/*/dist-docker/

--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ await pipeline.run();
   <td>The served search API as a bootable process and prebuilt Docker image: mounts a schema-declaration module, binds the GraphQL handler to a Typesense engine, and serves /graphql plus /health from environment config</td>
 </tr>
 <tr>
+  <td><a href="packages/search-indexer">@lde/search-indexer</a></td>
+  <td><a href="https://www.npmjs.com/package/@lde/search-indexer"><img src="https://img.shields.io/npm/v/@lde/search-indexer" alt="npm"></a></td>
+  <td>The search indexer as a bootable process and prebuilt Docker image: mounts the same schema-declaration module as the API server, selects datasets from a registry, and rebuilds the Typesense collections from environment config</td>
+</tr>
+<tr>
   <td><a href="packages/search-pipeline">@lde/search-pipeline</a></td>
   <td><a href="https://www.npmjs.com/package/@lde/search-pipeline"><img src="https://img.shields.io/npm/v/@lde/search-pipeline" alt="npm"></a></td>
   <td>Applies the @lde/search projection inside an @lde/pipeline run, fanning each document out to the transactional engine writer for its type’s collection (owns no projection itself)</td>
@@ -253,6 +258,10 @@ graph TD
     search-typesense --> pipeline
     search-pipeline --> search
     search-pipeline --> pipeline
+    search-indexer --> search-pipeline
+    search-indexer --> search-typesense
+    search-indexer --> sparql-qlever
+    search-indexer --> pipeline-console-reporter
   end
 
   subgraph Monitoring

--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ await pipeline.run();
   <td>Engine- and domain-agnostic GraphQL surface for search: builds an executable GraphQL schema from a SearchSchema at runtime and serves it as a framework-agnostic fetch handler with a self-contained playground</td>
 </tr>
 <tr>
+  <td><a href="packages/search-api-server">@lde/search-api-server</a></td>
+  <td><a href="https://www.npmjs.com/package/@lde/search-api-server"><img src="https://img.shields.io/npm/v/@lde/search-api-server" alt="npm"></a></td>
+  <td>The served search API as a bootable process and prebuilt Docker image: mounts a schema-declaration module, binds the GraphQL handler to a Typesense engine, and serves /graphql plus /health from environment config</td>
+</tr>
+<tr>
   <td><a href="packages/search-pipeline">@lde/search-pipeline</a></td>
   <td><a href="https://www.npmjs.com/package/@lde/search-pipeline"><img src="https://img.shields.io/npm/v/@lde/search-pipeline" alt="npm"></a></td>
   <td>Applies the @lde/search projection inside an @lde/pipeline run, fanning each document out to the transactional engine writer for its type’s collection (owns no projection itself)</td>
@@ -241,6 +246,8 @@ graph TD
     docgen
     search --> text-normalization
     search-api-graphql --> search
+    search-api-server --> search-api-graphql
+    search-api-server --> search-typesense
     search-typesense --> search
     search-typesense --> text-normalization
     search-typesense --> pipeline

--- a/docs/decisions/0015-ship-the-served-search-api-as-a-docker-image-built-from-the-workspace.md
+++ b/docs/decisions/0015-ship-the-served-search-api-as-a-docker-image-built-from-the-workspace.md
@@ -1,0 +1,91 @@
+# 15. Ship the served search API as a Docker image built from the workspace
+
+Date: 2026-07-23
+
+## Status
+
+Accepted
+
+Extends [ADR 14 (Serve the search GraphQL API with graphql-yoga)](./0014-serve-the-search-graphql-api-with-graphql-yoga.md).
+Implements the image layer (layer 3) of
+[#600](https://github.com/ldelements/lde/issues/600).
+
+## Context
+
+The `createSearchGraphQLHandler()` fetch handler (ADR 14) still requires a JS
+host to mount it. Turnkey, non-JS and ops-driven deployments – and the
+dedicated search-API pod topology #600 recommends – need a prebuilt image that
+boots from configuration alone.
+
+Three constraints shaped the design:
+
+1. `@lde/search-api-graphql` deliberately names neither the domain nor the
+   engine, so a bootable server that binds Typesense cannot live there.
+2. A mounted ES module cannot use bare imports (`import '@lde/search'` does not
+   resolve from a mounted path), so the schema mount cannot be authored against
+   the library. The SHACL + `search:` source #600 assumed does not exist yet –
+   schema generation is [#495](https://github.com/ldelements/lde/issues/495)’s
+   still-open scope.
+3. An image built from the published npm package (the first design of this
+   ADR) couples the Docker build to the npm publish: the build must wait for
+   the registry, the first image is blocked on the new package’s manual
+   Trusted-Publishing bootstrap, and no image can be built – let alone
+   smoke-tested – for unpublished code in a PR.
+
+The Dataset Register went through the same evolution for its app images and
+settled on building from the workspace, unbundled, after an esbuild-bundled
+image hid a workspace lib’s transitive dependencies until the container
+crashed at startup (dataset-register#2128/#2130). We adopt its end state.
+
+## Decision
+
+- **A separate composition package, `@lde/search-api-server`**: environment
+  config, schema-module loading, and a `node:http` server around the ADR 14
+  handler bound to `createTypesenseSearchEngine`. The engine-agnostic handler
+  package stays engine-agnostic. It is npm-published like every other package.
+- **The schema mounts as a plain-data declaration module**: a `.mjs` file
+  default-exporting `SearchType` declarations, validated at boot by
+  `searchSchema()` – the exact “declarations built outside TypeScript” path
+  the runtime validation exists for. Optional functions (`derive`,
+  `transform`) remain expressible; a serving process never calls them. When
+  #495 delivers the SHACL + `search:` generator, mounted SHACL becomes a
+  second source for the same schema.
+- **The image is built from the workspace’s own outputs, not from npm.**
+  `docker:build` (inferred by `@nx/docker`) depends on a staging chain –
+  `docker:stage` (compiled package), `@nx/js:copy-workspace-modules`
+  (same-commit builds of the `@lde/*` dependencies), `@nx/js:prune-lockfile`
+  plus a `npm install --package-lock-only` repair step (`docker:lockfile`,
+  needed because Nx’s lockfile pruning cannot map this workspace’s graph and
+  falls back to the root lockfile) – and the Dockerfile is a plain
+  `npm ci --omit=dev` + `COPY`. No bundling: the image keeps real modules, so
+  a missing dependency fails loudly instead of being silently inlined away.
+- **`docker:smoke` gates CI**: the built image is booted with a fixture
+  schema and probed over HTTP (`/health`, `/graphql?sdl`) in `nx affected`,
+  so both build-time and runtime-only failures (the
+  `ERR_MODULE_NOT_FOUND` class) fail the PR, not production.
+- **Publishing is tag-triggered but registry-independent**: the release run’s
+  `@lde/search-api-server@<version>` tag triggers the Docker workflow, which
+  checks out that commit, rebuilds and smoke-tests the image, and pushes
+  `ghcr.io/ldelements/search-api-server:<version>` and `:latest`. Image tags
+  stay aligned with the package’s semver; `nx release`’s own Docker support
+  (experimental, calendar-versioned, and unable to both npm- and
+  Docker-publish one project) is deliberately not used.
+- The read-only image **omits `@lde/search-typesense`’s peers**
+  (`@lde/pipeline`, `@lde/dataset`; `npm ci --legacy-peer-deps`): they type
+  the write side only and every runtime import is `import type`. The smoke
+  test guards this assumption.
+
+## Consequences
+
+- Ops deploys get a turnkey `/graphql` + playground from a schema mount and
+  environment variables; JS hosts keep mounting the handler directly.
+- The image cannot serve custom-code GraphQL fields – by design (#600): such
+  consumers use the handler, or build `FROM` this image.
+- The Docker build no longer waits on – or can be broken by – the npm
+  publish; the npm package’s one-time manual bootstrap only affects npm
+  consumers, not the image.
+- Every affected PR pays for an image build + boot in CI (~15 s), in exchange
+  for catching pruned-image runtime failures before merge.
+- The `docker:lockfile` repair step is a workaround for the Nx pruning
+  fallback; when Nx learns to prune this workspace’s lockfile it can be
+  dropped.

--- a/docs/decisions/0016-ship-the-search-indexer-as-a-config-driven-image.md
+++ b/docs/decisions/0016-ship-the-search-indexer-as-a-config-driven-image.md
@@ -1,0 +1,86 @@
+# 16. Ship the search indexer as a config-driven image
+
+Date: 2026-07-24
+
+## Status
+
+Accepted
+
+Extends [ADR 15 (Ship the served search API as a Docker image built from the
+workspace)](./0015-ship-the-served-search-api-as-a-docker-image-built-from-the-workspace.md).
+Implements [#652](https://github.com/ldelements/lde/issues/652), the
+write-path counterpart of #600/#646.
+
+## Context
+
+`searchIndexerPipeline()` (#647) composes the object-grain search indexer,
+but still requires a Node program around it. The read path already ends in a
+bootable image (ADR 15); the write path needs the same final layer, and the
+symmetry is the point: mount the **same schema-declaration module** into both
+images, point both at the same `TYPESENSE_*` coordinates, and the write and
+read sides cannot disagree about the schema.
+
+The one open design problem is the import path (`ImportResolver` +
+`@lde/sparql-qlever`). Importing is not ‘have a QLever running’ but a
+per-dataset control loop: download the dump, build the index offline,
+(re)start the server on the new index. A statically-declared QLever service
+(Docker Compose service, Kubernetes sidecar) therefore **cannot work**: it
+only exposes a SPARQL port, and the pipeline has no control plane to rebuild
+its index per dataset. Feeding a running server is not viable either – SPARQL
+UPDATE’s update-triples overlay performs badly and deleted triples can
+reappear after restart, and Graph Store HTTP `POST` is unusable for large
+datasets (ad-freiburg/qlever#2014). A QLever the pipeline uses must be a
+QLever the pipeline controls.
+
+## Decision
+
+- **A separate composition package, `@lde/search-indexer`**: environment
+  config, the shared schema-module loader, dataset selection against a
+  registry, and Typesense rebuild writers around `searchIndexerPipeline`.
+  Engine-bound to Typesense deliberately – that binding cannot live in
+  `@lde/search-pipeline` without breaking its engine-agnosticism. Published
+  to npm and shipped as `ghcr.io/ldelements/search-indexer`, reusing ADR 15’s
+  entire delivery pattern (workspace-built image, `docker:smoke` CI gate,
+  release-tag-triggered publish).
+- **The schema-module loader moves to `@lde/search/module`** and both images
+  use it, implementing the shared-mount symmetry in code: one loader, one
+  validation, one error vocabulary. Consumer-specific optional exports
+  (`schemaOptions`, `engineOptions`) stay validated in the consumers.
+- **Configuration is env-only and boot-or-fail**, every problem reported in
+  one error (ADR 15’s pattern): registry endpoint plus dataset IRIs or
+  criteria, `TYPESENSE_*`, rebuild mode, optional collection prefix, optional
+  file provenance + pipeline version. Two combinations are rejected at boot:
+  provenance with only one of its two halves, and provenance with blue-green
+  rebuilds – a skipped dataset would be missing from the fresh collection the
+  swap makes live.
+- **v1 ships endpoint-only by default, plus the Docker-socket import path
+  behind a flag.** `QLEVER_IMAGE` turns on `ImportResolver` with
+  `DockerTaskRunner`: the indexer container spawns and fully controls sibling
+  QLever containers over the mounted socket. It is free (the runner exists
+  and talks to the socket via dockerode), Compose-friendly, and keeps QLever
+  out of the indexer’s cgroup. Its limits are documented, not worked around:
+  no socket, no import path – on containerd-based Kubernetes, run
+  endpoint-only.
+- **Native mode in-image is the Kubernetes follow-up, not part of v1**:
+  shipping the QLever engine inside the indexer image (`NativeTaskRunner`)
+  works anywhere a container runs, but costs image size, engine-version
+  coupling and a shared cgroup (a QLever OOM kills the indexer). A
+  controllable QLever sidecar (own control agent and protocol) is only worth
+  designing if both other options prove unacceptable.
+
+## Consequences
+
+- Ops deploys configure the indexer (a cron job in Compose or Kubernetes)
+  instead of writing a Node program; deployments with bespoke root selectors
+  or per-stage tuning stay on the first-class library path
+  (`searchStages` + `searchIndexWriter` + `Pipeline`).
+- One mounted module drives both images; schema drift between the write and
+  read side is no longer expressible in deployment config.
+- The image runs batch-style: no ports, no `HEALTHCHECK`; overlapping runs
+  are serialized by the rebuild writers’ cross-pod lock.
+- The import path requires Docker-socket access and an identical host path
+  for `DATA_DIR` in the indexer and its sibling QLever containers – both
+  documented in the package README, both moot in endpoint-only mode.
+- When the Kubernetes need materializes, native mode lands as a second image
+  variant (or a base-image switch) without touching the configuration
+  surface: `QLEVER_IMAGE` is the only Docker-specific knob.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ export default [
   {
     ignores: [
       '**/dist',
+      '**/dist-docker',
       '**/coverage',
       '**/out-tsc',
       '**/vite.config.*.timestamp*',

--- a/nx.json
+++ b/nx.json
@@ -58,11 +58,50 @@
       "options": {
         "testTargetName": "test"
       }
+    },
+    {
+      "plugin": "@nx/docker",
+      "options": {
+        "buildTarget": "docker:build",
+        "runTarget": "docker:run"
+      }
     }
   ],
   "targetDefaults": {
     "test": {
       "dependsOn": ["^build"]
+    },
+    "docker:stage": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["production", "^production"],
+      "outputs": ["{projectRoot}/dist-docker"]
+    },
+    "copy-workspace-modules": {
+      "executor": "@nx/js:copy-workspace-modules",
+      "dependsOn": ["docker:stage"],
+      "options": {
+        "outputPath": "{projectRoot}/dist-docker"
+      }
+    },
+    "prune-lockfile": {
+      "executor": "@nx/js:prune-lockfile",
+      "dependsOn": ["docker:stage"],
+      "options": {
+        "outputPath": "{projectRoot}/dist-docker"
+      }
+    },
+    "docker:lockfile": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["copy-workspace-modules", "prune-lockfile"],
+      "options": {
+        "cwd": "{projectRoot}/dist-docker",
+        "command": "find workspace_modules -type d \\( -name src -o -name test \\) -prune -exec rm -rf {} + && find . -name '*.tsbuildinfo' -type f -delete && npm install --package-lock-only --ignore-scripts --legacy-peer-deps"
+      }
+    },
+    "docker:build": {
+      "dependsOn": ["docker:lockfile"]
     }
   },
   "release": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20441,6 +20441,10 @@
       "resolved": "packages/search-api-server",
       "link": true
     },
+    "node_modules/@lde/search-indexer": {
+      "resolved": "packages/search-indexer",
+      "link": true
+    },
     "node_modules/@lde/search-pipeline": {
       "resolved": "packages/search-pipeline",
       "link": true
@@ -38350,6 +38354,35 @@
       },
       "bin": {
         "search-api-server": "dist/cli.js"
+      }
+    },
+    "packages/search-indexer": {
+      "name": "@lde/search-indexer",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@lde/dataset-registry-client": "^0.9.0",
+        "@lde/pipeline": "^0.35.1",
+        "@lde/pipeline-console-reporter": "^0.26.1",
+        "@lde/search": "^0.12.1",
+        "@lde/search-pipeline": "^0.12.2",
+        "@lde/search-typesense": "^0.15.2",
+        "@lde/sparql-qlever": "^0.15.1",
+        "commander": "^15.0.0",
+        "tslib": "^2.3.0",
+        "typesense": "^3.0.6"
+      },
+      "bin": {
+        "search-indexer": "dist/cli.js"
+      }
+    },
+    "packages/search-indexer/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "packages/search-pipeline": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
         "@eslint/js": "^9.39.2",
+        "@nx/docker": "^23.1.0",
         "@nx/eslint": "23.1.0",
         "@nx/eslint-plugin": "23.1.0",
         "@nx/js": "23.1.0",
@@ -20436,6 +20437,10 @@
       "resolved": "packages/search-api-graphql",
       "link": true
     },
+    "node_modules/@lde/search-api-server": {
+      "resolved": "packages/search-api-server",
+      "link": true
+    },
     "node_modules/@lde/search-pipeline": {
       "resolved": "packages/search-pipeline",
       "link": true
@@ -20560,6 +20565,18 @@
       },
       "peerDependencies": {
         "nx": ">= 22 <= 24 || ^23.0.0-0"
+      }
+    },
+    "node_modules/@nx/docker": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/docker/-/docker-23.1.0.tgz",
+      "integrity": "sha512-rHn/ApGwmcnka3hArpdl5GAJ5wzti130woIAmLGIwCJxnpEbLO1eITic71ecE1+iam+sLVNPu2dC8aLy9xygMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "23.1.0",
+        "enquirer": "~2.3.6",
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/@nx/eslint": {
@@ -35819,11 +35836,11 @@
     },
     "packages/distribution-health": {
       "name": "@lde/distribution-health",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@lde/distribution-probe": "^0.2.6",
-        "@lde/sparql-importer": "^0.6.7",
+        "@lde/sparql-importer": "^0.6.8",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -37959,15 +37976,15 @@
     },
     "packages/pipeline": {
       "name": "@lde/pipeline",
-      "version": "0.35.0",
+      "version": "0.35.2",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "^0.7.8",
         "@lde/dataset-registry-client": "^0.9.0",
-        "@lde/distribution-health": "^0.2.7",
+        "@lde/distribution-health": "^0.2.8",
         "@lde/distribution-probe": "^0.2.6",
-        "@lde/sparql-importer": "^0.6.7",
-        "@lde/sparql-server": "^0.4.12",
+        "@lde/sparql-importer": "^0.6.8",
+        "@lde/sparql-server": "^0.4.13",
         "@rdfjs/namespace": "^2.0.1",
         "@rdfjs/types": "^2.0.1",
         "@tpluscode/rdf-ns-builders": "^5.0.0",
@@ -37985,7 +38002,7 @@
     },
     "packages/pipeline-console-reporter": {
       "name": "@lde/pipeline-console-reporter",
-      "version": "0.26.0",
+      "version": "0.26.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -37996,7 +38013,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.35.0"
+        "@lde/pipeline": "^0.35.2"
       }
     },
     "packages/pipeline-console-reporter/node_modules/ansi-regex": {
@@ -38176,7 +38193,7 @@
     },
     "packages/pipeline-shacl-sampler": {
       "name": "@lde/pipeline-shacl-sampler",
-      "version": "0.9.0",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -38187,7 +38204,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.35.0"
+        "@lde/pipeline": "^0.35.2"
       }
     },
     "packages/pipeline-shacl-sampler/node_modules/n3": {
@@ -38205,7 +38222,7 @@
     },
     "packages/pipeline-shacl-validator": {
       "name": "@lde/pipeline-shacl-validator",
-      "version": "0.18.0",
+      "version": "0.18.2",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -38219,7 +38236,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.35.0"
+        "@lde/pipeline": "^0.35.2"
       }
     },
     "packages/pipeline-shacl-validator/node_modules/n3": {
@@ -38238,7 +38255,7 @@
     },
     "packages/pipeline-void": {
       "name": "@lde/pipeline-void",
-      "version": "0.33.0",
+      "version": "0.33.2",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -38249,7 +38266,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.35.0"
+        "@lde/pipeline": "^0.35.2"
       }
     },
     "packages/pipeline-void/node_modules/n3": {
@@ -38319,9 +38336,25 @@
         "tslib": "^2.3.0"
       }
     },
+    "packages/search-api-server": {
+      "name": "@lde/search-api-server",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@lde/search": "^0.12.0",
+        "@lde/search-api-graphql": "^0.12.0",
+        "@lde/search-typesense": "^0.15.0",
+        "@whatwg-node/server": "^0.11.0",
+        "tslib": "^2.3.0",
+        "typesense": "^3.0.6"
+      },
+      "bin": {
+        "search-api-server": "dist/cli.js"
+      }
+    },
     "packages/search-pipeline": {
       "name": "@lde/search-pipeline",
-      "version": "0.12.1",
+      "version": "0.12.3",
       "license": "MIT",
       "dependencies": {
         "@lde/search": "^0.12.1",
@@ -38331,7 +38364,7 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@lde/search-typesense": "^0.15.1",
+        "@lde/search-typesense": "^0.15.3",
         "@rdfjs/types": "^2.0.1",
         "n3": "^2.1.1",
         "testcontainers": "^12.0.3",
@@ -38339,7 +38372,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.35.0"
+        "@lde/pipeline": "^0.35.2"
       }
     },
     "packages/search-pipeline/node_modules/n3": {
@@ -38358,7 +38391,7 @@
     },
     "packages/search-typesense": {
       "name": "@lde/search-typesense",
-      "version": "0.15.1",
+      "version": "0.15.3",
       "license": "MIT",
       "dependencies": {
         "@lde/search": "^0.12.1",
@@ -38371,7 +38404,7 @@
       },
       "peerDependencies": {
         "@lde/dataset": "^0.7.8",
-        "@lde/pipeline": "^0.35.0"
+        "@lde/pipeline": "^0.35.2"
       }
     },
     "packages/search/node_modules/n3": {
@@ -38390,7 +38423,7 @@
     },
     "packages/sparql-importer": {
       "name": "@lde/sparql-importer",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "^0.7.8",
@@ -38401,13 +38434,13 @@
     },
     "packages/sparql-qlever": {
       "name": "@lde/sparql-qlever",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "^0.7.8",
         "@lde/distribution-downloader": "^0.6.7",
-        "@lde/sparql-importer": "^0.6.7",
-        "@lde/sparql-server": "^0.4.12",
+        "@lde/sparql-importer": "^0.6.8",
+        "@lde/sparql-server": "^0.4.13",
         "@lde/task-runner": "^0.2.12",
         "@lde/task-runner-docker": "^0.2.14",
         "@lde/task-runner-native": "^0.2.15",
@@ -39116,7 +39149,7 @@
     },
     "packages/sparql-server": {
       "name": "@lde/sparql-server",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
     "@eslint/js": "^9.39.2",
+    "@nx/docker": "^23.1.0",
     "@nx/eslint": "23.1.0",
     "@nx/eslint-plugin": "23.1.0",
     "@nx/js": "23.1.0",

--- a/packages/search-api-server/Dockerfile
+++ b/packages/search-api-server/Dockerfile
@@ -1,0 +1,30 @@
+# The prebuilt served search API (https://github.com/ldelements/lde/issues/600,
+# layer 3), built from this workspace’s own outputs: `nx run
+# @lde/search-api-server:docker:build` stages the compiled package, the
+# same-commit builds of its @lde/* workspace dependencies
+# (copy-workspace-modules) and a pruned lockfile (prune-lockfile) into
+# dist-docker/, so the image never waits on – or drifts from – an npm publish.
+# CI smoke-tests the running image (docker:smoke); releases push it to
+# ghcr.io/ldelements/search-api-server (.github/workflows/docker.yml).
+FROM node:24-alpine
+LABEL org.opencontainers.image.source="https://github.com/ldelements/lde"
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY dist-docker/package.json dist-docker/package-lock.json ./
+# --legacy-peer-deps: @lde/search-typesense’s peers (@lde/pipeline,
+# @lde/dataset) type the WRITE side only – every runtime import is
+# `import type`, erased at compile time – so the read-only server image
+# deliberately leaves them (and their SPARQL dependency tree) out. The
+# docker:smoke boot test guards this: a future value import would crash
+# startup with ERR_MODULE_NOT_FOUND.
+RUN npm ci --omit=dev --legacy-peer-deps && npm cache clean --force
+# Lays the same-commit workspace modules over the registry-installed tree.
+COPY dist-docker/ ./
+
+USER node
+EXPOSE 4000
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD wget --quiet --output-document=- http://127.0.0.1:${PORT:-4000}/health || exit 1
+CMD ["node", "dist/cli.js"]

--- a/packages/search-api-server/README.md
+++ b/packages/search-api-server/README.md
@@ -1,0 +1,138 @@
+# @lde/search-api-server
+
+The served [@lde/search](../search) API as a bootable process and prebuilt
+Docker image: mount a schema-declaration module, point it at Typesense, and it
+serves `/graphql` – POST execution, the self-contained playground, the SDL –
+plus `/health`, with CORS and depth/cost limits on by default.
+
+This is the composition layer
+([#600](https://github.com/ldelements/lde/issues/600), layer 3) that binds the
+engine-agnostic [`@lde/search-api-graphql`](../search-api-graphql) handler
+(layer 2) to the [`@lde/search-typesense`](../search-typesense) engine. Use it
+for turnkey, non-JS and ops-driven deployments; a JS host that wants custom
+GraphQL fields mounts the handler itself instead (or builds `FROM` this image).
+
+## Run
+
+```sh
+docker run --publish 4000:4000 \
+  --volume "$(pwd)/search-schema.mjs:/config/search-schema.mjs:ro" \
+  --env TYPESENSE_HOST=typesense.internal \
+  --env TYPESENSE_API_KEY=search-only-key \
+  ghcr.io/ldelements/search-api-server
+```
+
+Or without Docker (the same environment variables apply):
+
+```sh
+npx @lde/search-api-server
+```
+
+## The schema module
+
+The mounted module default-exports the deployment’s search type declarations as
+**plain data** – it must not import `@lde/search` (bare specifiers do not
+resolve from a mounted file), and does not need to: the server validates the
+declarations at boot, exactly as it would a SHACL generator’s output. Optional
+functions (`derive`, `transform`) are allowed – it is a real JS module, only
+without imports; they are projection-time declarations a serving process never
+calls, carried so one module can drive both the indexer and this API.
+
+Authoring in TypeScript works fine: compile the module to `.mjs` first
+(`tsc` or esbuild) and mount the output – with `satisfies SearchType[]` you
+get the full compile-time checking, and functions survive compilation. If the
+module must import, bundle it (e.g. esbuild) before mounting.
+
+```js
+// search-schema.mjs
+export default [
+  {
+    name: 'Dataset',
+    class: 'http://www.w3.org/ns/dcat#Dataset',
+    fields: [
+      {
+        name: 'title',
+        kind: 'text',
+        locales: ['nl', 'en'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+      {
+        name: 'keyword',
+        kind: 'keyword',
+        array: true,
+        facetable: true,
+        output: true,
+      },
+    ],
+  },
+];
+
+// Optional: forwarded to buildGraphQLSchema (per-type options, maxPerPage, …).
+export const schemaOptions = { maxPerPage: 50 };
+
+// Optional: forwarded to createTypesenseSearchEngine (collection overrides, …).
+export const engineOptions = {};
+```
+
+Once the SHACL + `search:` generator lands
+([#495](https://github.com/ldelements/lde/issues/495)), mounted SHACL becomes
+an additional source for the same schema.
+
+## Configuration
+
+| Variable             | Default                     | Meaning                                            |
+| -------------------- | --------------------------- | -------------------------------------------------- |
+| `SCHEMA_MODULE`      | `/config/search-schema.mjs` | Path of the mounted schema-declaration module      |
+| `PORT`               | `4000`                      | TCP port the server binds                          |
+| `GRAPHQL_ENDPOINT`   | `/graphql`                  | Path serving GraphQL, the playground and the SDL   |
+| `PLAYGROUND`         | `true`                      | Serve the playground on GET (`false`/`0` disables) |
+| `MAX_DEPTH`          | handler default (15)        | Query depth cap                                    |
+| `MAX_COST`           | handler default (5000)      | Query cost cap                                     |
+| `TYPESENSE_HOST`     | **required**                | Typesense host                                     |
+| `TYPESENSE_PORT`     | `8108`                      | Typesense port                                     |
+| `TYPESENSE_PROTOCOL` | `http`                      | `http` or `https`                                  |
+| `TYPESENSE_API_KEY`  | **required**                | Use a search-only key: the server only ever reads  |
+
+A misconfigured boot reports **all** problems in one error, not one per crash
+loop.
+
+## Endpoints
+
+- `POST /graphql` – GraphQL execution.
+- `GET /graphql` – the self-contained playground (no external CDN, no framing
+  headers, so a docs site can `<iframe>` it as a live client).
+- `GET /graphql?sdl` – the printed SDL: the contract without a running
+  introspection query.
+- `GET /health` – liveness; the Docker image’s `HEALTHCHECK` uses it.
+- `GET /` – redirects to the endpoint.
+
+## Building the image
+
+The image is built from the workspace’s own outputs – the compiled package,
+the same-commit builds of its `@lde/*` dependencies and a pruned lockfile –
+never from npm, so it exists for any commit
+([ADR 15](../../docs/decisions/0015-ship-the-served-search-api-as-a-docker-image-built-from-the-workspace.md)):
+
+```sh
+npx nx run @lde/search-api-server:docker:build   # → packages-search-api-server
+npx nx run @lde/search-api-server:docker:smoke   # boots it and probes /health + ?sdl
+```
+
+CI runs `docker:smoke` for affected PRs; each release tag rebuilds and pushes
+`ghcr.io/ldelements/search-api-server:<version>` (`.github/workflows/docker.yml`).
+
+## Programmatic use
+
+The bin is a thin wrapper over the exported API, usable in tests or a custom
+boot:
+
+```ts
+import {
+  configFromEnvironment,
+  createSearchApiServer,
+} from '@lde/search-api-server';
+
+const server = await createSearchApiServer(configFromEnvironment(process.env));
+const port = await server.start();
+```

--- a/packages/search-api-server/eslint.config.mjs
+++ b/packages/search-api-server/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/packages/search-api-server/package.json
+++ b/packages/search-api-server/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@lde/search-api-server",
+  "version": "0.0.0",
+  "description": "The served @lde/search API as a bootable process and prebuilt Docker image: loads a mounted schema-declaration module and Typesense connection details from the environment, then serves /graphql (execution, playground, SDL) plus /health over node:http. The composition layer that binds the engine-agnostic @lde/search-api-graphql handler to @lde/search-typesense – for turnkey, non-JS and ops-driven deployments.",
+  "repository": {
+    "url": "git+https://github.com/ldelements/lde.git",
+    "directory": "packages/search-api-server"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "search-api-server": "dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@lde/search": "^0.12.0",
+    "@lde/search-api-graphql": "^0.12.0",
+    "@lde/search-typesense": "^0.15.0",
+    "@whatwg-node/server": "^0.11.0",
+    "tslib": "^2.3.0",
+    "typesense": "^3.0.6"
+  },
+  "nx": {
+    "targets": {
+      "docker:stage": {
+        "options": {
+          "cwd": "{projectRoot}",
+          "command": "rm -rf dist-docker && mkdir dist-docker && cp package.json dist-docker/ && cp -R dist dist-docker/dist"
+        }
+      },
+      "copy-workspace-modules": {},
+      "prune-lockfile": {},
+      "docker:lockfile": {},
+      "docker:smoke": {
+        "executor": "nx:run-commands",
+        "dependsOn": [
+          "docker:build"
+        ],
+        "cache": false,
+        "options": {
+          "command": "./tools/docker-smoke.sh packages-search-api-server"
+        }
+      }
+    }
+  }
+}

--- a/packages/search-api-server/src/cli.ts
+++ b/packages/search-api-server/src/cli.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { configFromEnvironment } from './config.js';
+import { createSearchApiServer } from './server.js';
+
+const { version } = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { version: string };
+
+try {
+  const config = configFromEnvironment(process.env);
+  const server = await createSearchApiServer(config);
+  const port = await server.start();
+  console.info(
+    `@lde/search-api-server ${version} serving ${config.graphqlEndpoint} on port ${port}.`,
+  );
+  const shutdown = (signal: string): void => {
+    console.info(`Received ${signal}; shutting down.`);
+    void server.stop().then(() => process.exit(0));
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/packages/search-api-server/src/config.ts
+++ b/packages/search-api-server/src/config.ts
@@ -1,0 +1,101 @@
+/**
+ * The server’s complete runtime configuration, read from environment
+ * variables ({@link configFromEnvironment}) – the contract of the Docker
+ * image. Everything engine- or schema-shaped (query defaults, collection
+ * overrides, per-type GraphQL options) lives in the mounted schema module
+ * instead, next to the declarations it configures.
+ */
+export interface ServerConfig {
+  /** Path of the mounted schema-declaration module (`SCHEMA_MODULE`). */
+  readonly schemaModulePath: string;
+  /** TCP port the HTTP server binds (`PORT`). */
+  readonly port: number;
+  /** Path serving GraphQL, the playground and the SDL (`GRAPHQL_ENDPOINT`). */
+  readonly graphqlEndpoint: string;
+  /** Serve the playground on GET requests to the endpoint (`PLAYGROUND`). */
+  readonly playground: boolean;
+  /** Query depth cap (`MAX_DEPTH`); the handler’s default when absent. */
+  readonly maxDepth?: number;
+  /** Query cost cap (`MAX_COST`); the handler’s default when absent. */
+  readonly maxCost?: number;
+  /** Where the Typesense engine reads (`TYPESENSE_*`). */
+  readonly typesense: TypesenseConnection;
+}
+
+/** Connection details of the Typesense node the engine searches. */
+export interface TypesenseConnection {
+  readonly host: string;
+  readonly port: number;
+  readonly protocol: 'http' | 'https';
+  /** Use a search-only key: the server only ever reads. */
+  readonly apiKey: string;
+}
+
+/**
+ * Read the {@link ServerConfig} from environment variables. Reports **all**
+ * problems in one error – a misconfigured deployment learns everything
+ * wrong with it from a single boot attempt, not one variable per crash loop.
+ */
+export function configFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+): ServerConfig {
+  const problems: string[] = [];
+
+  const required = (name: string): string => {
+    const value = environment[name];
+    if (value === undefined || value.length === 0) {
+      problems.push(`${name} is required`);
+      return '';
+    }
+    return value;
+  };
+  const integer = (name: string, fallback?: number): number | undefined => {
+    const value = environment[name];
+    if (value === undefined || value.length === 0) {
+      return fallback;
+    }
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      problems.push(`${name} must be a non-negative integer, got “${value}”`);
+      return fallback;
+    }
+    return parsed;
+  };
+
+  const graphqlEndpoint = environment['GRAPHQL_ENDPOINT'] ?? '/graphql';
+  if (!graphqlEndpoint.startsWith('/')) {
+    problems.push(
+      `GRAPHQL_ENDPOINT must be an absolute path, got “${graphqlEndpoint}”`,
+    );
+  }
+  const protocol = environment['TYPESENSE_PROTOCOL'] ?? 'http';
+  if (protocol !== 'http' && protocol !== 'https') {
+    problems.push(
+      `TYPESENSE_PROTOCOL must be “http” or “https”, got “${protocol}”`,
+    );
+  }
+
+  const config: ServerConfig = {
+    schemaModulePath:
+      environment['SCHEMA_MODULE'] ?? '/config/search-schema.mjs',
+    port: integer('PORT', 4000)!,
+    graphqlEndpoint,
+    playground: !['false', '0'].includes(
+      (environment['PLAYGROUND'] ?? '').toLowerCase(),
+    ),
+    maxDepth: integer('MAX_DEPTH'),
+    maxCost: integer('MAX_COST'),
+    typesense: {
+      host: required('TYPESENSE_HOST'),
+      port: integer('TYPESENSE_PORT', 8108)!,
+      protocol: protocol as 'http' | 'https',
+      apiKey: required('TYPESENSE_API_KEY'),
+    },
+  };
+  if (problems.length > 0) {
+    throw new Error(
+      `Invalid configuration:\n${problems.map((problem) => `- ${problem}`).join('\n')}`,
+    );
+  }
+  return config;
+}

--- a/packages/search-api-server/src/index.ts
+++ b/packages/search-api-server/src/index.ts
@@ -1,0 +1,10 @@
+// The bootable served search API: the composition layer binding the
+// engine-agnostic @lde/search-api-graphql handler to a Typesense engine, a
+// mounted schema-declaration module and environment config. The `search-api-server`
+// bin (src/cli.ts) and the Docker image are thin wrappers over these.
+export { createSearchApiServer } from './server.js';
+export type { SearchApiServer } from './server.js';
+export { configFromEnvironment } from './config.js';
+export type { ServerConfig, TypesenseConnection } from './config.js';
+export { loadSchemaModule } from './schema-module.js';
+export type { SchemaModule } from './schema-module.js';

--- a/packages/search-api-server/src/schema-module.ts
+++ b/packages/search-api-server/src/schema-module.ts
@@ -1,5 +1,5 @@
-import { pathToFileURL } from 'node:url';
-import { searchSchema, type SearchSchema, type SearchType } from '@lde/search';
+import { loadSchemaModule as loadDeclarations } from '@lde/search/module';
+import type { SearchSchema } from '@lde/search';
 import type { BuildGraphQLSchemaOptions } from '@lde/search-api-graphql';
 import type { TypesenseSearchEngineOptions } from '@lde/search-typesense';
 
@@ -26,48 +26,22 @@ export interface SchemaModule {
 }
 
 /**
- * Load and validate a mounted schema-declaration module: an ES module whose
- * default export is a non-empty array of {@link SearchType} declarations.
- * Throws with the module path in the message for every failure mode – an
- * unreadable file, a wrong export shape, an invalid declaration – so a bad
- * mount fails the boot with a diagnosis, never the first query.
+ * Load and validate a mounted schema-declaration module
+ * (`@lde/search/module`’s {@link loadDeclarations | loadSchemaModule} – the
+ * loader the indexer image shares, so both sides mount the same file), then
+ * validate the read side’s optional exports. Throws with the module path in
+ * the message for every failure mode, so a bad mount fails the boot with a
+ * diagnosis, never the first query.
  */
 export async function loadSchemaModule(
   modulePath: string,
 ): Promise<SchemaModule> {
-  let moduleExports: Record<string, unknown>;
-  try {
-    moduleExports = (await import(pathToFileURL(modulePath).href)) as Record<
-      string,
-      unknown
-    >;
-  } catch (cause) {
-    throw new Error(
-      `Cannot load schema module “${modulePath}”: ${cause instanceof Error ? cause.message : String(cause)}`,
-      { cause },
-    );
-  }
-  const declarations = moduleExports['default'];
-  if (!Array.isArray(declarations) || declarations.length === 0) {
-    throw new Error(
-      `Schema module “${modulePath}” must default-export a non-empty array of search type declarations.`,
-    );
-  }
-  try {
-    return {
-      searchSchema: searchSchema(...(declarations as SearchType[])),
-      schemaOptions: optionalObject(moduleExports, 'schemaOptions', modulePath),
-      engineOptions: optionalObject(moduleExports, 'engineOptions', modulePath),
-    };
-  } catch (cause) {
-    if (cause instanceof Error && cause.message.includes(modulePath)) {
-      throw cause;
-    }
-    throw new Error(
-      `Schema module “${modulePath}” declares an invalid schema: ${cause instanceof Error ? cause.message : String(cause)}`,
-      { cause },
-    );
-  }
+  const { schema, moduleExports } = await loadDeclarations(modulePath);
+  return {
+    searchSchema: schema,
+    schemaOptions: optionalObject(moduleExports, 'schemaOptions', modulePath),
+    engineOptions: optionalObject(moduleExports, 'engineOptions', modulePath),
+  };
 }
 
 function optionalObject<Options>(

--- a/packages/search-api-server/src/schema-module.ts
+++ b/packages/search-api-server/src/schema-module.ts
@@ -1,0 +1,88 @@
+import { pathToFileURL } from 'node:url';
+import { searchSchema, type SearchSchema, type SearchType } from '@lde/search';
+import type { BuildGraphQLSchemaOptions } from '@lde/search-api-graphql';
+import type { TypesenseSearchEngineOptions } from '@lde/search-typesense';
+
+/**
+ * What the mounted module declares: the deployment’s whole search
+ * declaration, plus the schema- and engine-shaped options that belong next to
+ * it. The module is **plain data with optional functions** (`derive`,
+ * `transform`) – it cannot `import '@lde/search'` (bare specifiers do not
+ * resolve from a mounted file), and does not need to: the declarations are
+ * validated here, the way a SHACL generator’s output would be. Once the
+ * SHACL + `search:` generator exists
+ * ([#495](https://github.com/ldelements/lde/issues/495)), a SHACL mount
+ * becomes an additional source for the same result.
+ */
+export interface SchemaModule {
+  /** The validated schema built from the module’s default export. */
+  readonly searchSchema: SearchSchema;
+  /** The module’s optional `schemaOptions` export, forwarded to
+   *  `buildGraphQLSchema` (per-type options, language order, `maxPerPage`). */
+  readonly schemaOptions?: BuildGraphQLSchemaOptions;
+  /** The module’s optional `engineOptions` export, forwarded to
+   *  `createTypesenseSearchEngine` (collection overrides, query knobs). */
+  readonly engineOptions?: TypesenseSearchEngineOptions;
+}
+
+/**
+ * Load and validate a mounted schema-declaration module: an ES module whose
+ * default export is a non-empty array of {@link SearchType} declarations.
+ * Throws with the module path in the message for every failure mode – an
+ * unreadable file, a wrong export shape, an invalid declaration – so a bad
+ * mount fails the boot with a diagnosis, never the first query.
+ */
+export async function loadSchemaModule(
+  modulePath: string,
+): Promise<SchemaModule> {
+  let moduleExports: Record<string, unknown>;
+  try {
+    moduleExports = (await import(pathToFileURL(modulePath).href)) as Record<
+      string,
+      unknown
+    >;
+  } catch (cause) {
+    throw new Error(
+      `Cannot load schema module “${modulePath}”: ${cause instanceof Error ? cause.message : String(cause)}`,
+      { cause },
+    );
+  }
+  const declarations = moduleExports['default'];
+  if (!Array.isArray(declarations) || declarations.length === 0) {
+    throw new Error(
+      `Schema module “${modulePath}” must default-export a non-empty array of search type declarations.`,
+    );
+  }
+  try {
+    return {
+      searchSchema: searchSchema(...(declarations as SearchType[])),
+      schemaOptions: optionalObject(moduleExports, 'schemaOptions', modulePath),
+      engineOptions: optionalObject(moduleExports, 'engineOptions', modulePath),
+    };
+  } catch (cause) {
+    if (cause instanceof Error && cause.message.includes(modulePath)) {
+      throw cause;
+    }
+    throw new Error(
+      `Schema module “${modulePath}” declares an invalid schema: ${cause instanceof Error ? cause.message : String(cause)}`,
+      { cause },
+    );
+  }
+}
+
+function optionalObject<Options>(
+  moduleExports: Record<string, unknown>,
+  name: string,
+  modulePath: string,
+): Options | undefined {
+  const value = moduleExports[name];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(
+      `Schema module “${modulePath}” export “${name}” must be an object.`,
+    );
+  }
+  return value as Options;
+}

--- a/packages/search-api-server/src/server.ts
+++ b/packages/search-api-server/src/server.ts
@@ -1,0 +1,91 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { createServerAdapter } from '@whatwg-node/server';
+import { Client } from 'typesense';
+import { createSearchGraphQLHandler } from '@lde/search-api-graphql';
+import { createTypesenseSearchEngine } from '@lde/search-typesense';
+import type { ServerConfig } from './config.js';
+import { loadSchemaModule } from './schema-module.js';
+
+/** The bootable server: construct with {@link createSearchApiServer}. */
+export interface SearchApiServer {
+  /** Start listening on the configured port; resolves with the bound port
+   *  (useful with `port: 0`, which binds an ephemeral one). */
+  start(): Promise<number>;
+  /** Stop accepting connections and close the server. */
+  stop(): Promise<void>;
+}
+
+/**
+ * Compose the served search API from a {@link ServerConfig}: load and
+ * validate the mounted schema module, bind the Typesense engine, build the
+ * GraphQL handler, and wrap it all in a `node:http` server that also answers
+ * `GET /health` (liveness) and redirects `/` to the endpoint. Every
+ * misconfiguration – an invalid schema, an underivable collection name
+ * – throws here, at boot, never on the first query.
+ */
+export async function createSearchApiServer(
+  config: ServerConfig,
+): Promise<SearchApiServer> {
+  const { searchSchema, schemaOptions, engineOptions } = await loadSchemaModule(
+    config.schemaModulePath,
+  );
+  const client = new Client({
+    nodes: [
+      {
+        host: config.typesense.host,
+        port: config.typesense.port,
+        protocol: config.typesense.protocol,
+      },
+    ],
+    apiKey: config.typesense.apiKey,
+  });
+  const engine = createTypesenseSearchEngine(
+    client,
+    searchSchema,
+    engineOptions,
+  );
+  const graphql = createSearchGraphQLHandler({
+    searchSchema,
+    engine,
+    schemaOptions,
+    graphqlEndpoint: config.graphqlEndpoint,
+    playground: config.playground,
+    maxDepth: config.maxDepth,
+    maxCost: config.maxCost,
+  });
+
+  const adapter = createServerAdapter(
+    (request: Request): Response | Promise<Response> => {
+      const url = new URL(request.url);
+      if (url.pathname === '/health') {
+        return Response.json({ status: 'ok' });
+      }
+      if (url.pathname === '/') {
+        return Response.redirect(
+          new URL(config.graphqlEndpoint, url.origin).href,
+          302,
+        );
+      }
+      return graphql(request);
+    },
+  );
+  const server: Server = createServer(adapter);
+
+  return {
+    start: () =>
+      new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(config.port, () => {
+          resolve((server.address() as AddressInfo).port);
+        });
+      }),
+    stop: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        // In-flight requests finish; idle keep-alive sockets would otherwise
+        // hold the close (and a rolling restart) open indefinitely.
+        server.closeIdleConnections();
+      }),
+  };
+}

--- a/packages/search-api-server/test/config.test.ts
+++ b/packages/search-api-server/test/config.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { configFromEnvironment } from '../src/config.js';
+
+const minimal = {
+  TYPESENSE_HOST: 'typesense.internal',
+  TYPESENSE_API_KEY: 'search-only-key',
+};
+
+describe('configFromEnvironment', () => {
+  it('applies defaults with only the required variables set', () => {
+    const config = configFromEnvironment(minimal);
+    expect(config).toEqual({
+      schemaModulePath: '/config/search-schema.mjs',
+      port: 4000,
+      graphqlEndpoint: '/graphql',
+      playground: true,
+      maxDepth: undefined,
+      maxCost: undefined,
+      typesense: {
+        host: 'typesense.internal',
+        port: 8108,
+        protocol: 'http',
+        apiKey: 'search-only-key',
+      },
+    });
+  });
+
+  it('reads every override', () => {
+    const config = configFromEnvironment({
+      ...minimal,
+      SCHEMA_MODULE: '/mnt/schema.mjs',
+      PORT: '8080',
+      GRAPHQL_ENDPOINT: '/api/graphql',
+      PLAYGROUND: 'false',
+      MAX_DEPTH: '10',
+      MAX_COST: '1000',
+      TYPESENSE_PORT: '443',
+      TYPESENSE_PROTOCOL: 'https',
+    });
+    expect(config).toEqual({
+      schemaModulePath: '/mnt/schema.mjs',
+      port: 8080,
+      graphqlEndpoint: '/api/graphql',
+      playground: false,
+      maxDepth: 10,
+      maxCost: 1000,
+      typesense: {
+        host: 'typesense.internal',
+        port: 443,
+        protocol: 'https',
+        apiKey: 'search-only-key',
+      },
+    });
+  });
+
+  it('reports all problems in one error', () => {
+    let message = '';
+    try {
+      configFromEnvironment({ PORT: 'eighty', TYPESENSE_PROTOCOL: 'ftp' });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('PORT must be a non-negative integer');
+    expect(message).toContain('TYPESENSE_PROTOCOL must be “http” or “https”');
+    expect(message).toContain('TYPESENSE_HOST is required');
+    expect(message).toContain('TYPESENSE_API_KEY is required');
+  });
+
+  it('disables the playground case-insensitively', () => {
+    expect(
+      configFromEnvironment({ ...minimal, PLAYGROUND: 'FALSE' }).playground,
+    ).toBe(false);
+  });
+
+  it('rejects a relative GraphQL endpoint', () => {
+    expect(() =>
+      configFromEnvironment({ ...minimal, GRAPHQL_ENDPOINT: 'graphql' }),
+    ).toThrowError(/GRAPHQL_ENDPOINT must be an absolute path/);
+  });
+
+  it('treats an empty required variable as missing', () => {
+    expect(() =>
+      configFromEnvironment({ ...minimal, TYPESENSE_API_KEY: '' }),
+    ).toThrowError(/TYPESENSE_API_KEY is required/);
+  });
+});

--- a/packages/search-api-server/test/fixtures/invalid-declaration.mjs
+++ b/packages/search-api-server/test/fixtures/invalid-declaration.mjs
@@ -1,0 +1,7 @@
+export default [
+  {
+    name: 'Broken',
+    class: 'http://example.com/Broken',
+    fields: [{ name: 'field', kind: 'no-such-kind' }],
+  },
+];

--- a/packages/search-api-server/test/fixtures/invalid-options.mjs
+++ b/packages/search-api-server/test/fixtures/invalid-options.mjs
@@ -1,0 +1,12 @@
+export default [
+  {
+    name: 'Dataset',
+    class: 'http://www.w3.org/ns/dcat#Dataset',
+    fields: [
+      { name: 'title', kind: 'text', locales: ['en'], output: true },
+    ],
+  },
+];
+
+// Not an object: rejected at boot.
+export const schemaOptions = 'nope';

--- a/packages/search-api-server/test/fixtures/not-an-array.mjs
+++ b/packages/search-api-server/test/fixtures/not-an-array.mjs
@@ -1,0 +1,1 @@
+export default { not: 'an array' };

--- a/packages/search-api-server/test/fixtures/search-schema.mjs
+++ b/packages/search-api-server/test/fixtures/search-schema.mjs
@@ -1,0 +1,29 @@
+/**
+ * A minimal schema-declaration module, shaped exactly as a deployment mounts
+ * it into the image: plain data, no imports.
+ */
+export default [
+  {
+    name: 'Dataset',
+    class: 'http://www.w3.org/ns/dcat#Dataset',
+    fields: [
+      {
+        name: 'title',
+        kind: 'text',
+        locales: ['nl', 'en'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+      {
+        name: 'keyword',
+        kind: 'keyword',
+        array: true,
+        facetable: true,
+        filterable: true,
+        output: true,
+      },
+    ],
+  },
+];
+
+export const schemaOptions = { maxPerPage: 50 };

--- a/packages/search-api-server/test/schema-module.test.ts
+++ b/packages/search-api-server/test/schema-module.test.ts
@@ -33,4 +33,10 @@ describe('loadSchemaModule', () => {
       loadSchemaModule(fixture('invalid-declaration.mjs')),
     ).rejects.toThrowError(/declares an invalid schema/);
   });
+
+  it('rejects a non-object optional export, naming it', async () => {
+    await expect(
+      loadSchemaModule(fixture('invalid-options.mjs')),
+    ).rejects.toThrowError(/export “schemaOptions” must be an object/);
+  });
 });

--- a/packages/search-api-server/test/schema-module.test.ts
+++ b/packages/search-api-server/test/schema-module.test.ts
@@ -1,0 +1,36 @@
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { loadSchemaModule } from '../src/schema-module.js';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url));
+
+describe('loadSchemaModule', () => {
+  it('builds the validated schema from the default export', async () => {
+    const { searchSchema, schemaOptions, engineOptions } =
+      await loadSchemaModule(fixture('search-schema.mjs'));
+    const types = [...searchSchema.values()];
+    expect(types).toHaveLength(1);
+    expect(types[0]!.name).toBe('Dataset');
+    expect(schemaOptions).toEqual({ maxPerPage: 50 });
+    expect(engineOptions).toBeUndefined();
+  });
+
+  it('rejects a missing file, naming the path', async () => {
+    await expect(loadSchemaModule('/no/such/module.mjs')).rejects.toThrowError(
+      /Cannot load schema module “\/no\/such\/module\.mjs”/,
+    );
+  });
+
+  it('rejects a default export that is not an array', async () => {
+    await expect(
+      loadSchemaModule(fixture('not-an-array.mjs')),
+    ).rejects.toThrowError(/must default-export a non-empty array/);
+  });
+
+  it('rejects invalid declarations with the validation diagnosis', async () => {
+    await expect(
+      loadSchemaModule(fixture('invalid-declaration.mjs')),
+    ).rejects.toThrowError(/declares an invalid schema/);
+  });
+});

--- a/packages/search-api-server/test/server.test.ts
+++ b/packages/search-api-server/test/server.test.ts
@@ -1,0 +1,89 @@
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createSearchApiServer, type SearchApiServer } from '../src/server.js';
+import type { ServerConfig } from '../src/config.js';
+
+const config: ServerConfig = {
+  schemaModulePath: fileURLToPath(
+    new URL('./fixtures/search-schema.mjs', import.meta.url),
+  ),
+  port: 0,
+  graphqlEndpoint: '/graphql',
+  playground: true,
+  // The engine is constructed but never searched in these tests, so the
+  // Typesense connection points nowhere.
+  typesense: { host: 'localhost', port: 1, protocol: 'http', apiKey: 'none' },
+};
+
+let server: SearchApiServer;
+let baseUrl: string;
+
+async function boot(overrides: Partial<ServerConfig> = {}): Promise<void> {
+  server = await createSearchApiServer({ ...config, ...overrides });
+  const port = await server.start();
+  baseUrl = `http://localhost:${port}`;
+}
+
+afterEach(() => server.stop());
+
+describe('createSearchApiServer', () => {
+  it('answers the liveness endpoint', async () => {
+    await boot();
+    const response = await fetch(`${baseUrl}/health`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ok' });
+  });
+
+  it('serves the SDL without a running introspection query', async () => {
+    await boot();
+    const response = await fetch(`${baseUrl}/graphql?sdl`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('datasets');
+  });
+
+  it('serves the self-contained playground on GET', async () => {
+    await boot();
+    const response = await fetch(`${baseUrl}/graphql`, {
+      headers: { accept: 'text/html' },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    // Consume the (large) page, releasing the connection before stop().
+    expect(await response.text()).toContain('graphiql');
+  });
+
+  it('executes GraphQL over POST', async () => {
+    await boot();
+    const response = await fetch(`${baseUrl}/graphql`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: '{ __schema { queryType { name } } }' }),
+    });
+    expect(response.status).toBe(200);
+    const { data, errors } = (await response.json()) as {
+      data: { __schema: { queryType: { name: string } } };
+      errors?: unknown;
+    };
+    expect(errors).toBeUndefined();
+    expect(data.__schema.queryType.name).toBe('Query');
+  });
+
+  it('redirects the root to the endpoint', async () => {
+    await boot();
+    const response = await fetch(baseUrl, { redirect: 'manual' });
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(`${baseUrl}/graphql`);
+  });
+
+  it('answers unknown paths with 404', async () => {
+    await boot();
+    const response = await fetch(`${baseUrl}/nope`);
+    expect(response.status).toBe(404);
+  });
+
+  it('serves a custom endpoint path', async () => {
+    await boot({ graphqlEndpoint: '/api/graphql' });
+    const response = await fetch(`${baseUrl}/api/graphql?sdl`);
+    expect(response.status).toBe(200);
+  });
+});

--- a/packages/search-api-server/tsconfig.json
+++ b/packages/search-api-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  }
+}

--- a/packages/search-api-server/tsconfig.lib.json
+++ b/packages/search-api-server/tsconfig.lib.json
@@ -1,0 +1,37 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "types": ["node"],
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../search/tsconfig.lib.json"
+    },
+    {
+      "path": "../search-api-graphql/tsconfig.lib.json"
+    },
+    {
+      "path": "../search-typesense/tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx",
+    "test/**/*.test.js",
+    "test/**/*.spec.js",
+    "test/**/*.test.jsx",
+    "test/**/*.spec.jsx"
+  ]
+}

--- a/packages/search-api-server/tsconfig.spec.json
+++ b/packages/search-api-server/tsconfig.spec.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "types": ["node"],
+    "ignoreDeprecations": "6.0",
+    "rootDir": "."
+  },
+  "include": [
+    "vitest.config.ts",
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx",
+    "test/**/*.test.js",
+    "test/**/*.spec.js",
+    "test/**/*.test.jsx",
+    "test/**/*.spec.jsx",
+    "test/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/search-api-server/vite.config.ts
+++ b/packages/search-api-server/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vite.base.config.js';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    root: __dirname,
+    cacheDir: '../../node_modules/.vite/packages/search-api-server',
+    resolve: {
+      // graphql ships both CJS and ESM builds without an `exports` map. Vite
+      // transforms our sources against the ESM build while the externalized
+      // graphql-yoga loads the CJS build in Node, and graphql rejects schemas
+      // crossing the two realms. Pin every import to the CJS build that Node
+      // resolves, so tests exercise one graphql instance.
+      alias: { graphql: 'graphql/index.js' },
+    },
+    test: {
+      coverage: {
+        exclude: ['src/cli.ts'],
+        thresholds: {
+          autoUpdate: true,
+          functions: 100,
+          lines: 96.92,
+          branches: 90.56,
+          statements: 96.96,
+        },
+      },
+    },
+  }),
+);

--- a/packages/search-api-server/vite.config.ts
+++ b/packages/search-api-server/vite.config.ts
@@ -20,9 +20,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 100,
-          lines: 96.92,
-          branches: 90.56,
-          statements: 96.96,
+          lines: 100,
+          branches: 97.56,
+          statements: 100,
         },
       },
     },

--- a/packages/search-indexer/Dockerfile
+++ b/packages/search-indexer/Dockerfile
@@ -1,0 +1,29 @@
+# The prebuilt search indexer (https://github.com/ldelements/lde/issues/652,
+# the write-path counterpart of the search-api-server image), built from this
+# workspace’s own outputs: `nx run @lde/search-indexer:docker:build` stages the
+# compiled package, the same-commit builds of its @lde/* workspace dependencies
+# (copy-workspace-modules) and a pruned lockfile (prune-lockfile) into
+# dist-docker/, so the image never waits on – or drifts from – an npm publish.
+# CI smoke-tests the running image (docker:smoke); releases push it to
+# ghcr.io/ldelements/search-indexer (.github/workflows/docker.yml).
+FROM node:24-alpine
+LABEL org.opencontainers.image.source="https://github.com/ldelements/lde"
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY dist-docker/package.json dist-docker/package-lock.json ./
+# --legacy-peer-deps: must match the flag the docker:lockfile repair step
+# installs with, or `npm ci` rejects the lockfile over peers that step left
+# out (typesense declares a `@babel/runtime` peer no runtime import needs).
+# The docker:smoke boot test guards that nothing genuinely needed is missing.
+RUN npm ci --omit=dev --legacy-peer-deps
+# Lays the same-commit workspace modules over the registry-installed tree.
+COPY dist-docker/ ./
+
+# Default DATA_DIR for the QLever import path; a real deployment mounts a
+# volume here (and the same host path into the sibling QLever container).
+RUN mkdir -p /data && chown node:node /data
+
+USER node
+CMD ["node", "dist/cli.js"]

--- a/packages/search-indexer/README.md
+++ b/packages/search-indexer/README.md
@@ -1,0 +1,133 @@
+# @lde/search-indexer
+
+The [@lde/search-pipeline](../search-pipeline) indexer as a bootable process
+and prebuilt Docker image: mount a schema-declaration module, point it at a
+dataset registry and Typesense, and one run selects the datasets, extracts and
+projects each root type per the schema, and rebuilds the engine collections –
+then exits. Run it as a cron job; the rebuild writers’ cross-pod lock makes an
+overlapping run fail fast instead of corrupting a collection.
+
+This is the write-path counterpart of
+[`@lde/search-api-server`](../search-api-server)
+([#652](https://github.com/ldelements/lde/issues/652)): the composition layer
+that binds the engine-agnostic `searchIndexerPipeline` to the
+[`@lde/search-typesense`](../search-typesense) rebuild writers. Mount the
+**same schema module** into both images and point both at the same
+`TYPESENSE_*` coordinates, and the write and the read side cannot disagree
+about the schema. A deployment that needs more – a bespoke root selector,
+per-stage tuning, another engine – composes `searchStages`,
+`searchIndexWriter` and `Pipeline` directly instead.
+
+## Run
+
+```sh
+docker run --rm \
+  --volume ./search-schema.mjs:/config/search-schema.mjs:ro \
+  --env REGISTRY_ENDPOINT=https://registry.example.org/sparql \
+  --env TYPESENSE_HOST=typesense.internal \
+  --env TYPESENSE_API_KEY=admin-key \
+  ghcr.io/ldelements/search-indexer
+```
+
+Or without Docker (the same environment variables apply):
+
+```sh
+npx @lde/search-indexer
+```
+
+Dataset IRIs can also be passed as arguments, which override `DATASETS`:
+
+```sh
+npx @lde/search-indexer https://example.org/id/dataset/1
+```
+
+`--check` validates the configuration and schema module, then exits without
+indexing – for CI and init containers.
+
+## The schema module
+
+The mounted module default-exports the deployment’s search type declarations
+as **plain data** – see [the API server’s
+README](../search-api-server/README.md#the-schema-module) for the format and
+authoring guidance; both images load the module with the same
+`@lde/search/module` loader. The indexer reads only the default export: the
+declarations drive one pipeline stage and one engine collection per root type,
+and each field’s `path` drives the extraction CONSTRUCT. The read-side extras
+(`schemaOptions`, `engineOptions`) are ignored here, so one file serves both
+images.
+
+## Configuration
+
+| Variable             | Default                     | Meaning                                                                      |
+| -------------------- | --------------------------- | ---------------------------------------------------------------------------- |
+| `SCHEMA_MODULE`      | `/config/search-schema.mjs` | Path of the mounted schema-declaration module                                |
+| `REGISTRY_ENDPOINT`  | **required**                | SPARQL endpoint of the DCAT dataset registry                                 |
+| `DATASETS`           | all registry datasets       | Dataset IRIs to index (whitespace- or comma-separated)                       |
+| `DATASET_CRITERIA`   | all registry datasets       | Registry search criteria as a JSON object (mutually exclusive w/ `DATASETS`) |
+| `TYPESENSE_HOST`     | **required**                | Typesense host                                                               |
+| `TYPESENSE_PORT`     | `8108`                      | Typesense port                                                               |
+| `TYPESENSE_PROTOCOL` | `http`                      | `http` or `https`                                                            |
+| `TYPESENSE_API_KEY`  | **required**                | An admin key: the indexer creates, writes and swaps collections              |
+| `REBUILD_MODE`       | `in-place`                  | `in-place` (update the live collection) or `blue-green` (swap on commit)     |
+| `COLLECTION_PREFIX`  | none                        | Prefix for every derived collection name (configure the read side to match)  |
+| `PROVENANCE_FILE`    | none                        | JSON file remembering per-dataset processing, to skip unchanged datasets     |
+| `PIPELINE_VERSION`   | none                        | Version keying the skip decisions; required with `PROVENANCE_FILE`           |
+| `QLEVER_IMAGE`       | none                        | Enables the QLever import path (see below), e.g. `adfreiburg/qlever:latest`  |
+| `IMPORT_STRATEGY`    | `sparql`                    | `sparql`, `sparqlWithImportFallback` or `import`; requires `QLEVER_IMAGE`    |
+| `DATA_DIR`           | `/data`                     | Directory for downloaded dumps and QLever index caches                       |
+
+A misconfigured boot reports **all** problems in one error, not one per crash
+loop. `PROVENANCE_FILE` must sit on a durable volume, and cannot be combined
+with `REBUILD_MODE=blue-green`: a skipped dataset would be missing from the
+fresh collection the swap makes live.
+
+## The QLever import path
+
+By default the indexer serves only datasets that publish a live SPARQL
+endpoint (the pipeline’s endpoint-only default). Setting `QLEVER_IMAGE`
+enables the import path: data dumps are downloaded to `DATA_DIR` and imported
+into a QLever instance the **pipeline itself creates and controls** – one
+sibling container per dataset, spawned over the Docker socket
+([ADR 16](../../docs/decisions/0016-ship-the-search-indexer-as-a-config-driven-image.md)
+explains why a statically-declared QLever service cannot work). That requires:
+
+- the Docker socket mounted into the indexer container
+  (`--volume /var/run/docker.sock:/var/run/docker.sock`), plus a group grant
+  to reach it as the image’s non-root user
+  (`--group-add $(stat -c %g /var/run/docker.sock)`);
+- `DATA_DIR` on a volume whose **host path is identical** for the indexer and
+  the spawned QLever containers – the pipeline passes `DATA_DIR` as a bind
+  mount to a sibling container, where it resolves against the host.
+
+This mode does not work on container runtimes without a Docker socket
+(containerd-based Kubernetes); there, run endpoint-only for now.
+
+## Building the image
+
+The image is built from the workspace’s own outputs – the compiled package,
+the same-commit builds of its `@lde/*` dependencies and a pruned lockfile –
+never from npm, so it exists for any commit
+([ADR 15](../../docs/decisions/0015-ship-the-served-search-api-as-a-docker-image-built-from-the-workspace.md)):
+
+```sh
+npx nx run @lde/search-indexer:docker:build   # → packages-search-indexer
+npx nx run @lde/search-indexer:docker:smoke   # boots it with --check
+```
+
+CI runs `docker:smoke` for affected PRs; each release tag rebuilds and pushes
+`ghcr.io/ldelements/search-indexer:<version>` (`.github/workflows/docker.yml`).
+
+## Programmatic use
+
+The bin is a thin wrapper over the exported API, usable in tests or a custom
+boot:
+
+```ts
+import {
+  configFromEnvironment,
+  createSearchIndexer,
+} from '@lde/search-indexer';
+
+const pipeline = await createSearchIndexer(configFromEnvironment(process.env));
+await pipeline.run();
+```

--- a/packages/search-indexer/eslint.config.mjs
+++ b/packages/search-indexer/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/packages/search-indexer/package.json
+++ b/packages/search-indexer/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@lde/search-indexer",
+  "version": "0.0.0",
+  "description": "The @lde/search-pipeline indexer as a bootable process and prebuilt Docker image: loads a mounted schema-declaration module, dataset selection, Typesense connection and rebuild mode from the environment, then runs the object-grain searchIndexerPipeline once to completion. The composition layer that binds the engine-agnostic @lde/search-pipeline stages to @lde/search-typesense – the write-path counterpart of @lde/search-api-server.",
+  "repository": {
+    "url": "git+https://github.com/ldelements/lde.git",
+    "directory": "packages/search-indexer"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "search-indexer": "dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@lde/dataset-registry-client": "^0.9.0",
+    "@lde/pipeline": "^0.35.1",
+    "@lde/pipeline-console-reporter": "^0.26.1",
+    "@lde/search": "^0.12.1",
+    "@lde/search-pipeline": "^0.12.2",
+    "@lde/search-typesense": "^0.15.2",
+    "@lde/sparql-qlever": "^0.15.1",
+    "commander": "^15.0.0",
+    "tslib": "^2.3.0",
+    "typesense": "^3.0.6"
+  },
+  "nx": {
+    "targets": {
+      "docker:stage": {
+        "options": {
+          "cwd": "{projectRoot}",
+          "command": "rm -rf dist-docker && mkdir dist-docker && cp package.json dist-docker/ && cp -R dist dist-docker/dist"
+        }
+      },
+      "copy-workspace-modules": {},
+      "prune-lockfile": {},
+      "docker:lockfile": {},
+      "docker:smoke": {
+        "executor": "nx:run-commands",
+        "dependsOn": [
+          "docker:build"
+        ],
+        "cache": false,
+        "options": {
+          "command": "./tools/docker-smoke-indexer.sh packages-search-indexer"
+        }
+      }
+    }
+  }
+}

--- a/packages/search-indexer/src/cli.ts
+++ b/packages/search-indexer/src/cli.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { Command } from 'commander';
+import { configFromEnvironment } from './config.js';
+import { createSearchIndexer } from './indexer.js';
+
+const { version } = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { version: string };
+
+const program = new Command()
+  .name('search-indexer')
+  .description(
+    'Run the object-grain search indexer: select datasets, extract and project each root type per the mounted schema module, and rebuild the Typesense collections. Configuration comes from environment variables; see the README.',
+  )
+  .version(version)
+  .argument(
+    '[datasets...]',
+    'dataset IRIs to index (overrides the DATASETS environment variable)',
+  )
+  .option(
+    '--check',
+    'validate the configuration and schema module, then exit without indexing',
+  );
+
+program.parse();
+
+try {
+  const datasets = program.args;
+  const config = configFromEnvironment(
+    datasets.length > 0
+      ? { ...process.env, DATASETS: datasets.join(' ') }
+      : process.env,
+  );
+  const pipeline = await createSearchIndexer(config);
+  if (program.opts<{ check?: boolean }>().check) {
+    console.info(
+      `@lde/search-indexer ${version}: configuration and schema module “${config.schemaModulePath}” are valid.`,
+    );
+  } else {
+    await pipeline.run();
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/packages/search-indexer/src/composition.ts
+++ b/packages/search-indexer/src/composition.ts
@@ -1,0 +1,75 @@
+// Internal composition pieces of createSearchIndexer, split out so each can
+// be tested without running a pipeline (Pipeline keeps its wiring private).
+import { Client as RegistryClient } from '@lde/dataset-registry-client';
+import {
+  ImportResolver,
+  RegistrySelector,
+  SparqlDistributionResolver,
+  type DatasetSelector,
+  type DistributionResolver,
+  type Writer,
+} from '@lde/pipeline';
+import type { RootType, SearchDocument } from '@lde/search';
+import {
+  BlueGreenRebuild,
+  deriveCollectionName,
+  InPlaceRebuild,
+} from '@lde/search-typesense';
+import { createQlever } from '@lde/sparql-qlever';
+import type { Client } from 'typesense';
+import type { IndexerConfig } from './config.js';
+
+/** The registry-backed dataset selection the configuration describes. */
+export function datasetSelectorFrom(config: IndexerConfig): DatasetSelector {
+  return new RegistrySelector({
+    registry: new RegistryClient(config.registryEndpoint),
+    criteria: config.datasetCriteria,
+  });
+}
+
+/**
+ * The engine-writer factory the configuration describes: an
+ * {@link InPlaceRebuild} or {@link BlueGreenRebuild} per root type, its
+ * collection name derived from the type – prefixed when the deployment says
+ * so, so the read side must be configured with the same prefix.
+ */
+export function writerFactoryFrom(
+  client: Client,
+  config: IndexerConfig,
+): (searchType: RootType) => Writer<SearchDocument> {
+  return (searchType) => {
+    const options = config.collectionPrefix
+      ? {
+          name: `${config.collectionPrefix}${deriveCollectionName(searchType)}`,
+        }
+      : {};
+    return config.rebuildMode === 'blue-green'
+      ? new BlueGreenRebuild(client, searchType, options)
+      : new InPlaceRebuild(client, searchType, options);
+  };
+}
+
+/**
+ * The distribution resolver the configuration describes: with `QLEVER_IMAGE`
+ * set, an {@link ImportResolver} that imports data dumps into a
+ * pipeline-controlled QLever sibling container over the mounted Docker
+ * socket; without it, `undefined`, leaving the pipeline its endpoint-only
+ * default (a bare {@link SparqlDistributionResolver}).
+ */
+export function distributionResolverFrom(
+  config: IndexerConfig,
+): DistributionResolver | undefined {
+  if (!config.qlever) {
+    return undefined;
+  }
+  const { importer, server } = createQlever({
+    mode: 'docker',
+    image: config.qlever.image,
+    dataDir: config.qlever.dataDir,
+  });
+  return new ImportResolver(new SparqlDistributionResolver(), {
+    importer,
+    server,
+    strategy: config.qlever.strategy,
+  });
+}

--- a/packages/search-indexer/src/config.ts
+++ b/packages/search-indexer/src/config.ts
@@ -1,0 +1,260 @@
+import type { SearchCriteria } from '@lde/dataset-registry-client';
+
+/**
+ * The indexer’s complete runtime configuration, read from environment
+ * variables ({@link configFromEnvironment}) – the contract of the Docker
+ * image. Everything schema-shaped lives in the mounted schema module instead,
+ * the same file the served-API image mounts.
+ */
+export interface IndexerConfig {
+  /** Path of the mounted schema-declaration module (`SCHEMA_MODULE`). */
+  readonly schemaModulePath: string;
+  /** SPARQL endpoint of the DCAT dataset registry the selection queries
+   *  (`REGISTRY_ENDPOINT`). */
+  readonly registryEndpoint: URL;
+  /** Dataset selection within the registry: explicit IRIs (`DATASETS`),
+   *  search criteria (`DATASET_CRITERIA`), or every dataset when neither is
+   *  set. */
+  readonly datasetCriteria: SearchCriteria;
+  /** Where the Typesense engine writes (`TYPESENSE_*`). */
+  readonly typesense: TypesenseConnection;
+  /** How each type’s collection is rebuilt (`REBUILD_MODE`): update the live
+   *  collection in place, or build a fresh one and swap on commit. */
+  readonly rebuildMode: 'in-place' | 'blue-green';
+  /** Prefix prepended to every derived collection name
+   *  (`COLLECTION_PREFIX`), e.g. for a shared multi-tenant engine. */
+  readonly collectionPrefix?: string;
+  /** Per-dataset processing memory: skip unchanged datasets
+   *  (`PROVENANCE_FILE` + `PIPELINE_VERSION`). */
+  readonly provenance?: ProvenanceConfig;
+  /** The QLever import path (`QLEVER_IMAGE` + `IMPORT_STRATEGY` +
+   *  `DATA_DIR`): import data dumps into a pipeline-controlled QLever
+   *  container instead of relying on live SPARQL endpoints alone. */
+  readonly qlever?: QleverConfig;
+}
+
+/** Connection details of the Typesense node the indexer writes to. */
+export interface TypesenseConnection {
+  readonly host: string;
+  readonly port: number;
+  readonly protocol: 'http' | 'https';
+  /** An admin key: the indexer creates, writes and swaps collections. */
+  readonly apiKey: string;
+}
+
+/** File-backed provenance: both halves required, so a skip-enabled pipeline
+ *  can never run without the version that keys its skip decisions. */
+export interface ProvenanceConfig {
+  /** Path of the JSON provenance file; must sit on a durable volume. */
+  readonly path: string;
+  /** Consumer-declared version of the indexer’s output-affecting logic. */
+  readonly pipelineVersion: string;
+}
+
+/** The pipeline-controlled QLever sibling container (Docker socket mode). */
+export interface QleverConfig {
+  /** QLever Docker image to run, e.g. `adfreiburg/qlever:latest`. */
+  readonly image: string;
+  /** When to import a data dump instead of querying a live endpoint. */
+  readonly strategy: 'sparql' | 'sparqlWithImportFallback' | 'import';
+  /** Directory for downloaded dumps and QLever index caches. */
+  readonly dataDir: string;
+}
+
+const IMPORT_STRATEGIES = [
+  'sparql',
+  'sparqlWithImportFallback',
+  'import',
+] as const;
+
+/**
+ * Read the {@link IndexerConfig} from environment variables. Reports **all**
+ * problems in one error – a misconfigured deployment learns everything
+ * wrong with it from a single boot attempt, not one variable per crash loop.
+ */
+export function configFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+): IndexerConfig {
+  const problems: string[] = [];
+
+  const required = (name: string): string => {
+    const value = environment[name];
+    if (value === undefined || value.length === 0) {
+      problems.push(`${name} is required`);
+      return '';
+    }
+    return value;
+  };
+  const integer = (name: string, fallback: number): number => {
+    const value = environment[name];
+    if (value === undefined || value.length === 0) {
+      return fallback;
+    }
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      problems.push(`${name} must be a non-negative integer, got “${value}”`);
+      return fallback;
+    }
+    return parsed;
+  };
+  const url = (name: string, value: string): URL => {
+    try {
+      return new URL(value);
+    } catch {
+      // An empty value is already reported as missing by required().
+      if (value.length > 0) {
+        problems.push(`${name} must be an absolute URL, got “${value}”`);
+      }
+      return new URL('http://invalid.invalid');
+    }
+  };
+
+  const registryEndpoint = url(
+    'REGISTRY_ENDPOINT',
+    required('REGISTRY_ENDPOINT'),
+  );
+
+  const protocol = environment['TYPESENSE_PROTOCOL'] ?? 'http';
+  if (protocol !== 'http' && protocol !== 'https') {
+    problems.push(
+      `TYPESENSE_PROTOCOL must be “http” or “https”, got “${protocol}”`,
+    );
+  }
+
+  const rebuildMode = environment['REBUILD_MODE'] ?? 'in-place';
+  if (rebuildMode !== 'in-place' && rebuildMode !== 'blue-green') {
+    problems.push(
+      `REBUILD_MODE must be “in-place” or “blue-green”, got “${rebuildMode}”`,
+    );
+  }
+
+  const datasetCriteria = criteriaFromEnvironment(environment, problems);
+  const provenance = provenanceFromEnvironment(
+    environment,
+    rebuildMode,
+    problems,
+  );
+  const qlever = qleverFromEnvironment(environment, problems);
+
+  const config: IndexerConfig = {
+    schemaModulePath:
+      environment['SCHEMA_MODULE'] ?? '/config/search-schema.mjs',
+    registryEndpoint,
+    datasetCriteria,
+    typesense: {
+      host: required('TYPESENSE_HOST'),
+      port: integer('TYPESENSE_PORT', 8108),
+      protocol: protocol as 'http' | 'https',
+      apiKey: required('TYPESENSE_API_KEY'),
+    },
+    rebuildMode: rebuildMode as 'in-place' | 'blue-green',
+    collectionPrefix: environment['COLLECTION_PREFIX'],
+    provenance,
+    qlever,
+  };
+  if (problems.length > 0) {
+    throw new Error(
+      `Invalid configuration:\n${problems.map((problem) => `- ${problem}`).join('\n')}`,
+    );
+  }
+  return config;
+}
+
+/** `DATASETS` (whitespace-separated IRIs) or `DATASET_CRITERIA` (a JSON
+ *  object) – never both; neither selects the whole registry. */
+function criteriaFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+  problems: string[],
+): SearchCriteria {
+  const datasets = environment['DATASETS'];
+  const criteriaJson = environment['DATASET_CRITERIA'];
+  if (datasets && criteriaJson) {
+    problems.push(
+      'DATASETS and DATASET_CRITERIA are mutually exclusive; set at most one',
+    );
+    return {};
+  }
+  if (datasets) {
+    const iris = datasets.split(/[\s,]+/).filter((iri) => iri.length > 0);
+    for (const iri of iris) {
+      try {
+        new URL(iri);
+      } catch {
+        problems.push(`DATASETS contains “${iri}”, which is not an IRI`);
+      }
+    }
+    return { $id: iris };
+  }
+  if (criteriaJson) {
+    try {
+      const parsed: unknown = JSON.parse(criteriaJson);
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        problems.push('DATASET_CRITERIA must be a JSON object');
+        return {};
+      }
+      return parsed as SearchCriteria;
+    } catch {
+      problems.push('DATASET_CRITERIA must be valid JSON');
+      return {};
+    }
+  }
+  return {};
+}
+
+function provenanceFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+  rebuildMode: string,
+  problems: string[],
+): ProvenanceConfig | undefined {
+  const path = environment['PROVENANCE_FILE'];
+  const pipelineVersion = environment['PIPELINE_VERSION'];
+  if (!path && !pipelineVersion) {
+    return undefined;
+  }
+  if (!path || !pipelineVersion) {
+    problems.push(
+      'PROVENANCE_FILE and PIPELINE_VERSION must be set together: the version keys the skip decisions the file remembers',
+    );
+    return undefined;
+  }
+  if (rebuildMode === 'blue-green') {
+    problems.push(
+      'PROVENANCE_FILE cannot be combined with REBUILD_MODE=blue-green: a skipped dataset would be missing from the fresh collection the swap makes live',
+    );
+    return undefined;
+  }
+  return { path, pipelineVersion };
+}
+
+function qleverFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+  problems: string[],
+): QleverConfig | undefined {
+  const image = environment['QLEVER_IMAGE'];
+  const strategy = environment['IMPORT_STRATEGY'];
+  if (!image) {
+    if (strategy) {
+      problems.push(
+        'IMPORT_STRATEGY requires QLEVER_IMAGE: without an import engine there is nothing to import into',
+      );
+    }
+    return undefined;
+  }
+  if (
+    strategy !== undefined &&
+    !(IMPORT_STRATEGIES as readonly string[]).includes(strategy)
+  ) {
+    problems.push(
+      `IMPORT_STRATEGY must be one of ${IMPORT_STRATEGIES.map((name) => `“${name}”`).join(', ')}, got “${strategy}”`,
+    );
+  }
+  return {
+    image,
+    strategy: (strategy ?? 'sparql') as QleverConfig['strategy'],
+    dataDir: environment['DATA_DIR'] ?? '/data',
+  };
+}

--- a/packages/search-indexer/src/index.ts
+++ b/packages/search-indexer/src/index.ts
@@ -1,0 +1,13 @@
+// The bootable search indexer: the composition layer binding the
+// engine-agnostic @lde/search-pipeline indexer to Typesense rebuild writers,
+// a mounted schema-declaration module and environment config. The
+// `search-indexer` bin (src/cli.ts) and the Docker image are thin wrappers
+// over these.
+export { createSearchIndexer } from './indexer.js';
+export { configFromEnvironment } from './config.js';
+export type {
+  IndexerConfig,
+  ProvenanceConfig,
+  QleverConfig,
+  TypesenseConnection,
+} from './config.js';

--- a/packages/search-indexer/src/indexer.ts
+++ b/packages/search-indexer/src/indexer.ts
@@ -1,0 +1,49 @@
+import { FileProvenanceStore, type Pipeline } from '@lde/pipeline';
+import { ConsoleReporter } from '@lde/pipeline-console-reporter';
+import { loadSchemaModule } from '@lde/search/module';
+import {
+  searchIndexerPipeline,
+  type TypedSearchDocument,
+} from '@lde/search-pipeline';
+import { Client } from 'typesense';
+import {
+  datasetSelectorFrom,
+  distributionResolverFrom,
+  writerFactoryFrom,
+} from './composition.js';
+import type { IndexerConfig } from './config.js';
+
+/**
+ * Compose the ready-to-run search indexer from an {@link IndexerConfig}: load
+ * and validate the mounted schema module (the same file the served-API image
+ * mounts), select datasets from the registry, bind the Typesense rebuild
+ * writers, and wire the optional QLever import path and provenance store into
+ * `searchIndexerPipeline`. Every misconfiguration – an invalid schema, an
+ * underivable collection name – throws here, at boot, never mid-run.
+ */
+export async function createSearchIndexer(
+  config: IndexerConfig,
+): Promise<Pipeline<TypedSearchDocument>> {
+  const { schema } = await loadSchemaModule(config.schemaModulePath);
+  const client = new Client({
+    nodes: [
+      {
+        host: config.typesense.host,
+        port: config.typesense.port,
+        protocol: config.typesense.protocol,
+      },
+    ],
+    apiKey: config.typesense.apiKey,
+  });
+  return searchIndexerPipeline({
+    schema,
+    datasets: datasetSelectorFrom(config),
+    distributionResolver: distributionResolverFrom(config),
+    writerFor: writerFactoryFrom(client, config),
+    provenanceStore: config.provenance
+      ? new FileProvenanceStore({ path: config.provenance.path })
+      : undefined,
+    pipelineVersion: config.provenance?.pipelineVersion,
+    reporter: new ConsoleReporter(),
+  });
+}

--- a/packages/search-indexer/test/composition.test.ts
+++ b/packages/search-indexer/test/composition.test.ts
@@ -1,0 +1,86 @@
+import { ImportResolver, RegistrySelector } from '@lde/pipeline';
+import { searchSchema } from '@lde/search';
+import { BlueGreenRebuild, InPlaceRebuild } from '@lde/search-typesense';
+import { Client } from 'typesense';
+import { describe, expect, it } from 'vitest';
+import {
+  datasetSelectorFrom,
+  distributionResolverFrom,
+  writerFactoryFrom,
+} from '../src/composition.js';
+import { configFromEnvironment } from '../src/config.js';
+
+const minimal = {
+  REGISTRY_ENDPOINT: 'https://registry.example.org/sparql',
+  TYPESENSE_HOST: 'typesense.internal',
+  TYPESENSE_API_KEY: 'admin-key',
+};
+
+const client = new Client({
+  nodes: [{ host: 'typesense.internal', port: 8108, protocol: 'http' }],
+  apiKey: 'admin-key',
+});
+
+const schema = searchSchema({
+  name: 'Dataset',
+  class: 'http://www.w3.org/ns/dcat#Dataset',
+  fields: [{ name: 'title', kind: 'text', locales: ['en'], output: true }],
+});
+const datasetType = [...schema.values()][0]!;
+
+describe('datasetSelectorFrom', () => {
+  it('selects from the configured registry', () => {
+    const selector = datasetSelectorFrom(configFromEnvironment(minimal));
+    expect(selector).toBeInstanceOf(RegistrySelector);
+  });
+});
+
+describe('writerFactoryFrom', () => {
+  it('builds an in-place rebuild writer by default', () => {
+    const writerFor = writerFactoryFrom(client, configFromEnvironment(minimal));
+    const writer = writerFor(datasetType);
+    expect(writer).toBeInstanceOf(InPlaceRebuild);
+    expect((writer as InPlaceRebuild<never>).collectionName).toBe('datasets');
+  });
+
+  it('builds a blue-green rebuild writer when configured', () => {
+    const writerFor = writerFactoryFrom(
+      client,
+      configFromEnvironment({ ...minimal, REBUILD_MODE: 'blue-green' }),
+    );
+    const writer = writerFor(datasetType);
+    expect(writer).toBeInstanceOf(BlueGreenRebuild);
+    expect((writer as BlueGreenRebuild<never>).collectionName).toBe('datasets');
+  });
+
+  it('prefixes the derived collection name when configured', () => {
+    const writerFor = writerFactoryFrom(
+      client,
+      configFromEnvironment({ ...minimal, COLLECTION_PREFIX: 'staging_' }),
+    );
+    const writer = writerFor(datasetType);
+    expect((writer as InPlaceRebuild<never>).collectionName).toBe(
+      'staging_datasets',
+    );
+  });
+});
+
+describe('distributionResolverFrom', () => {
+  it('leaves the pipeline its endpoint-only default without QLEVER_IMAGE', () => {
+    expect(
+      distributionResolverFrom(configFromEnvironment(minimal)),
+    ).toBeUndefined();
+  });
+
+  it('builds the QLever import path when configured', () => {
+    const resolver = distributionResolverFrom(
+      configFromEnvironment({
+        ...minimal,
+        QLEVER_IMAGE: 'adfreiburg/qlever:latest',
+        IMPORT_STRATEGY: 'import',
+        DATA_DIR: '/tmp/qlever-data',
+      }),
+    );
+    expect(resolver).toBeInstanceOf(ImportResolver);
+  });
+});

--- a/packages/search-indexer/test/config.test.ts
+++ b/packages/search-indexer/test/config.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import { configFromEnvironment } from '../src/config.js';
+
+const minimal = {
+  REGISTRY_ENDPOINT: 'https://registry.example.org/sparql',
+  TYPESENSE_HOST: 'typesense.internal',
+  TYPESENSE_API_KEY: 'admin-key',
+};
+
+describe('configFromEnvironment', () => {
+  it('applies defaults with only the required variables set', () => {
+    const config = configFromEnvironment(minimal);
+    expect(config).toEqual({
+      schemaModulePath: '/config/search-schema.mjs',
+      registryEndpoint: new URL('https://registry.example.org/sparql'),
+      datasetCriteria: {},
+      typesense: {
+        host: 'typesense.internal',
+        port: 8108,
+        protocol: 'http',
+        apiKey: 'admin-key',
+      },
+      rebuildMode: 'in-place',
+      collectionPrefix: undefined,
+      provenance: undefined,
+      qlever: undefined,
+    });
+  });
+
+  it('reads every override', () => {
+    const config = configFromEnvironment({
+      ...minimal,
+      SCHEMA_MODULE: '/mnt/schema.mjs',
+      TYPESENSE_PORT: '443',
+      TYPESENSE_PROTOCOL: 'https',
+      REBUILD_MODE: 'blue-green',
+      COLLECTION_PREFIX: 'staging_',
+      QLEVER_IMAGE: 'adfreiburg/qlever:latest',
+      IMPORT_STRATEGY: 'import',
+      DATA_DIR: '/mnt/data',
+    });
+    expect(config).toEqual({
+      schemaModulePath: '/mnt/schema.mjs',
+      registryEndpoint: new URL('https://registry.example.org/sparql'),
+      datasetCriteria: {},
+      typesense: {
+        host: 'typesense.internal',
+        port: 443,
+        protocol: 'https',
+        apiKey: 'admin-key',
+      },
+      rebuildMode: 'blue-green',
+      collectionPrefix: 'staging_',
+      provenance: undefined,
+      qlever: {
+        image: 'adfreiburg/qlever:latest',
+        strategy: 'import',
+        dataDir: '/mnt/data',
+      },
+    });
+  });
+
+  it('reports all problems in one error', () => {
+    let message = '';
+    try {
+      configFromEnvironment({
+        TYPESENSE_PORT: 'eighty',
+        TYPESENSE_PROTOCOL: 'ftp',
+        REBUILD_MODE: 'green-blue',
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('REGISTRY_ENDPOINT is required');
+    expect(message).toContain('TYPESENSE_HOST is required');
+    expect(message).toContain('TYPESENSE_API_KEY is required');
+    expect(message).toContain('TYPESENSE_PORT must be a non-negative integer');
+    expect(message).toContain('TYPESENSE_PROTOCOL must be “http” or “https”');
+    expect(message).toContain(
+      'REBUILD_MODE must be “in-place” or “blue-green”',
+    );
+  });
+
+  it('rejects a malformed registry endpoint', () => {
+    expect(() =>
+      configFromEnvironment({ ...minimal, REGISTRY_ENDPOINT: 'not-a-url' }),
+    ).toThrowError(/REGISTRY_ENDPOINT must be an absolute URL/);
+  });
+
+  describe('dataset selection', () => {
+    it('turns DATASETS into $id criteria, splitting on whitespace and commas', () => {
+      const config = configFromEnvironment({
+        ...minimal,
+        DATASETS:
+          'https://example.org/dataset/1, https://example.org/dataset/2\nhttps://example.org/dataset/3',
+      });
+      expect(config.datasetCriteria).toEqual({
+        $id: [
+          'https://example.org/dataset/1',
+          'https://example.org/dataset/2',
+          'https://example.org/dataset/3',
+        ],
+      });
+    });
+
+    it('rejects a dataset entry that is not an IRI', () => {
+      expect(() =>
+        configFromEnvironment({ ...minimal, DATASETS: 'not-an-iri' }),
+      ).toThrowError(/DATASETS contains “not-an-iri”, which is not an IRI/);
+    });
+
+    it('parses DATASET_CRITERIA as a JSON object', () => {
+      const config = configFromEnvironment({
+        ...minimal,
+        DATASET_CRITERIA: '{"publisher": {"$id": "https://example.org/org"}}',
+      });
+      expect(config.datasetCriteria).toEqual({
+        publisher: { $id: 'https://example.org/org' },
+      });
+    });
+
+    it('rejects DATASET_CRITERIA that is not valid JSON', () => {
+      expect(() =>
+        configFromEnvironment({ ...minimal, DATASET_CRITERIA: '{oops' }),
+      ).toThrowError(/DATASET_CRITERIA must be valid JSON/);
+    });
+
+    it('rejects DATASET_CRITERIA that is not an object', () => {
+      expect(() =>
+        configFromEnvironment({ ...minimal, DATASET_CRITERIA: '["a"]' }),
+      ).toThrowError(/DATASET_CRITERIA must be a JSON object/);
+    });
+
+    it('rejects DATASETS combined with DATASET_CRITERIA', () => {
+      expect(() =>
+        configFromEnvironment({
+          ...minimal,
+          DATASETS: 'https://example.org/dataset/1',
+          DATASET_CRITERIA: '{}',
+        }),
+      ).toThrowError(/mutually exclusive/);
+    });
+  });
+
+  describe('provenance', () => {
+    it('requires the file and the version together', () => {
+      expect(() =>
+        configFromEnvironment({
+          ...minimal,
+          PROVENANCE_FILE: '/state/provenance.json',
+        }),
+      ).toThrowError(
+        /PROVENANCE_FILE and PIPELINE_VERSION must be set together/,
+      );
+      expect(() =>
+        configFromEnvironment({ ...minimal, PIPELINE_VERSION: '1' }),
+      ).toThrowError(
+        /PROVENANCE_FILE and PIPELINE_VERSION must be set together/,
+      );
+    });
+
+    it('reads both halves', () => {
+      const config = configFromEnvironment({
+        ...minimal,
+        PROVENANCE_FILE: '/state/provenance.json',
+        PIPELINE_VERSION: '2026-07-24',
+      });
+      expect(config.provenance).toEqual({
+        path: '/state/provenance.json',
+        pipelineVersion: '2026-07-24',
+      });
+    });
+
+    it('rejects provenance with blue-green rebuilds', () => {
+      expect(() =>
+        configFromEnvironment({
+          ...minimal,
+          REBUILD_MODE: 'blue-green',
+          PROVENANCE_FILE: '/state/provenance.json',
+          PIPELINE_VERSION: '1',
+        }),
+      ).toThrowError(/cannot be combined with REBUILD_MODE=blue-green/);
+    });
+  });
+
+  describe('QLever import', () => {
+    it('defaults to the sparql strategy and /data', () => {
+      const config = configFromEnvironment({
+        ...minimal,
+        QLEVER_IMAGE: 'adfreiburg/qlever:latest',
+      });
+      expect(config.qlever).toEqual({
+        image: 'adfreiburg/qlever:latest',
+        strategy: 'sparql',
+        dataDir: '/data',
+      });
+    });
+
+    it('rejects an unknown strategy', () => {
+      expect(() =>
+        configFromEnvironment({
+          ...minimal,
+          QLEVER_IMAGE: 'adfreiburg/qlever:latest',
+          IMPORT_STRATEGY: 'always',
+        }),
+      ).toThrowError(/IMPORT_STRATEGY must be one of/);
+    });
+
+    it('rejects a strategy without an image', () => {
+      expect(() =>
+        configFromEnvironment({ ...minimal, IMPORT_STRATEGY: 'import' }),
+      ).toThrowError(/IMPORT_STRATEGY requires QLEVER_IMAGE/);
+    });
+  });
+});

--- a/packages/search-indexer/test/fixtures/search-schema.mjs
+++ b/packages/search-indexer/test/fixtures/search-schema.mjs
@@ -1,0 +1,29 @@
+/**
+ * A minimal schema-declaration module, shaped exactly as a deployment mounts
+ * it into the image: plain data, no imports.
+ */
+export default [
+  {
+    name: 'Dataset',
+    class: 'http://www.w3.org/ns/dcat#Dataset',
+    fields: [
+      {
+        name: 'title',
+        kind: 'text',
+        path: '<http://purl.org/dc/terms/title>',
+        locales: ['nl', 'en'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+      {
+        name: 'keyword',
+        kind: 'keyword',
+        path: '<http://www.w3.org/ns/dcat#keyword>',
+        array: true,
+        facetable: true,
+        filterable: true,
+        output: true,
+      },
+    ],
+  },
+];

--- a/packages/search-indexer/test/indexer.test.ts
+++ b/packages/search-indexer/test/indexer.test.ts
@@ -1,0 +1,49 @@
+import { fileURLToPath } from 'node:url';
+import { Pipeline } from '@lde/pipeline';
+import { describe, expect, it } from 'vitest';
+import { configFromEnvironment } from '../src/config.js';
+import { createSearchIndexer } from '../src/indexer.js';
+
+const fixture = fileURLToPath(
+  new URL('./fixtures/search-schema.mjs', import.meta.url),
+);
+
+const minimal = {
+  REGISTRY_ENDPOINT: 'https://registry.example.org/sparql',
+  TYPESENSE_HOST: 'typesense.internal',
+  TYPESENSE_API_KEY: 'admin-key',
+};
+
+describe('createSearchIndexer', () => {
+  it('composes a ready-to-run pipeline from config and schema module', async () => {
+    const pipeline = await createSearchIndexer(
+      configFromEnvironment({
+        ...minimal,
+        SCHEMA_MODULE: fixture,
+        PROVENANCE_FILE: '/state/provenance.json',
+        PIPELINE_VERSION: '1',
+      }),
+    );
+    expect(pipeline).toBeInstanceOf(Pipeline);
+  });
+
+  it('composes without provenance when none is configured', async () => {
+    const pipeline = await createSearchIndexer(
+      configFromEnvironment({ ...minimal, SCHEMA_MODULE: fixture }),
+    );
+    expect(pipeline).toBeInstanceOf(Pipeline);
+  });
+
+  it('fails the boot on an unloadable schema module, naming the path', async () => {
+    await expect(
+      createSearchIndexer(
+        configFromEnvironment({
+          ...minimal,
+          SCHEMA_MODULE: '/no/such/module.mjs',
+        }),
+      ),
+    ).rejects.toThrowError(
+      /Cannot load schema module “\/no\/such\/module\.mjs”/,
+    );
+  });
+});

--- a/packages/search-indexer/tsconfig.json
+++ b/packages/search-indexer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  }
+}

--- a/packages/search-indexer/tsconfig.lib.json
+++ b/packages/search-indexer/tsconfig.lib.json
@@ -1,0 +1,49 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "types": ["node"],
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../sparql-qlever/tsconfig.lib.json"
+    },
+    {
+      "path": "../search-typesense/tsconfig.lib.json"
+    },
+    {
+      "path": "../search-pipeline/tsconfig.lib.json"
+    },
+    {
+      "path": "../search/tsconfig.lib.json"
+    },
+    {
+      "path": "../pipeline-console-reporter/tsconfig.lib.json"
+    },
+    {
+      "path": "../pipeline/tsconfig.lib.json"
+    },
+    {
+      "path": "../dataset-registry-client/tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx",
+    "test/**/*.test.js",
+    "test/**/*.spec.js",
+    "test/**/*.test.jsx",
+    "test/**/*.spec.jsx"
+  ]
+}

--- a/packages/search-indexer/tsconfig.spec.json
+++ b/packages/search-indexer/tsconfig.spec.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "types": ["node"],
+    "ignoreDeprecations": "6.0",
+    "rootDir": "."
+  },
+  "include": [
+    "vitest.config.ts",
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx",
+    "test/**/*.test.js",
+    "test/**/*.spec.js",
+    "test/**/*.test.jsx",
+    "test/**/*.spec.jsx",
+    "test/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/search-indexer/vite.config.ts
+++ b/packages/search-indexer/vite.config.ts
@@ -1,18 +1,19 @@
-/// <reference types='vitest' />
-import { defineConfig, mergeConfig } from 'vite';
+import { defineConfig, mergeConfig } from 'vitest/config';
 import baseConfig from '../../vite.base.config.js';
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     root: __dirname,
-    cacheDir: '../../node_modules/.vite/packages/search',
+    cacheDir: '../../node_modules/.vite/packages/search-indexer',
     test: {
       coverage: {
+        exclude: ['src/cli.ts'],
         thresholds: {
+          autoUpdate: true,
           functions: 100,
           lines: 100,
-          branches: 98.92,
+          branches: 100,
           statements: 100,
         },
       },

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -62,6 +62,11 @@ Exports are stratified by audience:
 - **`@lde/search/adapter`** – plumbing for engine adapters and API surfaces:
   `physicalFields`, the field selectors, `assertValidQuery`, the filter
   operators and storage codecs.
+- **`@lde/search/module`** – `loadSchemaModule`, the Node-only loader for a
+  mounted schema-declaration module (an `.mjs` default-exporting declarations
+  as plain data). The one loader both the indexer image and the served-API
+  image boot from, so the write and the read side cannot disagree about the
+  schema.
 - **`@lde/search/testing`** – `describeSearchEngineContract`, the executable
   port contract every engine adapter runs against a live instance of itself
   (vitest; optional peer).

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -16,6 +16,12 @@
       "development": "./src/index.ts",
       "default": "./dist/index.js"
     },
+    "./module": {
+      "types": "./dist/module.d.ts",
+      "import": "./dist/module.js",
+      "development": "./src/module.ts",
+      "default": "./dist/module.js"
+    },
     "./adapter": {
       "types": "./dist/adapter.d.ts",
       "import": "./dist/adapter.js",

--- a/packages/search/src/module.ts
+++ b/packages/search/src/module.ts
@@ -1,0 +1,65 @@
+// The `@lde/search/module` entry point: load a mounted schema-declaration
+// module. Node-only (it touches the filesystem), so it lives outside the main
+// entry point, which stays runtime-agnostic.
+import { pathToFileURL } from 'node:url';
+import { searchSchema, type SearchSchema, type SearchType } from './schema.js';
+
+/** What {@link loadSchemaModule} returns: the validated schema plus the raw
+ *  module exports, so each consumer validates its own optional exports (the
+ *  served API reads `schemaOptions`/`engineOptions`; the indexer reads none). */
+export interface LoadedSchemaModule {
+  /** The validated schema built from the module’s default export. */
+  readonly schema: SearchSchema;
+  /** Every export of the module, for consumer-specific optional exports. */
+  readonly moduleExports: Record<string, unknown>;
+}
+
+/**
+ * Load and validate a mounted schema-declaration module: an ES module whose
+ * default export is a non-empty array of {@link SearchType} declarations –
+ * **plain data with optional functions** (`derive`, `transform`), because a
+ * mounted file cannot resolve bare imports like `@lde/search`. The one schema
+ * source both the indexer image and the served-API image mount, so the write
+ * and the read side cannot disagree about the schema.
+ *
+ * Throws with the module path in the message for every failure mode – an
+ * unreadable file, a wrong export shape, an invalid declaration – so a bad
+ * mount fails the boot with a diagnosis, never the first query.
+ */
+export async function loadSchemaModule(
+  modulePath: string,
+): Promise<LoadedSchemaModule> {
+  let moduleExports: Record<string, unknown>;
+  try {
+    moduleExports = (await import(pathToFileURL(modulePath).href)) as Record<
+      string,
+      unknown
+    >;
+  } catch (cause) {
+    throw new Error(
+      `Cannot load schema module “${modulePath}”: ${messageOf(cause)}`,
+      { cause },
+    );
+  }
+  const declarations = moduleExports['default'];
+  if (!Array.isArray(declarations) || declarations.length === 0) {
+    throw new Error(
+      `Schema module “${modulePath}” must default-export a non-empty array of search type declarations.`,
+    );
+  }
+  try {
+    return {
+      schema: searchSchema(...(declarations as SearchType[])),
+      moduleExports,
+    };
+  } catch (cause) {
+    throw new Error(
+      `Schema module “${modulePath}” declares an invalid schema: ${messageOf(cause)}`,
+      { cause },
+    );
+  }
+}
+
+function messageOf(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -581,6 +581,7 @@ export interface SearchTypeIssue {
   readonly reason:
     | 'duplicate-field-name'
     | 'invalid-field-name'
+    | 'unknown-kind'
     | 'invalid-locale'
     | 'missing-ref'
     | 'ref-not-allowed'
@@ -667,6 +668,12 @@ export function validateSearchType(
     // pattern, so it must be a metacharacter-free identifier.
     if (!FIELD_NAME_PATTERN.test(field.name)) {
       issue('invalid-field-name');
+    }
+    // Every kind-dependent rule below would silently pass for a kind outside
+    // the union, so a typo’d kind in a plain-JS declaration must fail here.
+    if (!Object.hasOwn(OPERATOR_BY_KIND, field.kind)) {
+      issue('unknown-kind');
+      continue;
     }
     if (field.kind === 'reference') {
       if (field.output === true && field.ref === undefined) {

--- a/packages/search/test/fixtures/module/empty-array.mjs
+++ b/packages/search/test/fixtures/module/empty-array.mjs
@@ -1,0 +1,1 @@
+export default [];

--- a/packages/search/test/fixtures/module/invalid-declaration.mjs
+++ b/packages/search/test/fixtures/module/invalid-declaration.mjs
@@ -1,0 +1,6 @@
+export default [
+  {
+    name: 'Dataset',
+    // Missing `class` and `fields`: fails searchSchema() validation.
+  },
+];

--- a/packages/search/test/fixtures/module/not-an-array.mjs
+++ b/packages/search/test/fixtures/module/not-an-array.mjs
@@ -1,0 +1,1 @@
+export default { name: 'Dataset' };

--- a/packages/search/test/fixtures/module/search-schema.mjs
+++ b/packages/search/test/fixtures/module/search-schema.mjs
@@ -1,0 +1,21 @@
+/**
+ * A minimal schema-declaration module, shaped exactly as a deployment mounts
+ * it into an image: plain data, no imports.
+ */
+export default [
+  {
+    name: 'Dataset',
+    class: 'http://www.w3.org/ns/dcat#Dataset',
+    fields: [
+      {
+        name: 'title',
+        kind: 'text',
+        locales: ['nl', 'en'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+    ],
+  },
+];
+
+export const schemaOptions = { maxPerPage: 50 };

--- a/packages/search/test/fixtures/module/throws-string.mjs
+++ b/packages/search/test/fixtures/module/throws-string.mjs
@@ -1,0 +1,2 @@
+// A module whose evaluation throws a non-Error value.
+throw 'boom';

--- a/packages/search/test/module.test.ts
+++ b/packages/search/test/module.test.ts
@@ -1,0 +1,48 @@
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { loadSchemaModule } from '../src/module.js';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/module/${name}`, import.meta.url));
+
+describe('loadSchemaModule', () => {
+  it('builds the validated schema from the default export', async () => {
+    const { schema, moduleExports } = await loadSchemaModule(
+      fixture('search-schema.mjs'),
+    );
+    const types = [...schema.values()];
+    expect(types).toHaveLength(1);
+    expect(types[0]!.name).toBe('Dataset');
+    expect(moduleExports['schemaOptions']).toEqual({ maxPerPage: 50 });
+  });
+
+  it('rejects a missing file, naming the path', async () => {
+    await expect(loadSchemaModule('/no/such/module.mjs')).rejects.toThrowError(
+      /Cannot load schema module “\/no\/such\/module\.mjs”/,
+    );
+  });
+
+  it('rejects a module that throws a non-Error value', async () => {
+    await expect(
+      loadSchemaModule(fixture('throws-string.mjs')),
+    ).rejects.toThrowError(/Cannot load schema module .*boom/);
+  });
+
+  it('rejects a default export that is not an array', async () => {
+    await expect(
+      loadSchemaModule(fixture('not-an-array.mjs')),
+    ).rejects.toThrowError(/must default-export a non-empty array/);
+  });
+
+  it('rejects an empty default export', async () => {
+    await expect(
+      loadSchemaModule(fixture('empty-array.mjs')),
+    ).rejects.toThrowError(/must default-export a non-empty array/);
+  });
+
+  it('rejects invalid declarations with the validation diagnosis', async () => {
+    await expect(
+      loadSchemaModule(fixture('invalid-declaration.mjs')),
+    ).rejects.toThrowError(/declares an invalid schema/);
+  });
+});

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -331,6 +331,14 @@ describe('validateSearchType', () => {
     ]);
   });
 
+  it('rejects an unknown field kind', () => {
+    // A typo’d kind in a plain-JS declaration must fail at declaration time –
+    // every kind-dependent rule would silently pass for it otherwise.
+    expect(
+      validateSearchType(typeWith({ name: 'broken', kind: 'no-such-kind' })),
+    ).toEqual([{ field: 'broken', reason: 'unknown-kind' }]);
+  });
+
   it('rejects a field name carrying a regex metacharacter', () => {
     // The name is interpolated raw into the display RE2 pattern, so a
     // metacharacter would over-match or break the collection schema.

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 98.88,
+          branches: 98.89,
           statements: 100,
         },
       },

--- a/tools/docker-smoke-indexer.sh
+++ b/tools/docker-smoke-indexer.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the built search-indexer image by actually running it: boot with
+# a fixture schema module and `--check`, which loads the full module graph and
+# validates configuration, then exits. `nx … docker:build` only *builds* the
+# image, so a runtime-only failure – e.g. a runtime dependency missing from
+# the pruned image, surfacing as `ERR_MODULE_NOT_FOUND` at boot – passes the
+# build yet crashes in production. This is the gate that catches that class
+# before it ships. The indexer is a batch process, so unlike docker-smoke.sh
+# (the HTTP-server variant) there is no port to probe: a clean `--check` exit
+# is the startup signal.
+#
+# Usage: docker-smoke-indexer.sh <image-tag>
+set -euo pipefail
+
+image="$1"
+
+# Dummy values: we test module resolution and startup, not behaviour. Nothing
+# connects during --check. The schema module ships into the container only for
+# this smoke via the test fixture bind mount.
+if output="$(docker run --rm \
+  -e REGISTRY_ENDPOINT=https://registry.invalid/sparql \
+  -e TYPESENSE_HOST=localhost \
+  -e TYPESENSE_API_KEY=dummy \
+  -v "$(pwd)/packages/search-indexer/test/fixtures/search-schema.mjs:/config/search-schema.mjs:ro" \
+  "$image" node dist/cli.js --check 2>&1)"; then
+  if echo "$output" | grep -q "configuration and schema module .* are valid"; then
+    echo "PASS: $image booted, loaded the schema module and validated configuration"
+    exit 0
+  fi
+  echo "FAIL: $image exited 0 but did not report a valid configuration:"
+  echo "$output"
+  exit 1
+fi
+
+echo "FAIL: $image failed --check:"
+echo "$output"
+if echo "$output" | grep -qiE "ERR_MODULE_NOT_FOUND|Cannot find (package|module)"; then
+  echo "(module-resolution error: a runtime dependency is missing from the pruned image)"
+fi
+exit 1

--- a/tools/docker-smoke.sh
+++ b/tools/docker-smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Smoke-test a built application image by actually running it and asserting it
+# reaches startup and serves HTTP. `nx … docker:build` only *builds* the image,
+# so a runtime-only failure – e.g. a runtime dependency missing from the pruned
+# image, surfacing as `ERR_MODULE_NOT_FOUND` at boot – passes the build yet
+# crashes in production. This is the gate that catches that class before it
+# ships.
+#
+# Usage: docker-smoke.sh <image-tag>
+set -euo pipefail
+
+image="$1"
+container="smoke-${image}-$$"
+
+cleanup() { docker rm -f "$container" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# Dummy values: we test module resolution and startup, not behaviour. The
+# Typesense client connects lazily, so an unreachable host does not block boot.
+# The schema module ships in the image only for this smoke via the test
+# fixture bind mount.
+docker run -d --name "$container" -p 4000 \
+  -e SCHEMA_MODULE=/config/search-schema.mjs \
+  -e TYPESENSE_HOST=localhost \
+  -e TYPESENSE_API_KEY=dummy \
+  -v "$(pwd)/packages/search-api-server/test/fixtures/search-schema.mjs:/config/search-schema.mjs:ro" \
+  "$image" >/dev/null
+
+for _ in $(seq 1 30); do
+  logs="$(docker logs "$container" 2>&1)"
+  # Check failure conditions before success: a container that logged the
+  # startup line and then crashed must be reported FAIL, not PASS.
+  if echo "$logs" | grep -qiE "ERR_MODULE_NOT_FOUND|Cannot find (package|module)"; then
+    echo "FAIL: $image hit a module-resolution error at startup:"
+    echo "$logs"
+    exit 1
+  fi
+  if [ "$(docker inspect -f '{{.State.Status}}' "$container")" = "exited" ]; then
+    echo "FAIL: $image exited before reaching startup:"
+    echo "$logs"
+    exit 1
+  fi
+  if echo "$logs" | grep -qE "serving /graphql"; then
+    host_port="$(docker port "$container" 4000/tcp | head -1 | sed 's/.*://')"
+    health_code="$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${host_port}/health" || true)"
+    if [ "$health_code" != "200" ]; then
+      echo "FAIL: $image reached startup but served /health with HTTP ${health_code:-000} (expected 200)"
+      exit 1
+    fi
+    sdl="$(curl -s "http://localhost:${host_port}/graphql?sdl" || true)"
+    if ! echo "$sdl" | grep -q "type Query"; then
+      echo "FAIL: $image served /health but /graphql?sdl returned no schema:"
+      echo "$sdl" | head -5
+      exit 1
+    fi
+    echo "PASS: $image reached startup and serves /health and /graphql?sdl"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "FAIL: $image did not reach startup within 30s:"
+docker logs "$container" 2>&1
+exit 1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,6 +85,9 @@
     },
     {
       "path": "./packages/search-api-server"
+    },
+    {
+      "path": "./packages/search-indexer"
     }
   ],
   "compilerOptions": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -82,6 +82,9 @@
     },
     {
       "path": "./packages/search-pipeline"
+    },
+    {
+      "path": "./packages/search-api-server"
     }
   ],
   "compilerOptions": {


### PR DESCRIPTION
Part of #600 (layer 3 of 3: the prebuilt images; the handler, layer 2, shipped in #637).

Ships the search stack as **two prebuilt, workspace-built Docker images** that boot from the **same mounted schema-declaration module**, loaded by the shared `@lde/search/module` loader so the write side and the read side cannot disagree about the schema:

- **`ghcr.io/ldelements/search-api-server`** (`@lde/search-api-server`, new): the served search API – mount a schema module, set `TYPESENSE_*` env vars, get `/graphql` (POST execution, self-contained playground, `?sdl`) plus `/health`, with CORS and depth/cost limits on by default. The composition layer binding the deliberately engine-agnostic `@lde/search-api-graphql` handler to `@lde/search-typesense`.
- **`ghcr.io/ldelements/search-indexer`** (`@lde/search-indexer`, new): the write side – a Commander CLI wrapping `searchIndexerPipeline`, configured entirely from environment variables. Dataset selection against a DCAT registry (explicit IRIs, search criteria, or the whole registry), in-place (default) or blue-green Typesense rebuild writers, optional file provenance, and an optional QLever import path behind `QLEVER_IMAGE` ([ADR 16](docs/decisions/0016-ship-the-search-indexer-as-a-config-driven-image.md)). `--check` validates config + schema module and exits; the Docker smoke boots the image with it.

## Design ([ADR 15](docs/decisions/0015-ship-the-served-search-api-as-a-docker-image-built-from-the-workspace.md), [ADR 16](docs/decisions/0016-ship-the-search-indexer-as-a-config-driven-image.md))

- **Schema input: a plain-data declaration module, not SHACL.** #600 assumed mounted SHACL + `search:` definitions, but that generator is #495’s still-open scope. The mount is an `.mjs` default-exporting `SearchType` declarations, loaded and validated at boot by the new **`@lde/search/module`** entry point (Node-only, like `./adapter` and `./testing`) – the “declarations built outside TypeScript” path the runtime validation exists for. Functions (`derive`, `transform`) remain expressible: the indexer projects with them, the server ignores them – one module drives both images. When #495 lands, mounted SHACL becomes a second source for the same schema.
- **Separate composition packages**, because a Typesense-bound server cannot live in `@lde/search-api-graphql` without breaking its engine-agnosticism.
- **The images are built from the workspace’s own outputs, never from npm** – adopting the pattern the Dataset Register converged on (netwerk-digitaal-erfgoed/dataset-register#2130): `docker:build` (inferred by the new `@nx/docker` plugin) stages the compiled package, the **same-commit builds** of its `@lde/*` dependencies (`@nx/js:copy-workspace-modules`) and a pruned lockfile (`@nx/js:prune-lockfile` + an `npm install --package-lock-only` repair step, because Nx’s pruning cannot map this workspace’s graph and falls back to the root lockfile); the Dockerfiles are a plain `npm ci --omit=dev` + `COPY`. No bundling, deliberately: bundling hid missing transitives until boot in the Dataset Register (#2128).
- **`docker:smoke` gates CI** for both images: every affected PR builds the image and boots it (the server probed over real HTTP on `/health` + `/graphql?sdl`; the indexer via `--check`), so runtime-only failures – the `ERR_MODULE_NOT_FOUND` class – cannot pass a green build. The smoke step runs after the test suites so image builds cannot starve timing-sensitive tests on the shared runner.
- **Releases are registry-independent**: an `@lde/<package>@<version>` tag triggers a workflow that derives the package from the tag, checks out that commit, rebuilds, smoke-tests and pushes `:<version>` + `:latest`. No waiting on the npm publish; image tags stay aligned with the package semver. `nx release`’s own Docker support (experimental, calendar-versioned, cannot npm- and Docker-publish one project) is deliberately not used.
- The read-only server image **omits `@lde/search-typesense`’s write-side peers** (`@lde/pipeline`, `@lde/dataset`): every runtime import is `import type`, and the smoke test guards that assumption.

## Also

- `feat(search)`: `validateSearchType` now rejects an unknown field `kind` (new `unknown-kind` issue reason). Previously a typo’d kind in a plain-JS declaration passed every kind-dependent rule vacuously – exactly the path the mounted schema module relies on.

## Acceptance criteria covered (of #600)

- [x] A prebuilt image serving `/graphql` + playground from mounted definitions and engine config
- [ ] The Dataset Register drops its hand-rolled `+server.ts` – downstream (netwerk-digitaal-erfgoed/dataset-register#2282)

## After merge

`@lde/search-api-server` and `@lde/search-indexer` are new on npm: each first version needs the manual Trusted-Publishing bootstrap for **npm consumers**. The Docker images are unaffected – they build from the workspace.
