### PR TITLE
fix(pipeline)!: count fetched rows for pagination and yield only uniform IRI rows

### DIFF
--- a/packages/pipeline-shacl-sampler/src/sampleStages.ts
+++ b/packages/pipeline-shacl-sampler/src/sampleStages.ts
@@ -144,7 +144,7 @@ function subjectSelector(
   assertSafeIri(targetClass.value);
   return {
     // Forward `options` so the Pipeline’s per-dataset TimeoutPolicy
-    // reaches the inner SparqlItemSelector — without this the adaptive
+    // reaches the inner SparqlItemSelector – without this the adaptive
     // budget is silently bypassed for subject selection.
     select(distribution, batchSize, options) {
       const query = buildSubjectSelectorQuery({
@@ -193,10 +193,14 @@ export function buildSubjectSelectorQuery({
     fromClause = `FROM <${namedGraph}>`;
   }
   const typePattern = buildTypePattern(targetClass, namespaceAliases);
+  // Exclude blank-node subjects at the endpoint: the selector would drop them
+  // client-side anyway (no stable identity), but only after fetching them –
+  // and a class instantiated by many blank nodes would then be walked to the
+  // end through pages that yield nothing.
   return [
     'SELECT DISTINCT ?s',
     fromClause,
-    `WHERE { ${subjectFilter ?? ''} ${typePattern} ${excludeFilter ?? ''} }`,
+    `WHERE { ${subjectFilter ?? ''} ${typePattern} FILTER(!isBlank(?s)) ${excludeFilter ?? ''} }`,
   ].join('\n');
 }
 

--- a/packages/pipeline-void/src/stage.ts
+++ b/packages/pipeline-void/src/stage.ts
@@ -83,7 +83,7 @@ export interface VoidStageOptions {
  * Options for per-class VoID stages that iterate over classes.
  *
  * `batchSize` and `maxConcurrency` control how class bindings are batched
- * and processed concurrently — they have no effect on global (non-per-class) stages.
+ * and processed concurrently – they have no effect on global (non-per-class) stages.
  */
 export interface PerClassVoidStageOptions extends VoidStageOptions {
   /** Maximum number of class bindings per reader call. @default 10 */
@@ -159,7 +159,7 @@ function asTransforms(
 function classSelector(): ItemSelector {
   return {
     // Forward `options` so the Pipeline’s per-dataset TimeoutPolicy
-    // reaches the inner SparqlItemSelector — without this the adaptive
+    // reaches the inner SparqlItemSelector – without this the adaptive
     // budget is silently bypassed for class selection.
     select: (distribution, batchSize, options) => {
       const subjectFilter = distribution.subjectFilter ?? '';
@@ -168,10 +168,13 @@ function classSelector(): ItemSelector {
         assertSafeIri(distribution.namedGraph);
         fromClause = `FROM <${distribution.namedGraph}>`;
       }
+      // Exclude blank-node classes at the endpoint: the selector would drop
+      // them client-side anyway (no stable identity), but only after fetching
+      // them.
       const selectorQuery = [
         'SELECT DISTINCT ?class',
         fromClause,
-        `WHERE { ${subjectFilter} ?s a ?class . }`,
+        `WHERE { ${subjectFilter} ?s a ?class . FILTER(!isBlank(?class)) }`,
         'LIMIT 1000',
       ].join('\n');
 
@@ -255,7 +258,7 @@ export function classPropertyObjects(
 export function countDatatypes(options?: VoidStageOptions): Promise<Stage> {
   // No expectsOutput: unlike the other counts, this query joins the scalar
   // count with a `SELECT DISTINCT ?datatype` group, so a dataset with no
-  // literals yields zero rows — a legitimately empty result, not a truncation.
+  // literals yields zero rows – a legitimately empty result, not a truncation.
   return createVoidStage(VOID_STAGE_NAMES.datatypes, options);
 }
 
@@ -356,7 +359,7 @@ export async function voidStages(
     countDatatypes(withTransform(VOID_STAGE_NAMES.datatypes)),
     countTriples(withTransform(VOID_STAGE_NAMES.triples)),
 
-    // Cache warming — must precede per-class stages.
+    // Cache warming – must precede per-class stages.
     classPartitions(withTransform(VOID_STAGE_NAMES.classPartitions)),
 
     // Per-class stages.

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -113,6 +113,8 @@ new SparqlItemSelector({
 });
 ```
 
+Only `NamedNode` binding values are yielded – binding values double as stable item identities downstream, which a blank-node label or literal cannot provide. A row without any `NamedNode` binding is dropped, but still counts toward pagination (it occupied a result slot at the endpoint), so a partly-dropped page never ends pagination early. To skip such rows without fetching them at all, filter in the query itself (e.g. `FILTER(!isBlank(?s))`, as `selectByClass` in `@lde/search-pipeline` does).
+
 #### Capping total results with `maxResults`
 
 By default, `SparqlItemSelector` paginates through **all** matching rows: any `LIMIT` clause in the query is interpreted as the page size, then it walks pages with `OFFSET` until the source is exhausted. To cap the total bindings yielded across all pages – for sampling, testing, prototyping, or just safety – set `maxResults`:

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -113,7 +113,7 @@ new SparqlItemSelector({
 });
 ```
 
-Only `NamedNode` binding values are yielded – binding values double as stable item identities downstream, which a blank-node label or literal cannot provide. A row without any `NamedNode` binding is dropped, but still counts toward pagination (it occupied a result slot at the endpoint), so a partly-dropped page never ends pagination early. To skip such rows without fetching them at all, filter in the query itself (e.g. `FILTER(!isBlank(?s))`, as `selectByClass` in `@lde/search-pipeline` does).
+A row is yielded only when **every** projected variable binds a `NamedNode` – binding values double as stable item identities downstream, which a blank-node label or literal cannot provide. Other rows are dropped client-side but still count toward pagination, so they are fetched first; to skip them at the endpoint, filter in the query itself (e.g. `FILTER(isIRI(?s))`, as `selectByClass` in `@lde/search-pipeline` does with `FILTER(!isBlank(?root))`).
 
 #### Capping total results with `maxResults`
 
@@ -129,7 +129,7 @@ new SparqlItemSelector({
 When `maxResults` is set:
 
 - Pagination stops as soon as `maxResults` bindings have been yielded – no wasted page request after the cap is hit.
-- The last (partial) page's `LIMIT` is shrunk to the remaining cap so the endpoint doesn't over-fetch on the remainder (e.g. with `maxResults: 85` and `pageSize: 10`, the 9th page request is `LIMIT 5`, not `LIMIT 10`).
+- As long as no row has been dropped, the last (partial) page's `LIMIT` is shrunk to the remaining cap so the endpoint doesn't over-fetch on the remainder (e.g. with `maxResults: 85` and `pageSize: 10`, the 9th page request is `LIMIT 5`, not `LIMIT 10`). Once rows have been dropped, pages stay at full size – shrinking to the yielded remainder would crawl a dropped-row region one row per request.
 - The first page uses the configured page size as-is; `maxResults` and page size stay orthogonal. If `maxResults < pageSize`, the first page may return a few rows that aren't yielded.
 - `maxResults: 0` is a valid no-op; the selector yields nothing without issuing any SPARQL request.
 - `maxResults` is independent of any `LIMIT` clause in the query, which still controls page size when the cap is larger than one page.

--- a/packages/pipeline/src/sparql/selector.ts
+++ b/packages/pipeline/src/sparql/selector.ts
@@ -34,7 +34,7 @@ export interface SparqlItemSelectorOptions {
    * SELECT query projecting at least one named variable.
    *
    * A `LIMIT` clause in the query overrides the stage's `batchSize` as the
-   * page size — use this when the SPARQL endpoint enforces a result limit.
+   * page size – use this when the SPARQL endpoint enforces a result limit.
    * It does **not** cap the total number of bindings the selector yields;
    * pagination continues with `OFFSET` until the source is exhausted. Use
    * {@link maxResults} to cap the total.
@@ -42,7 +42,7 @@ export interface SparqlItemSelectorOptions {
   query: string;
   /**
    * Maximum number of bindings the selector yields across all pages.
-   * Use this for sampling — “give me at most N items, don’t walk the full
+   * Use this for sampling – “give me at most N items, don’t walk the full
    * source”. Independent of {@link query}’s `LIMIT`, which controls page
    * size. Pagination stops as soon as `maxResults` bindings have been
    * yielded.
@@ -55,9 +55,14 @@ export interface SparqlItemSelectorOptions {
 /**
  * {@link ItemSelector} that pages through SPARQL SELECT results,
  * yielding all projected variable bindings (NamedNode values only) per row.
+ * A row whose projected variables bind no NamedNode at all (e.g. only blank
+ * nodes) is dropped – binding values double as stable item identities
+ * downstream, which a blank-node label cannot provide. Dropped rows still
+ * count toward pagination (they occupied result slots at the endpoint), so a
+ * partly-dropped page never ends pagination early.
  *
  * The endpoint URL comes from the {@link Distribution} passed to {@link select}.
- * Pagination is an internal detail — consumers iterate binding rows directly.
+ * Pagination is an internal detail – consumers iterate binding rows directly.
  *
  * The page size (results per SPARQL request) is determined by, in order:
  * 1. A `LIMIT` clause in the selector query (for endpoints with hard result limits)
@@ -112,7 +117,7 @@ export class SparqlItemSelector implements ItemSelector {
         this.maxResults !== undefined
           ? this.maxResults - totalYielded
           : Infinity;
-      // The first page uses the configured page size as-is — keeps page-size
+      // The first page uses the configured page size as-is – keeps page-size
       // and total-cap orthogonal. Subsequent pages clamp to `remaining` so
       // the last (partial) page doesn’t over-fetch.
       const effectivePageSize =
@@ -130,8 +135,14 @@ export class SparqlItemSelector implements ItemSelector {
         policy,
       );
 
-      let count = 0;
+      // Pagination counts FETCHED rows, not yielded ones: a row dropped by the
+      // NamedNode filter (e.g. a blank-node binding) still occupied a slot in
+      // the page, so it must advance OFFSET, and a full page of partly-dropped
+      // rows must not look short – that would end pagination with results still
+      // remaining at the endpoint. Only `maxResults` counts yielded rows.
+      let fetched = 0;
       for await (const record of stream) {
+        fetched++;
         const row = Object.fromEntries(
           Object.entries(record).filter(
             ([, term]) => term.termType === 'NamedNode',
@@ -140,7 +151,6 @@ export class SparqlItemSelector implements ItemSelector {
 
         if (Object.keys(row).length > 0) {
           yield row;
-          count++;
           totalYielded++;
           if (
             this.maxResults !== undefined &&
@@ -151,11 +161,11 @@ export class SparqlItemSelector implements ItemSelector {
         }
       }
 
-      if (count === 0 || count < effectivePageSize) {
+      if (fetched === 0 || fetched < effectivePageSize) {
         return;
       }
 
-      offset += count;
+      offset += fetched;
     }
   }
 

--- a/packages/pipeline/src/sparql/selector.ts
+++ b/packages/pipeline/src/sparql/selector.ts
@@ -34,7 +34,7 @@ export interface SparqlItemSelectorOptions {
    * SELECT query projecting at least one named variable.
    *
    * A `LIMIT` clause in the query overrides the stage's `batchSize` as the
-   * page size – use this when the SPARQL endpoint enforces a result limit.
+   * page size — use this when the SPARQL endpoint enforces a result limit.
    * It does **not** cap the total number of bindings the selector yields;
    * pagination continues with `OFFSET` until the source is exhausted. Use
    * {@link maxResults} to cap the total.
@@ -42,10 +42,10 @@ export interface SparqlItemSelectorOptions {
   query: string;
   /**
    * Maximum number of bindings the selector yields across all pages.
-   * Use this for sampling – “give me at most N items, don’t walk the full
+   * Use this for sampling — “give me at most N items, don’t walk the full
    * source”. Independent of {@link query}’s `LIMIT`, which controls page
    * size. Pagination stops as soon as `maxResults` bindings have been
-   * yielded.
+   * yielded. Must not be negative.
    */
   maxResults?: number;
   /** Custom fetcher instance. */
@@ -53,31 +53,40 @@ export interface SparqlItemSelectorOptions {
 }
 
 /**
- * {@link ItemSelector} that pages through SPARQL SELECT results,
- * yielding all projected variable bindings (NamedNode values only) per row.
- * A row whose projected variables bind no NamedNode at all (e.g. only blank
- * nodes) is dropped – binding values double as stable item identities
- * downstream, which a blank-node label cannot provide. Dropped rows still
- * count toward pagination (they occupied result slots at the endpoint), so a
- * partly-dropped page never ends pagination early.
+ * {@link ItemSelector} that pages through SPARQL SELECT results, yielding one
+ * bindings row per result row. A row is yielded only when **every** projected
+ * variable binds a NamedNode: binding values double as stable item identities
+ * downstream and are re-injected into reader queries as a `VALUES` block,
+ * which needs uniform rows – a blank-node label or literal provides no stable
+ * identity, and a partially-bound row would silently weaken the join. Any
+ * other row is dropped, but still counts toward pagination (it occupied a
+ * result slot at the endpoint), so a partly-dropped page never ends
+ * pagination early. Dropped rows are still fetched; to skip them at the
+ * endpoint, filter in the query itself (e.g. `FILTER(isIRI(?s))`).
  *
  * The endpoint URL comes from the {@link Distribution} passed to {@link select}.
- * Pagination is an internal detail – consumers iterate binding rows directly.
+ * Pagination is an internal detail — consumers iterate binding rows directly.
  *
  * The page size (results per SPARQL request) is determined by, in order:
  * 1. A `LIMIT` clause in the selector query (for endpoints with hard result limits)
  * 2. The stage's {@link StageOptions.batchSize} (passed via {@link select})
  * 3. A default of 10
  *
+ * The page size must be positive – a page size of 0 could never terminate,
+ * so it is rejected as a configuration error.
+ *
  * {@link SparqlItemSelectorOptions.maxResults} is independent of page size:
  * it caps the *total* bindings yielded across pages without changing how
- * the first page is requested. The last (partial) page’s `LIMIT` is
- * shrunk to whatever’s left of the cap so the endpoint doesn’t over-fetch
- * on the remainder.
+ * the first page is requested. As long as no row has been dropped, the last
+ * (partial) page’s `LIMIT` is shrunk to whatever’s left of the cap so the
+ * endpoint doesn’t over-fetch on the remainder; once rows have been dropped,
+ * pages stay at full size – shrinking them to the yielded remainder would
+ * crawl a dropped-row region one row per request.
  */
 export class SparqlItemSelector implements ItemSelector {
   private readonly parsed: QuerySelect;
   private readonly queryLimit?: number;
+  private readonly variableNames: readonly string[];
   private readonly maxResults?: number;
   private readonly userFetcher?: SparqlEndpointFetcher;
 
@@ -94,8 +103,15 @@ export class SparqlItemSelector implements ItemSelector {
       );
     }
 
+    if (options.maxResults !== undefined && options.maxResults < 0) {
+      throw new Error(
+        `maxResults must not be negative; got ${options.maxResults}`,
+      );
+    }
+
     this.parsed = parsed as QuerySelect;
     this.queryLimit = this.parsed.solutionModifiers.limitOffset?.limit;
+    this.variableNames = variables.map((variable) => variable.value);
     this.maxResults = options.maxResults;
     this.userFetcher = options.fetcher;
   }
@@ -107,9 +123,15 @@ export class SparqlItemSelector implements ItemSelector {
   ): AsyncIterableIterator<VariableBindings> {
     if (this.maxResults === 0) return;
     const basePageSize = this.queryLimit ?? batchSize ?? 10;
+    if (basePageSize <= 0) {
+      throw new Error(
+        `Page size must be positive; got ${basePageSize} (from the query’s LIMIT or the stage’s batchSize)`,
+      );
+    }
     const endpoint = distribution.accessUrl!;
     const policy = options?.timeout ?? defaultTimeoutPolicy;
     let offset = 0;
+    let totalFetched = 0;
     let totalYielded = 0;
 
     while (true) {
@@ -118,10 +140,14 @@ export class SparqlItemSelector implements ItemSelector {
           ? this.maxResults - totalYielded
           : Infinity;
       // The first page uses the configured page size as-is – keeps page-size
-      // and total-cap orthogonal. Subsequent pages clamp to `remaining` so
-      // the last (partial) page doesn’t over-fetch.
+      // and total-cap orthogonal. Subsequent pages clamp to `remaining` so the
+      // last (partial) page doesn’t over-fetch – but only while nothing has
+      // been dropped: once yields lag fetches, clamping would crawl a
+      // dropped-row region at down to one row per request (see class JSDoc).
       const effectivePageSize =
-        offset === 0 ? basePageSize : Math.min(basePageSize, remaining);
+        offset === 0 || totalFetched > totalYielded
+          ? basePageSize
+          : Math.min(basePageSize, remaining);
       this.parsed.solutionModifiers.limitOffset = F.solutionModifierLimitOffset(
         effectivePageSize,
         offset,
@@ -135,22 +161,19 @@ export class SparqlItemSelector implements ItemSelector {
         policy,
       );
 
-      // Pagination counts FETCHED rows, not yielded ones: a row dropped by the
-      // NamedNode filter (e.g. a blank-node binding) still occupied a slot in
-      // the page, so it must advance OFFSET, and a full page of partly-dropped
-      // rows must not look short – that would end pagination with results still
-      // remaining at the endpoint. Only `maxResults` counts yielded rows.
+      // Fetched rows drive pagination, yielded rows only `maxResults` – see
+      // the class JSDoc for why dropped rows must keep their page slot.
       let fetched = 0;
       for await (const record of stream) {
         fetched++;
-        const row = Object.fromEntries(
-          Object.entries(record).filter(
-            ([, term]) => term.termType === 'NamedNode',
-          ),
-        ) as VariableBindings;
+        totalFetched++;
 
-        if (Object.keys(row).length > 0) {
-          yield row;
+        if (
+          this.variableNames.every(
+            (name) => record[name]?.termType === 'NamedNode',
+          )
+        ) {
+          yield record as VariableBindings;
           totalYielded++;
           if (
             this.maxResults !== undefined &&
@@ -161,7 +184,7 @@ export class SparqlItemSelector implements ItemSelector {
         }
       }
 
-      if (fetched === 0 || fetched < effectivePageSize) {
+      if (fetched < effectivePageSize) {
         return;
       }
 

--- a/packages/pipeline/test/sparql/selector.test.ts
+++ b/packages/pipeline/test/sparql/selector.test.ts
@@ -10,9 +10,9 @@ const { namedNode, literal, blankNode } = DataFactory;
 
 const distribution = Distribution.sparql(new URL('http://example.com/sparql'));
 
-function bindingsStream(
-  records: Record<string, { termType: string; value: string }>[],
-): Promise<Readable> {
+type MockRecord = Record<string, { termType: string; value: string }>;
+
+function bindingsStream(records: MockRecord[]): Promise<Readable> {
   const stream = new Readable({
     objectMode: true,
     read() {
@@ -26,30 +26,53 @@ function bindingsStream(
   return Promise.resolve(stream);
 }
 
+/**
+ * A mock fetcher serving `pages` in request order (an empty page once
+ * exhausted), recording every generated query so tests can assert the
+ * LIMIT/OFFSET per request.
+ */
+function pagedFetcher(pages: MockRecord[][]) {
+  const queries: string[] = [];
+  const fetcher = {
+    fetchBindings: vi
+      .fn()
+      .mockImplementation((_endpoint: string, generatedQuery: string) => {
+        queries.push(generatedQuery);
+        return bindingsStream(pages[queries.length - 1] ?? []);
+      }),
+  };
+  return { fetcher, queries };
+}
+
+/** Drain a selector into an array of yielded binding rows. */
+async function selectAll(
+  selector: ItemSelector,
+  batchSize?: number,
+): Promise<VariableBindings[]> {
+  const rows: VariableBindings[] = [];
+  for await (const row of selector.select(distribution, batchSize)) {
+    rows.push(row);
+  }
+  return rows;
+}
+
 describe('SparqlItemSelector', () => {
   const query = 'SELECT ?uri WHERE { ?uri a <http://example.com/Class> }';
 
   it('yields all bindings when results are fewer than page size', async () => {
-    const mockFetcher = {
-      fetchBindings: vi
-        .fn()
-        .mockImplementation(() =>
-          bindingsStream([
-            { uri: namedNode('http://example.com/1') },
-            { uri: namedNode('http://example.com/2') },
-          ]),
-        ),
-    };
+    const { fetcher } = pagedFetcher([
+      [
+        { uri: namedNode('http://example.com/1') },
+        { uri: namedNode('http://example.com/2') },
+      ],
+    ]);
 
     const selector = new SparqlItemSelector({
       query,
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    const rows: VariableBindings[] = [];
-    for await (const row of selector.select(distribution, 10)) {
-      rows.push(row);
-    }
+    const rows = await selectAll(selector, 10);
 
     expect(rows).toHaveLength(2);
     expect(rows[0].uri.value).toBe('http://example.com/1');
@@ -57,31 +80,20 @@ describe('SparqlItemSelector', () => {
   });
 
   it('paginates with correct OFFSET increments', async () => {
-    const queries: string[] = [];
-    const mockFetcher = {
-      fetchBindings: vi
-        .fn()
-        .mockImplementation((_endpoint: string, q: string) => {
-          queries.push(q);
-          if (queries.length === 1) {
-            return bindingsStream([
-              { uri: namedNode('http://example.com/1') },
-              { uri: namedNode('http://example.com/2') },
-            ]);
-          }
-          return bindingsStream([{ uri: namedNode('http://example.com/3') }]);
-        }),
-    };
+    const { fetcher, queries } = pagedFetcher([
+      [
+        { uri: namedNode('http://example.com/1') },
+        { uri: namedNode('http://example.com/2') },
+      ],
+      [{ uri: namedNode('http://example.com/3') }],
+    ]);
 
     const selector = new SparqlItemSelector({
       query,
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    const rows: VariableBindings[] = [];
-    for await (const row of selector.select(distribution, 2)) {
-      rows.push(row);
-    }
+    const rows = await selectAll(selector, 2);
 
     expect(rows).toHaveLength(3);
     expect(rows.map((r) => r.uri.value)).toEqual([
@@ -97,46 +109,32 @@ describe('SparqlItemSelector', () => {
   });
 
   it('yields nothing for empty results', async () => {
-    const mockFetcher = {
-      fetchBindings: vi.fn().mockImplementation(() => bindingsStream([])),
-    };
+    const { fetcher } = pagedFetcher([]);
 
     const selector = new SparqlItemSelector({
       query,
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    const rows: unknown[] = [];
-    for await (const row of selector.select(distribution)) {
-      rows.push(row);
-    }
-
-    expect(rows).toHaveLength(0);
+    expect(await selectAll(selector)).toHaveLength(0);
   });
 
-  it('skips rows where all projected variables are non-NamedNode', async () => {
-    const mockFetcher = {
-      fetchBindings: vi
-        .fn()
-        .mockImplementation(() =>
-          bindingsStream([
-            { uri: namedNode('http://example.com/1') },
-            { uri: literal('not a URI') },
-            { uri: blankNode('b0') },
-            { uri: namedNode('http://example.com/2') },
-          ]),
-        ),
-    };
+  it('skips rows where projected variables bind a non-NamedNode', async () => {
+    const { fetcher } = pagedFetcher([
+      [
+        { uri: namedNode('http://example.com/1') },
+        { uri: literal('not a URI') },
+        { uri: blankNode('b0') },
+        { uri: namedNode('http://example.com/2') },
+      ],
+    ]);
 
     const selector = new SparqlItemSelector({
       query,
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    const rows: VariableBindings[] = [];
-    for await (const row of selector.select(distribution, 10)) {
-      rows.push(row);
-    }
+    const rows = await selectAll(selector, 10);
 
     expect(rows).toHaveLength(2);
     expect(rows[0].uri.value).toBe('http://example.com/1');
@@ -147,31 +145,17 @@ describe('SparqlItemSelector', () => {
     // A skipped (blank-node) row still occupied a result slot at the endpoint:
     // the page is full, so pagination must continue – and OFFSET must advance
     // by the fetched count, not the yielded count, or rows are re-read.
-    const queries: string[] = [];
-    const mockFetcher = {
-      fetchBindings: vi
-        .fn()
-        .mockImplementation((_endpoint: string, q: string) => {
-          queries.push(q);
-          if (queries.length === 1) {
-            return bindingsStream([
-              { uri: blankNode('b0') },
-              { uri: namedNode('http://example.com/1') },
-            ]);
-          }
-          return bindingsStream([{ uri: namedNode('http://example.com/2') }]);
-        }),
-    };
+    const { fetcher, queries } = pagedFetcher([
+      [{ uri: blankNode('b0') }, { uri: namedNode('http://example.com/1') }],
+      [{ uri: namedNode('http://example.com/2') }],
+    ]);
 
     const selector = new SparqlItemSelector({
       query,
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    const rows: VariableBindings[] = [];
-    for await (const row of selector.select(distribution, 2)) {
-      rows.push(row);
-    }
+    const rows = await selectAll(selector, 2);
 
     expect(rows.map((row) => row.uri.value)).toEqual([
       'http://example.com/1',
@@ -184,31 +168,17 @@ describe('SparqlItemSelector', () => {
   it('keeps paginating past a page of only skipped rows', async () => {
     // All rows dropped is not the end of the results – the endpoint returned a
     // full page, so the next page may still hold yieldable rows.
-    const queries: string[] = [];
-    const mockFetcher = {
-      fetchBindings: vi
-        .fn()
-        .mockImplementation((_endpoint: string, q: string) => {
-          queries.push(q);
-          if (queries.length === 1) {
-            return bindingsStream([
-              { uri: blankNode('b0') },
-              { uri: blankNode('b1') },
-            ]);
-          }
-          return bindingsStream([{ uri: namedNode('http://example.com/1') }]);
-        }),
-    };
+    const { fetcher, queries } = pagedFetcher([
+      [{ uri: blankNode('b0') }, { uri: blankNode('b1') }],
+      [{ uri: namedNode('http://example.com/1') }],
+    ]);
 
     const selector = new SparqlItemSelector({
       query,
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    const rows: VariableBindings[] = [];
-    for await (const row of selector.select(distribution, 2)) {
-      rows.push(row);
-    }
+    const rows = await selectAll(selector, 2);
 
     expect(rows.map((row) => row.uri.value)).toEqual(['http://example.com/1']);
     expect(queries).toHaveLength(2);
@@ -216,151 +186,153 @@ describe('SparqlItemSelector', () => {
   });
 
   it('defaults page size to 10', async () => {
-    const queries: string[] = [];
-    const mockFetcher = {
-      fetchBindings: vi
-        .fn()
-        .mockImplementation((_endpoint: string, q: string) => {
-          queries.push(q);
-          return bindingsStream([]);
-        }),
-    };
+    const { fetcher, queries } = pagedFetcher([]);
 
     const selector = new SparqlItemSelector({
       query,
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    for await (const _row of selector.select(distribution)) {
-      // consume
-    }
+    await selectAll(selector);
 
     expect(queries[0]).toMatch(/LIMIT\s+10/);
   });
 
   it('uses batchSize from select()', async () => {
-    const queries: string[] = [];
-    const mockFetcher = {
-      fetchBindings: vi
-        .fn()
-        .mockImplementation((_endpoint: string, q: string) => {
-          queries.push(q);
-          return bindingsStream([]);
-        }),
-    };
+    const { fetcher, queries } = pagedFetcher([]);
 
     const selector = new SparqlItemSelector({
       query,
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    for await (const _row of selector.select(distribution, 500)) {
-      // consume
-    }
+    await selectAll(selector, 500);
 
     expect(queries[0]).toMatch(/LIMIT\s+500/);
   });
 
   it('uses query LIMIT as page size', async () => {
-    const queries: string[] = [];
-    const mockFetcher = {
-      fetchBindings: vi
-        .fn()
-        .mockImplementation((_endpoint: string, q: string) => {
-          queries.push(q);
-          return bindingsStream([{ class: namedNode('http://example.com/a') }]);
-        }),
-    };
+    const { fetcher, queries } = pagedFetcher([
+      [{ class: namedNode('http://example.com/a') }],
+    ]);
 
     const selector = new SparqlItemSelector({
       query: 'SELECT ?class WHERE { ?s a ?class } LIMIT 25',
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    for await (const _row of selector.select(distribution)) {
-      // consume
-    }
+    await selectAll(selector);
 
     expect(queries[0]).toMatch(/LIMIT\s+25/);
   });
 
   it('prefers query LIMIT over batchSize from select()', async () => {
-    const queries: string[] = [];
-    const mockFetcher = {
-      fetchBindings: vi
-        .fn()
-        .mockImplementation((_endpoint: string, q: string) => {
-          queries.push(q);
-          return bindingsStream([{ class: namedNode('http://example.com/a') }]);
-        }),
-    };
+    const { fetcher, queries } = pagedFetcher([
+      [{ class: namedNode('http://example.com/a') }],
+    ]);
 
     const selector = new SparqlItemSelector({
       query: 'SELECT ?class WHERE { ?s a ?class } LIMIT 25',
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    for await (const _row of selector.select(distribution, 500)) {
-      // consume
-    }
+    await selectAll(selector, 500);
 
     // Query LIMIT 25 takes priority over batchSize from select().
     expect(queries[0]).toMatch(/LIMIT\s+25/);
   });
 
+  it('rejects a non-positive page size instead of querying pointlessly', async () => {
+    // batchSize 0 (or a query LIMIT 0) is a configuration error: a LIMIT 0
+    // request can never terminate pagination meaningfully, and silently
+    // yielding nothing would make a misconfigured stage look like an empty
+    // source.
+    const { fetcher } = pagedFetcher([]);
+
+    const selector = new SparqlItemSelector({
+      query,
+      fetcher: fetcher as never,
+    });
+
+    await expect(selectAll(selector, 0)).rejects.toThrow(
+      'Page size must be positive',
+    );
+    expect(fetcher.fetchBindings).not.toHaveBeenCalled();
+  });
+
   it('collects all projected variables per row', async () => {
-    const mockFetcher = {
-      fetchBindings: vi.fn().mockImplementation(() =>
-        bindingsStream([
-          {
-            class: namedNode('http://example.com/Person'),
-            property: namedNode('http://example.com/name'),
-          },
-        ]),
-      ),
-    };
+    const { fetcher } = pagedFetcher([
+      [
+        {
+          class: namedNode('http://example.com/Person'),
+          property: namedNode('http://example.com/name'),
+        },
+      ],
+    ]);
 
     const selector = new SparqlItemSelector({
       query: 'SELECT ?class ?property WHERE { ?s a ?class ; ?property ?o }',
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    const rows: VariableBindings[] = [];
-    for await (const row of selector.select(distribution)) {
-      rows.push(row);
-    }
+    const rows = await selectAll(selector);
 
     expect(rows[0].class.value).toBe('http://example.com/Person');
     expect(rows[0].property.value).toBe('http://example.com/name');
   });
 
-  it('includes row when at least one variable is a NamedNode', async () => {
-    const mockFetcher = {
-      fetchBindings: vi.fn().mockImplementation(() =>
-        bindingsStream([
-          {
-            class: namedNode('http://example.com/Person'),
-            label: literal('Person'),
-          },
-        ]),
-      ),
-    };
+  it('drops a row when any projected variable binds a non-NamedNode', async () => {
+    // A partially-usable row is not yielded partially: the bindings are
+    // re-injected into reader queries as a VALUES block, which needs uniform
+    // rows – a row missing one variable would silently weaken the join.
+    const { fetcher } = pagedFetcher([
+      [
+        {
+          class: namedNode('http://example.com/Person'),
+          label: literal('Person'),
+        },
+        {
+          class: namedNode('http://example.com/Organization'),
+          label: namedNode('http://example.com/org-label'),
+        },
+      ],
+    ]);
 
     const selector = new SparqlItemSelector({
       query:
         'SELECT ?class ?label WHERE { ?s a ?class ; <http://www.w3.org/2000/01/rdf-schema#label> ?label }',
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    const rows: VariableBindings[] = [];
-    for await (const row of selector.select(distribution)) {
-      rows.push(row);
-    }
+    const rows = await selectAll(selector);
 
-    // Row is included because ?class is a NamedNode; ?label (literal) is omitted.
     expect(rows).toHaveLength(1);
-    expect(rows[0].class.value).toBe('http://example.com/Person');
-    expect(rows[0].label).toBeUndefined();
+    expect(rows[0].class.value).toBe('http://example.com/Organization');
+  });
+
+  it('drops a row when a projected variable is unbound', async () => {
+    // Same uniformity requirement: an unbound (e.g. OPTIONAL) variable would
+    // leave a hole in the VALUES block.
+    const { fetcher } = pagedFetcher([
+      [
+        { class: namedNode('http://example.com/Person') },
+        {
+          class: namedNode('http://example.com/Organization'),
+          label: namedNode('http://example.com/org-label'),
+        },
+      ],
+    ]);
+
+    const selector = new SparqlItemSelector({
+      query:
+        'SELECT ?class ?label WHERE { ?s a ?class ; <http://www.w3.org/2000/01/rdf-schema#label> ?label }',
+      fetcher: fetcher as never,
+    });
+
+    const rows = await selectAll(selector);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].class.value).toBe('http://example.com/Organization');
   });
 
   it('throws on non-SELECT queries', () => {
@@ -382,43 +354,30 @@ describe('SparqlItemSelector', () => {
   });
 
   it('is assignable to ItemSelector', async () => {
-    const mockFetcher = {
-      fetchBindings: vi
-        .fn()
-        .mockImplementation(() =>
-          bindingsStream([{ uri: namedNode('http://example.com/1') }]),
-        ),
-    };
+    const { fetcher } = pagedFetcher([
+      [{ uri: namedNode('http://example.com/1') }],
+    ]);
 
     // Verify SparqlItemSelector satisfies ItemSelector.
     const selector: ItemSelector = new SparqlItemSelector({
       query,
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    const rows: VariableBindings[] = [];
-    for await (const row of selector.select(distribution)) {
-      rows.push(row);
-    }
-
-    expect(rows).toHaveLength(1);
+    expect(await selectAll(selector)).toHaveLength(1);
   });
 
   it('uses distribution endpoint for SPARQL queries', async () => {
-    const mockFetcher = {
-      fetchBindings: vi.fn().mockImplementation(() => bindingsStream([])),
-    };
+    const { fetcher } = pagedFetcher([]);
 
     const selector = new SparqlItemSelector({
       query,
-      fetcher: mockFetcher as never,
+      fetcher: fetcher as never,
     });
 
-    for await (const _row of selector.select(distribution)) {
-      // consume
-    }
+    await selectAll(selector);
 
-    expect(mockFetcher.fetchBindings).toHaveBeenCalledWith(
+    expect(fetcher.fetchBindings).toHaveBeenCalledWith(
       'http://example.com/sparql',
       expect.any(String),
     );
@@ -426,59 +385,39 @@ describe('SparqlItemSelector', () => {
 
   describe('maxResults', () => {
     it('caps total bindings yielded across pages', async () => {
-      const mockFetcher = {
-        fetchBindings: vi
-          .fn()
-          .mockImplementation(() =>
-            bindingsStream([
-              { uri: namedNode('http://example.com/1') },
-              { uri: namedNode('http://example.com/2') },
-              { uri: namedNode('http://example.com/3') },
-              { uri: namedNode('http://example.com/4') },
-              { uri: namedNode('http://example.com/5') },
-            ]),
-          ),
-      };
+      const { fetcher } = pagedFetcher([
+        [
+          { uri: namedNode('http://example.com/1') },
+          { uri: namedNode('http://example.com/2') },
+          { uri: namedNode('http://example.com/3') },
+          { uri: namedNode('http://example.com/4') },
+          { uri: namedNode('http://example.com/5') },
+        ],
+      ]);
 
       const selector = new SparqlItemSelector({
         query,
-        fetcher: mockFetcher as never,
+        fetcher: fetcher as never,
         maxResults: 3,
       });
 
-      const rows: VariableBindings[] = [];
-      for await (const row of selector.select(distribution, 100)) {
-        rows.push(row);
-      }
-
-      expect(rows).toHaveLength(3);
+      expect(await selectAll(selector, 100)).toHaveLength(3);
     });
 
     it('does not clamp the first page LIMIT to maxResults (page size and total cap stay orthogonal)', async () => {
-      const queries: string[] = [];
-      const mockFetcher = {
-        fetchBindings: vi
-          .fn()
-          .mockImplementation((_endpoint: string, q: string) => {
-            queries.push(q);
-            return bindingsStream(
-              Array.from({ length: 100 }, (_, i) => ({
-                uri: namedNode(`http://example.com/${i + 1}`),
-              })),
-            );
-          }),
-      };
+      const { fetcher, queries } = pagedFetcher([
+        Array.from({ length: 100 }, (_, i) => ({
+          uri: namedNode(`http://example.com/${i + 1}`),
+        })),
+      ]);
 
       const selector = new SparqlItemSelector({
         query,
-        fetcher: mockFetcher as never,
+        fetcher: fetcher as never,
         maxResults: 5,
       });
 
-      const rows: VariableBindings[] = [];
-      for await (const row of selector.select(distribution, 100)) {
-        rows.push(row);
-      }
+      const rows = await selectAll(selector, 100);
 
       // The first page asks for the configured page size (100), even though
       // we only yield 5 rows from it.
@@ -487,90 +426,113 @@ describe('SparqlItemSelector', () => {
     });
 
     it('shrinks the last page LIMIT to the remaining cap', async () => {
-      const queries: string[] = [];
-      let calls = 0;
-      const mockFetcher = {
-        fetchBindings: vi
-          .fn()
-          .mockImplementation((_endpoint: string, q: string) => {
-            queries.push(q);
-            calls++;
-            // First page returns 10 rows; second page request should be
-            // shrunk to LIMIT 2 (12 total cap minus 10 already yielded).
-            return bindingsStream(
-              Array.from({ length: calls === 1 ? 10 : 2 }, (_, i) => ({
-                uri: namedNode(`http://example.com/${calls}-${i + 1}`),
-              })),
-            );
-          }),
-      };
+      // First page returns 10 rows; the second page request is shrunk to
+      // LIMIT 2 (12 total cap minus 10 already yielded).
+      const { fetcher, queries } = pagedFetcher([
+        Array.from({ length: 10 }, (_, i) => ({
+          uri: namedNode(`http://example.com/1-${i + 1}`),
+        })),
+        Array.from({ length: 2 }, (_, i) => ({
+          uri: namedNode(`http://example.com/2-${i + 1}`),
+        })),
+      ]);
 
       const selector = new SparqlItemSelector({
         query,
-        fetcher: mockFetcher as never,
+        fetcher: fetcher as never,
         maxResults: 12,
       });
 
-      const rows: VariableBindings[] = [];
-      for await (const row of selector.select(distribution, 10)) {
-        rows.push(row);
-      }
+      const rows = await selectAll(selector, 10);
 
       expect(queries[0]).toMatch(/LIMIT\s+10/);
       expect(queries[1]).toMatch(/LIMIT\s+2/);
       expect(rows).toHaveLength(12);
     });
 
-    it('does not paginate beyond maxResults', async () => {
-      let calls = 0;
-      const mockFetcher = {
-        fetchBindings: vi.fn().mockImplementation(() => {
-          calls++;
-          return bindingsStream([
-            { uri: namedNode(`http://example.com/${calls}-1`) },
-            { uri: namedNode(`http://example.com/${calls}-2`) },
-          ]);
-        }),
-      };
+    it('keeps full-size pages once rows have been dropped', async () => {
+      // With dropped rows, yields lag fetches – shrinking pages to the yielded
+      // remainder would crawl a dropped-row region at down to one row per
+      // request. Page 1 (LIMIT 3) yields 2 of 3 rows; the cap has 1 left, but
+      // page 2 must still ask for LIMIT 3, and the cap still holds.
+      const { fetcher, queries } = pagedFetcher([
+        [
+          { uri: namedNode('http://example.com/1') },
+          { uri: blankNode('b0') },
+          { uri: namedNode('http://example.com/2') },
+        ],
+        [
+          { uri: blankNode('b1') },
+          { uri: namedNode('http://example.com/3') },
+          { uri: namedNode('http://example.com/4') },
+        ],
+      ]);
 
       const selector = new SparqlItemSelector({
         query,
-        fetcher: mockFetcher as never,
+        fetcher: fetcher as never,
+        maxResults: 3,
+      });
+
+      const rows = await selectAll(selector, 3);
+
+      expect(rows.map((row) => row.uri.value)).toEqual([
+        'http://example.com/1',
+        'http://example.com/2',
+        'http://example.com/3',
+      ]);
+      expect(queries[1]).toMatch(/LIMIT\s+3/);
+      expect(queries[1]).toMatch(/OFFSET\s+3/);
+    });
+
+    it('does not paginate beyond maxResults', async () => {
+      const { fetcher, queries } = pagedFetcher([
+        [
+          { uri: namedNode('http://example.com/1-1') },
+          { uri: namedNode('http://example.com/1-2') },
+        ],
+        [
+          { uri: namedNode('http://example.com/2-1') },
+          { uri: namedNode('http://example.com/2-2') },
+        ],
+      ]);
+
+      const selector = new SparqlItemSelector({
+        query,
+        fetcher: fetcher as never,
         maxResults: 2,
       });
 
-      const rows: VariableBindings[] = [];
-      for await (const row of selector.select(distribution, 2)) {
-        rows.push(row);
-      }
-
-      expect(rows).toHaveLength(2);
+      expect(await selectAll(selector, 2)).toHaveLength(2);
       // Only one page fetched; we don't keep asking for more.
-      expect(calls).toBe(1);
+      expect(queries).toHaveLength(1);
     });
 
     it('yields nothing when maxResults is 0', async () => {
-      const mockFetcher = {
-        fetchBindings: vi
-          .fn()
-          .mockImplementation(() =>
-            bindingsStream([{ uri: namedNode('http://example.com/1') }]),
-          ),
-      };
+      const { fetcher } = pagedFetcher([
+        [{ uri: namedNode('http://example.com/1') }],
+      ]);
 
       const selector = new SparqlItemSelector({
         query,
-        fetcher: mockFetcher as never,
+        fetcher: fetcher as never,
         maxResults: 0,
       });
 
-      const rows: VariableBindings[] = [];
-      for await (const row of selector.select(distribution, 10)) {
-        rows.push(row);
-      }
+      expect(await selectAll(selector, 10)).toHaveLength(0);
+      expect(fetcher.fetchBindings).not.toHaveBeenCalled();
+    });
 
-      expect(rows).toHaveLength(0);
-      expect(mockFetcher.fetchBindings).not.toHaveBeenCalled();
+    it('rejects a negative maxResults', () => {
+      // A negative cap (e.g. an underflowed computed value) would silently
+      // behave as maxResults 1: the first yield satisfies totalYielded >= -1.
+      expect(
+        () =>
+          new SparqlItemSelector({
+            query,
+            maxResults: -1,
+          }),
+      ).toThrow('maxResults must not be negative');
     });
   });
 
@@ -583,24 +545,18 @@ describe('SparqlItemSelector', () => {
     }
 
     it('calls beforeRequest and afterRequest({outcome: "ok"}) per page', async () => {
-      const mockFetcher = {
-        fetchBindings: vi
-          .fn()
-          .mockImplementationOnce(() =>
-            bindingsStream([
-              { uri: namedNode('http://example.com/1') },
-              { uri: namedNode('http://example.com/2') },
-            ]),
-          )
-          .mockImplementationOnce(() =>
-            bindingsStream([{ uri: namedNode('http://example.com/3') }]),
-          ),
-      };
+      const { fetcher } = pagedFetcher([
+        [
+          { uri: namedNode('http://example.com/1') },
+          { uri: namedNode('http://example.com/2') },
+        ],
+        [{ uri: namedNode('http://example.com/3') }],
+      ]);
 
       const policy = recordingPolicy();
       const selector = new SparqlItemSelector({
         query,
-        fetcher: mockFetcher as never,
+        fetcher: fetcher as never,
       });
 
       const rows: VariableBindings[] = [];
@@ -693,7 +649,7 @@ describe('SparqlItemSelector', () => {
         fetcher: mockFetcher as never,
       });
 
-      // No policy supplied at construction or per call – pagination still
+      // No policy supplied at construction or per call — pagination still
       // works against the module-level default policy.
       const rows: VariableBindings[] = [];
       for await (const row of selector.select(distribution, 10)) {

--- a/packages/pipeline/test/sparql/selector.test.ts
+++ b/packages/pipeline/test/sparql/selector.test.ts
@@ -143,6 +143,78 @@ describe('SparqlItemSelector', () => {
     expect(rows[1].uri.value).toBe('http://example.com/2');
   });
 
+  it('keeps paginating when a full page contains skipped rows', async () => {
+    // A skipped (blank-node) row still occupied a result slot at the endpoint:
+    // the page is full, so pagination must continue – and OFFSET must advance
+    // by the fetched count, not the yielded count, or rows are re-read.
+    const queries: string[] = [];
+    const mockFetcher = {
+      fetchBindings: vi
+        .fn()
+        .mockImplementation((_endpoint: string, q: string) => {
+          queries.push(q);
+          if (queries.length === 1) {
+            return bindingsStream([
+              { uri: blankNode('b0') },
+              { uri: namedNode('http://example.com/1') },
+            ]);
+          }
+          return bindingsStream([{ uri: namedNode('http://example.com/2') }]);
+        }),
+    };
+
+    const selector = new SparqlItemSelector({
+      query,
+      fetcher: mockFetcher as never,
+    });
+
+    const rows: VariableBindings[] = [];
+    for await (const row of selector.select(distribution, 2)) {
+      rows.push(row);
+    }
+
+    expect(rows.map((row) => row.uri.value)).toEqual([
+      'http://example.com/1',
+      'http://example.com/2',
+    ]);
+    expect(queries).toHaveLength(2);
+    expect(queries[1]).toMatch(/OFFSET\s+2/);
+  });
+
+  it('keeps paginating past a page of only skipped rows', async () => {
+    // All rows dropped is not the end of the results – the endpoint returned a
+    // full page, so the next page may still hold yieldable rows.
+    const queries: string[] = [];
+    const mockFetcher = {
+      fetchBindings: vi
+        .fn()
+        .mockImplementation((_endpoint: string, q: string) => {
+          queries.push(q);
+          if (queries.length === 1) {
+            return bindingsStream([
+              { uri: blankNode('b0') },
+              { uri: blankNode('b1') },
+            ]);
+          }
+          return bindingsStream([{ uri: namedNode('http://example.com/1') }]);
+        }),
+    };
+
+    const selector = new SparqlItemSelector({
+      query,
+      fetcher: mockFetcher as never,
+    });
+
+    const rows: VariableBindings[] = [];
+    for await (const row of selector.select(distribution, 2)) {
+      rows.push(row);
+    }
+
+    expect(rows.map((row) => row.uri.value)).toEqual(['http://example.com/1']);
+    expect(queries).toHaveLength(2);
+    expect(queries[1]).toMatch(/OFFSET\s+2/);
+  });
+
   it('defaults page size to 10', async () => {
     const queries: string[] = [];
     const mockFetcher = {
@@ -621,7 +693,7 @@ describe('SparqlItemSelector', () => {
         fetcher: mockFetcher as never,
       });
 
-      // No policy supplied at construction or per call — pagination still
+      // No policy supplied at construction or per call – pagination still
       // works against the module-level default policy.
       const rows: VariableBindings[] = [];
       for await (const row of selector.select(distribution, 10)) {

--- a/packages/pipeline/vite.config.ts
+++ b/packages/pipeline/vite.config.ts
@@ -11,10 +11,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          functions: 97.43,
-          lines: 97.09,
-          branches: 91.79,
-          statements: 96.63,
+          functions: 97.44,
+          lines: 97.1,
+          branches: 91.87,
+          statements: 96.65,
         },
       },
     },


### PR DESCRIPTION
Fix #645

## `@lde/pipeline` – `SparqlItemSelector`

**Pagination counts fetched rows, yielded rows only count toward `maxResults`.** The selector drops rows client-side after fetching a page, but counted only yielded rows for pagination: any page containing a dropped (e.g. blank-node) row looked short, terminating pagination early and silently skipping the rest of the results – and `OFFSET` advancing by the yielded count would have re-read rows. A page of entirely dropped rows also no longer ends the walk.

Follow-up hardening from an in-depth review of the fix:

- **Uniform IRI rows (BREAKING).** A row is now yielded only when *every* projected variable binds a `NamedNode`, instead of yielding partial rows when at least one did. Bindings are re-injected into reader queries as a `VALUES` block, which needs uniform rows: a partially-bound row silently weakened the join, and a row could even lose its identity variable yet still yield.
- **No page shrinking once rows have been dropped.** The `maxResults` last-page clamp assumed fetched ≈ yielded; combined with drop-tolerant pagination it would have crawled a dropped-row region at down to `LIMIT 1` per HTTP request. Pages now stay at full size once yields lag fetches; the mid-stream cap check still stops exactly on `maxResults`.
- **Loud configuration errors.** A non-positive page size (`batchSize: 0` or a query `LIMIT 0`) now throws instead of silently yielding nothing, and a negative `maxResults` throws instead of behaving as `maxResults: 1`.
- **One source for the rationale.** The full dropped-row/pagination reasoning lives in the class JSDoc; the README states the user-facing contract, with `FILTER(isIRI(?s))` as the query-side remedy (covers blank nodes *and* literals).
- **Tests**: `pagedFetcher`/`selectAll` helpers replace nine copies of the hand-rolled mock-fetcher scaffold; new coverage for partly- and fully-dropped pages, `maxResults` combined with dropped rows, unbound projected variables, and the new validation errors. The original two pagination tests were verified red against the pre-fix implementation.

## Query-side filters for callers

`@lde/pipeline-shacl-sampler`'s subject selector and `@lde/pipeline-void`'s class selector now exclude blank nodes at the endpoint (`FILTER(!isBlank(…))`), like `@lde/search-pipeline`'s `selectByClass` (#644). Without this, a class instantiated by many blank nodes would be fetched and walked to the end through pages that yield nothing.

## Streaming

Unchanged: rows still stream through as the endpoint delivers them; dropped rows are discarded immediately, and memory stays bounded by page size.
