### PR TITLE
feat(search-indexer): ship the search indexer as a CLI and Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '@lde/search-api-server@*'
+      - '@lde/search-indexer@*'
   workflow_dispatch:
     inputs:
       ref:
@@ -31,14 +32,17 @@ jobs:
       # The image is built from this tagged commit's own workspace outputs
       # (nx docker:build stages the compiled package, its workspace
       # dependencies and a pruned lockfile), so it needs no npm publish to
-      # have happened – the release tag alone identifies the version.
-      - name: Determine version
+      # have happened – the release tag alone identifies the package and
+      # version (e.g. "@lde/search-indexer@0.1.0").
+      - name: Determine package and version
         id: version
         # The ref reaches the shell via env, never inline interpolation, so a
         # crafted dispatch input cannot inject shell syntax.
         env:
           REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}
         run: |
+          package="${REF#@lde/}"
+          echo "package=${package%@*}" >> "$GITHUB_OUTPUT"
           echo "version=${REF##*@}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v7
@@ -49,7 +53,7 @@ jobs:
       - run: npm ci
 
       - name: Build and smoke-test the image
-        run: npx nx run @lde/search-api-server:docker:smoke
+        run: npx nx run "@lde/${{ steps.version.outputs.package }}:docker:smoke"
 
       - uses: docker/login-action@v3
         with:
@@ -59,7 +63,9 @@ jobs:
 
       - name: Push the image
         run: |
-          docker tag packages-search-api-server "ghcr.io/ldelements/search-api-server:${{ steps.version.outputs.version }}"
-          docker tag packages-search-api-server ghcr.io/ldelements/search-api-server:latest
-          docker push "ghcr.io/ldelements/search-api-server:${{ steps.version.outputs.version }}"
-          docker push ghcr.io/ldelements/search-api-server:latest
+          package="${{ steps.version.outputs.package }}"
+          version="${{ steps.version.outputs.version }}"
+          docker tag "packages-${package}" "ghcr.io/ldelements/${package}:${version}"
+          docker tag "packages-${package}" "ghcr.io/ldelements/${package}:latest"
+          docker push "ghcr.io/ldelements/${package}:${version}"
+          docker push "ghcr.io/ldelements/${package}:latest"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ await pipeline.run();
   <td>The served search API as a bootable process and prebuilt Docker image: mounts a schema-declaration module, binds the GraphQL handler to a Typesense engine, and serves /graphql plus /health from environment config</td>
 </tr>
 <tr>
+  <td><a href="packages/search-indexer">@lde/search-indexer</a></td>
+  <td><a href="https://www.npmjs.com/package/@lde/search-indexer"><img src="https://img.shields.io/npm/v/@lde/search-indexer" alt="npm"></a></td>
+  <td>The search indexer as a bootable process and prebuilt Docker image: mounts the same schema-declaration module as the API server, selects datasets from a registry, and rebuilds the Typesense collections from environment config</td>
+</tr>
+<tr>
   <td><a href="packages/search-pipeline">@lde/search-pipeline</a></td>
   <td><a href="https://www.npmjs.com/package/@lde/search-pipeline"><img src="https://img.shields.io/npm/v/@lde/search-pipeline" alt="npm"></a></td>
   <td>Applies the @lde/search projection inside an @lde/pipeline run, fanning each document out to the transactional engine writer for its type’s collection (owns no projection itself)</td>
@@ -253,6 +258,10 @@ graph TD
     search-typesense --> pipeline
     search-pipeline --> search
     search-pipeline --> pipeline
+    search-indexer --> search-pipeline
+    search-indexer --> search-typesense
+    search-indexer --> sparql-qlever
+    search-indexer --> pipeline-console-reporter
   end
 
   subgraph Monitoring

--- a/docs/decisions/0016-ship-the-search-indexer-as-a-config-driven-image.md
+++ b/docs/decisions/0016-ship-the-search-indexer-as-a-config-driven-image.md
@@ -1,0 +1,86 @@
+# 16. Ship the search indexer as a config-driven image
+
+Date: 2026-07-24
+
+## Status
+
+Accepted
+
+Extends [ADR 15 (Ship the served search API as a Docker image built from the
+workspace)](./0015-ship-the-served-search-api-as-a-docker-image-built-from-the-workspace.md).
+Implements [#652](https://github.com/ldelements/lde/issues/652), the
+write-path counterpart of #600/#646.
+
+## Context
+
+`searchIndexerPipeline()` (#647) composes the object-grain search indexer,
+but still requires a Node program around it. The read path already ends in a
+bootable image (ADR 15); the write path needs the same final layer, and the
+symmetry is the point: mount the **same schema-declaration module** into both
+images, point both at the same `TYPESENSE_*` coordinates, and the write and
+read sides cannot disagree about the schema.
+
+The one open design problem is the import path (`ImportResolver` +
+`@lde/sparql-qlever`). Importing is not ‘have a QLever running’ but a
+per-dataset control loop: download the dump, build the index offline,
+(re)start the server on the new index. A statically-declared QLever service
+(Docker Compose service, Kubernetes sidecar) therefore **cannot work**: it
+only exposes a SPARQL port, and the pipeline has no control plane to rebuild
+its index per dataset. Feeding a running server is not viable either – SPARQL
+UPDATE’s update-triples overlay performs badly and deleted triples can
+reappear after restart, and Graph Store HTTP `POST` is unusable for large
+datasets (ad-freiburg/qlever#2014). A QLever the pipeline uses must be a
+QLever the pipeline controls.
+
+## Decision
+
+- **A separate composition package, `@lde/search-indexer`**: environment
+  config, the shared schema-module loader, dataset selection against a
+  registry, and Typesense rebuild writers around `searchIndexerPipeline`.
+  Engine-bound to Typesense deliberately – that binding cannot live in
+  `@lde/search-pipeline` without breaking its engine-agnosticism. Published
+  to npm and shipped as `ghcr.io/ldelements/search-indexer`, reusing ADR 15’s
+  entire delivery pattern (workspace-built image, `docker:smoke` CI gate,
+  release-tag-triggered publish).
+- **The schema-module loader moves to `@lde/search/module`** and both images
+  use it, implementing the shared-mount symmetry in code: one loader, one
+  validation, one error vocabulary. Consumer-specific optional exports
+  (`schemaOptions`, `engineOptions`) stay validated in the consumers.
+- **Configuration is env-only and boot-or-fail**, every problem reported in
+  one error (ADR 15’s pattern): registry endpoint plus dataset IRIs or
+  criteria, `TYPESENSE_*`, rebuild mode, optional collection prefix, optional
+  file provenance + pipeline version. Two combinations are rejected at boot:
+  provenance with only one of its two halves, and provenance with blue-green
+  rebuilds – a skipped dataset would be missing from the fresh collection the
+  swap makes live.
+- **v1 ships endpoint-only by default, plus the Docker-socket import path
+  behind a flag.** `QLEVER_IMAGE` turns on `ImportResolver` with
+  `DockerTaskRunner`: the indexer container spawns and fully controls sibling
+  QLever containers over the mounted socket. It is free (the runner exists
+  and talks to the socket via dockerode), Compose-friendly, and keeps QLever
+  out of the indexer’s cgroup. Its limits are documented, not worked around:
+  no socket, no import path – on containerd-based Kubernetes, run
+  endpoint-only.
+- **Native mode in-image is the Kubernetes follow-up, not part of v1**:
+  shipping the QLever engine inside the indexer image (`NativeTaskRunner`)
+  works anywhere a container runs, but costs image size, engine-version
+  coupling and a shared cgroup (a QLever OOM kills the indexer). A
+  controllable QLever sidecar (own control agent and protocol) is only worth
+  designing if both other options prove unacceptable.
+
+## Consequences
+
+- Ops deploys configure the indexer (a cron job in Compose or Kubernetes)
+  instead of writing a Node program; deployments with bespoke root selectors
+  or per-stage tuning stay on the first-class library path
+  (`searchStages` + `searchIndexWriter` + `Pipeline`).
+- One mounted module drives both images; schema drift between the write and
+  read side is no longer expressible in deployment config.
+- The image runs batch-style: no ports, no `HEALTHCHECK`; overlapping runs
+  are serialized by the rebuild writers’ cross-pod lock.
+- The import path requires Docker-socket access and an identical host path
+  for `DATA_DIR` in the indexer and its sibling QLever containers – both
+  documented in the package README, both moot in endpoint-only mode.
+- When the Kubernetes need materializes, native mode lands as a second image
+  variant (or a base-image switch) without touching the configuration
+  surface: `QLEVER_IMAGE` is the only Docker-specific knob.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20441,6 +20441,10 @@
       "resolved": "packages/search-api-server",
       "link": true
     },
+    "node_modules/@lde/search-indexer": {
+      "resolved": "packages/search-indexer",
+      "link": true
+    },
     "node_modules/@lde/search-pipeline": {
       "resolved": "packages/search-pipeline",
       "link": true
@@ -38350,6 +38354,35 @@
       },
       "bin": {
         "search-api-server": "dist/cli.js"
+      }
+    },
+    "packages/search-indexer": {
+      "name": "@lde/search-indexer",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@lde/dataset-registry-client": "^0.9.0",
+        "@lde/pipeline": "^0.35.1",
+        "@lde/pipeline-console-reporter": "^0.26.1",
+        "@lde/search": "^0.12.1",
+        "@lde/search-pipeline": "^0.12.2",
+        "@lde/search-typesense": "^0.15.2",
+        "@lde/sparql-qlever": "^0.15.1",
+        "commander": "^15.0.0",
+        "tslib": "^2.3.0",
+        "typesense": "^3.0.6"
+      },
+      "bin": {
+        "search-indexer": "dist/cli.js"
+      }
+    },
+    "packages/search-indexer/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "packages/search-pipeline": {

--- a/packages/search-api-server/src/schema-module.ts
+++ b/packages/search-api-server/src/schema-module.ts
@@ -1,5 +1,5 @@
-import { pathToFileURL } from 'node:url';
-import { searchSchema, type SearchSchema, type SearchType } from '@lde/search';
+import { loadSchemaModule as loadDeclarations } from '@lde/search/module';
+import type { SearchSchema } from '@lde/search';
 import type { BuildGraphQLSchemaOptions } from '@lde/search-api-graphql';
 import type { TypesenseSearchEngineOptions } from '@lde/search-typesense';
 
@@ -26,48 +26,22 @@ export interface SchemaModule {
 }
 
 /**
- * Load and validate a mounted schema-declaration module: an ES module whose
- * default export is a non-empty array of {@link SearchType} declarations.
- * Throws with the module path in the message for every failure mode – an
- * unreadable file, a wrong export shape, an invalid declaration – so a bad
- * mount fails the boot with a diagnosis, never the first query.
+ * Load and validate a mounted schema-declaration module
+ * (`@lde/search/module`’s {@link loadDeclarations | loadSchemaModule} – the
+ * loader the indexer image shares, so both sides mount the same file), then
+ * validate the read side’s optional exports. Throws with the module path in
+ * the message for every failure mode, so a bad mount fails the boot with a
+ * diagnosis, never the first query.
  */
 export async function loadSchemaModule(
   modulePath: string,
 ): Promise<SchemaModule> {
-  let moduleExports: Record<string, unknown>;
-  try {
-    moduleExports = (await import(pathToFileURL(modulePath).href)) as Record<
-      string,
-      unknown
-    >;
-  } catch (cause) {
-    throw new Error(
-      `Cannot load schema module “${modulePath}”: ${cause instanceof Error ? cause.message : String(cause)}`,
-      { cause },
-    );
-  }
-  const declarations = moduleExports['default'];
-  if (!Array.isArray(declarations) || declarations.length === 0) {
-    throw new Error(
-      `Schema module “${modulePath}” must default-export a non-empty array of search type declarations.`,
-    );
-  }
-  try {
-    return {
-      searchSchema: searchSchema(...(declarations as SearchType[])),
-      schemaOptions: optionalObject(moduleExports, 'schemaOptions', modulePath),
-      engineOptions: optionalObject(moduleExports, 'engineOptions', modulePath),
-    };
-  } catch (cause) {
-    if (cause instanceof Error && cause.message.includes(modulePath)) {
-      throw cause;
-    }
-    throw new Error(
-      `Schema module “${modulePath}” declares an invalid schema: ${cause instanceof Error ? cause.message : String(cause)}`,
-      { cause },
-    );
-  }
+  const { schema, moduleExports } = await loadDeclarations(modulePath);
+  return {
+    searchSchema: schema,
+    schemaOptions: optionalObject(moduleExports, 'schemaOptions', modulePath),
+    engineOptions: optionalObject(moduleExports, 'engineOptions', modulePath),
+  };
 }
 
 function optionalObject<Options>(

--- a/packages/search-api-server/test/fixtures/invalid-options.mjs
+++ b/packages/search-api-server/test/fixtures/invalid-options.mjs
@@ -1,0 +1,12 @@
+export default [
+  {
+    name: 'Dataset',
+    class: 'http://www.w3.org/ns/dcat#Dataset',
+    fields: [
+      { name: 'title', kind: 'text', locales: ['en'], output: true },
+    ],
+  },
+];
+
+// Not an object: rejected at boot.
+export const schemaOptions = 'nope';

--- a/packages/search-api-server/test/schema-module.test.ts
+++ b/packages/search-api-server/test/schema-module.test.ts
@@ -33,4 +33,10 @@ describe('loadSchemaModule', () => {
       loadSchemaModule(fixture('invalid-declaration.mjs')),
     ).rejects.toThrowError(/declares an invalid schema/);
   });
+
+  it('rejects a non-object optional export, naming it', async () => {
+    await expect(
+      loadSchemaModule(fixture('invalid-options.mjs')),
+    ).rejects.toThrowError(/export “schemaOptions” must be an object/);
+  });
 });

--- a/packages/search-api-server/vite.config.ts
+++ b/packages/search-api-server/vite.config.ts
@@ -20,9 +20,9 @@ export default mergeConfig(
         thresholds: {
           autoUpdate: true,
           functions: 100,
-          lines: 96.92,
-          branches: 90.56,
-          statements: 96.96,
+          lines: 100,
+          branches: 97.56,
+          statements: 100,
         },
       },
     },

--- a/packages/search-indexer/Dockerfile
+++ b/packages/search-indexer/Dockerfile
@@ -1,0 +1,29 @@
+# The prebuilt search indexer (https://github.com/ldelements/lde/issues/652,
+# the write-path counterpart of the search-api-server image), built from this
+# workspace’s own outputs: `nx run @lde/search-indexer:docker:build` stages the
+# compiled package, the same-commit builds of its @lde/* workspace dependencies
+# (copy-workspace-modules) and a pruned lockfile (prune-lockfile) into
+# dist-docker/, so the image never waits on – or drifts from – an npm publish.
+# CI smoke-tests the running image (docker:smoke); releases push it to
+# ghcr.io/ldelements/search-indexer (.github/workflows/docker.yml).
+FROM node:24-alpine
+LABEL org.opencontainers.image.source="https://github.com/ldelements/lde"
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY dist-docker/package.json dist-docker/package-lock.json ./
+# --legacy-peer-deps: must match the flag the docker:lockfile repair step
+# installs with, or `npm ci` rejects the lockfile over peers that step left
+# out (typesense declares a `@babel/runtime` peer no runtime import needs).
+# The docker:smoke boot test guards that nothing genuinely needed is missing.
+RUN npm ci --omit=dev --legacy-peer-deps
+# Lays the same-commit workspace modules over the registry-installed tree.
+COPY dist-docker/ ./
+
+# Default DATA_DIR for the QLever import path; a real deployment mounts a
+# volume here (and the same host path into the sibling QLever container).
+RUN mkdir -p /data && chown node:node /data
+
+USER node
+CMD ["node", "dist/cli.js"]

--- a/packages/search-indexer/README.md
+++ b/packages/search-indexer/README.md
@@ -1,0 +1,133 @@
+# @lde/search-indexer
+
+The [@lde/search-pipeline](../search-pipeline) indexer as a bootable process
+and prebuilt Docker image: mount a schema-declaration module, point it at a
+dataset registry and Typesense, and one run selects the datasets, extracts and
+projects each root type per the schema, and rebuilds the engine collections –
+then exits. Run it as a cron job; the rebuild writers’ cross-pod lock makes an
+overlapping run fail fast instead of corrupting a collection.
+
+This is the write-path counterpart of
+[`@lde/search-api-server`](../search-api-server)
+([#652](https://github.com/ldelements/lde/issues/652)): the composition layer
+that binds the engine-agnostic `searchIndexerPipeline` to the
+[`@lde/search-typesense`](../search-typesense) rebuild writers. Mount the
+**same schema module** into both images and point both at the same
+`TYPESENSE_*` coordinates, and the write and the read side cannot disagree
+about the schema. A deployment that needs more – a bespoke root selector,
+per-stage tuning, another engine – composes `searchStages`,
+`searchIndexWriter` and `Pipeline` directly instead.
+
+## Run
+
+```sh
+docker run --rm \
+  --volume ./search-schema.mjs:/config/search-schema.mjs:ro \
+  --env REGISTRY_ENDPOINT=https://registry.example.org/sparql \
+  --env TYPESENSE_HOST=typesense.internal \
+  --env TYPESENSE_API_KEY=admin-key \
+  ghcr.io/ldelements/search-indexer
+```
+
+Or without Docker (the same environment variables apply):
+
+```sh
+npx @lde/search-indexer
+```
+
+Dataset IRIs can also be passed as arguments, which override `DATASETS`:
+
+```sh
+npx @lde/search-indexer https://example.org/id/dataset/1
+```
+
+`--check` validates the configuration and schema module, then exits without
+indexing – for CI and init containers.
+
+## The schema module
+
+The mounted module default-exports the deployment’s search type declarations
+as **plain data** – see [the API server’s
+README](../search-api-server/README.md#the-schema-module) for the format and
+authoring guidance; both images load the module with the same
+`@lde/search/module` loader. The indexer reads only the default export: the
+declarations drive one pipeline stage and one engine collection per root type,
+and each field’s `path` drives the extraction CONSTRUCT. The read-side extras
+(`schemaOptions`, `engineOptions`) are ignored here, so one file serves both
+images.
+
+## Configuration
+
+| Variable             | Default                     | Meaning                                                                      |
+| -------------------- | --------------------------- | ---------------------------------------------------------------------------- |
+| `SCHEMA_MODULE`      | `/config/search-schema.mjs` | Path of the mounted schema-declaration module                                |
+| `REGISTRY_ENDPOINT`  | **required**                | SPARQL endpoint of the DCAT dataset registry                                 |
+| `DATASETS`           | all registry datasets       | Dataset IRIs to index (whitespace- or comma-separated)                       |
+| `DATASET_CRITERIA`   | all registry datasets       | Registry search criteria as a JSON object (mutually exclusive w/ `DATASETS`) |
+| `TYPESENSE_HOST`     | **required**                | Typesense host                                                               |
+| `TYPESENSE_PORT`     | `8108`                      | Typesense port                                                               |
+| `TYPESENSE_PROTOCOL` | `http`                      | `http` or `https`                                                            |
+| `TYPESENSE_API_KEY`  | **required**                | An admin key: the indexer creates, writes and swaps collections              |
+| `REBUILD_MODE`       | `in-place`                  | `in-place` (update the live collection) or `blue-green` (swap on commit)     |
+| `COLLECTION_PREFIX`  | none                        | Prefix for every derived collection name (configure the read side to match)  |
+| `PROVENANCE_FILE`    | none                        | JSON file remembering per-dataset processing, to skip unchanged datasets     |
+| `PIPELINE_VERSION`   | none                        | Version keying the skip decisions; required with `PROVENANCE_FILE`           |
+| `QLEVER_IMAGE`       | none                        | Enables the QLever import path (see below), e.g. `adfreiburg/qlever:latest`  |
+| `IMPORT_STRATEGY`    | `sparql`                    | `sparql`, `sparqlWithImportFallback` or `import`; requires `QLEVER_IMAGE`    |
+| `DATA_DIR`           | `/data`                     | Directory for downloaded dumps and QLever index caches                       |
+
+A misconfigured boot reports **all** problems in one error, not one per crash
+loop. `PROVENANCE_FILE` must sit on a durable volume, and cannot be combined
+with `REBUILD_MODE=blue-green`: a skipped dataset would be missing from the
+fresh collection the swap makes live.
+
+## The QLever import path
+
+By default the indexer serves only datasets that publish a live SPARQL
+endpoint (the pipeline’s endpoint-only default). Setting `QLEVER_IMAGE`
+enables the import path: data dumps are downloaded to `DATA_DIR` and imported
+into a QLever instance the **pipeline itself creates and controls** – one
+sibling container per dataset, spawned over the Docker socket
+([ADR 16](../../docs/decisions/0016-ship-the-search-indexer-as-a-config-driven-image.md)
+explains why a statically-declared QLever service cannot work). That requires:
+
+- the Docker socket mounted into the indexer container
+  (`--volume /var/run/docker.sock:/var/run/docker.sock`), plus a group grant
+  to reach it as the image’s non-root user
+  (`--group-add $(stat -c %g /var/run/docker.sock)`);
+- `DATA_DIR` on a volume whose **host path is identical** for the indexer and
+  the spawned QLever containers – the pipeline passes `DATA_DIR` as a bind
+  mount to a sibling container, where it resolves against the host.
+
+This mode does not work on container runtimes without a Docker socket
+(containerd-based Kubernetes); there, run endpoint-only for now.
+
+## Building the image
+
+The image is built from the workspace’s own outputs – the compiled package,
+the same-commit builds of its `@lde/*` dependencies and a pruned lockfile –
+never from npm, so it exists for any commit
+([ADR 15](../../docs/decisions/0015-ship-the-served-search-api-as-a-docker-image-built-from-the-workspace.md)):
+
+```sh
+npx nx run @lde/search-indexer:docker:build   # → packages-search-indexer
+npx nx run @lde/search-indexer:docker:smoke   # boots it with --check
+```
+
+CI runs `docker:smoke` for affected PRs; each release tag rebuilds and pushes
+`ghcr.io/ldelements/search-indexer:<version>` (`.github/workflows/docker.yml`).
+
+## Programmatic use
+
+The bin is a thin wrapper over the exported API, usable in tests or a custom
+boot:
+
+```ts
+import {
+  configFromEnvironment,
+  createSearchIndexer,
+} from '@lde/search-indexer';
+
+const pipeline = await createSearchIndexer(configFromEnvironment(process.env));
+await pipeline.run();
+```

--- a/packages/search-indexer/eslint.config.mjs
+++ b/packages/search-indexer/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/packages/search-indexer/package.json
+++ b/packages/search-indexer/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@lde/search-indexer",
+  "version": "0.0.0",
+  "description": "The @lde/search-pipeline indexer as a bootable process and prebuilt Docker image: loads a mounted schema-declaration module, dataset selection, Typesense connection and rebuild mode from the environment, then runs the object-grain searchIndexerPipeline once to completion. The composition layer that binds the engine-agnostic @lde/search-pipeline stages to @lde/search-typesense – the write-path counterpart of @lde/search-api-server.",
+  "repository": {
+    "url": "git+https://github.com/ldelements/lde.git",
+    "directory": "packages/search-indexer"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "search-indexer": "dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
+  "dependencies": {
+    "@lde/dataset-registry-client": "^0.9.0",
+    "@lde/pipeline": "^0.35.1",
+    "@lde/pipeline-console-reporter": "^0.26.1",
+    "@lde/search": "^0.12.1",
+    "@lde/search-pipeline": "^0.12.2",
+    "@lde/search-typesense": "^0.15.2",
+    "@lde/sparql-qlever": "^0.15.1",
+    "commander": "^15.0.0",
+    "tslib": "^2.3.0",
+    "typesense": "^3.0.6"
+  },
+  "nx": {
+    "targets": {
+      "docker:stage": {
+        "options": {
+          "cwd": "{projectRoot}",
+          "command": "rm -rf dist-docker && mkdir dist-docker && cp package.json dist-docker/ && cp -R dist dist-docker/dist"
+        }
+      },
+      "copy-workspace-modules": {},
+      "prune-lockfile": {},
+      "docker:lockfile": {},
+      "docker:smoke": {
+        "executor": "nx:run-commands",
+        "dependsOn": [
+          "docker:build"
+        ],
+        "cache": false,
+        "options": {
+          "command": "./tools/docker-smoke-indexer.sh packages-search-indexer"
+        }
+      }
+    }
+  }
+}

--- a/packages/search-indexer/src/cli.ts
+++ b/packages/search-indexer/src/cli.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { Command } from 'commander';
+import { configFromEnvironment } from './config.js';
+import { createSearchIndexer } from './indexer.js';
+
+const { version } = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { version: string };
+
+const program = new Command()
+  .name('search-indexer')
+  .description(
+    'Run the object-grain search indexer: select datasets, extract and project each root type per the mounted schema module, and rebuild the Typesense collections. Configuration comes from environment variables; see the README.',
+  )
+  .version(version)
+  .argument(
+    '[datasets...]',
+    'dataset IRIs to index (overrides the DATASETS environment variable)',
+  )
+  .option(
+    '--check',
+    'validate the configuration and schema module, then exit without indexing',
+  );
+
+program.parse();
+
+try {
+  const datasets = program.args;
+  const config = configFromEnvironment(
+    datasets.length > 0
+      ? { ...process.env, DATASETS: datasets.join(' ') }
+      : process.env,
+  );
+  const pipeline = await createSearchIndexer(config);
+  if (program.opts<{ check?: boolean }>().check) {
+    console.info(
+      `@lde/search-indexer ${version}: configuration and schema module “${config.schemaModulePath}” are valid.`,
+    );
+  } else {
+    await pipeline.run();
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/packages/search-indexer/src/composition.ts
+++ b/packages/search-indexer/src/composition.ts
@@ -1,0 +1,75 @@
+// Internal composition pieces of createSearchIndexer, split out so each can
+// be tested without running a pipeline (Pipeline keeps its wiring private).
+import { Client as RegistryClient } from '@lde/dataset-registry-client';
+import {
+  ImportResolver,
+  RegistrySelector,
+  SparqlDistributionResolver,
+  type DatasetSelector,
+  type DistributionResolver,
+  type Writer,
+} from '@lde/pipeline';
+import type { RootType, SearchDocument } from '@lde/search';
+import {
+  BlueGreenRebuild,
+  deriveCollectionName,
+  InPlaceRebuild,
+} from '@lde/search-typesense';
+import { createQlever } from '@lde/sparql-qlever';
+import type { Client } from 'typesense';
+import type { IndexerConfig } from './config.js';
+
+/** The registry-backed dataset selection the configuration describes. */
+export function datasetSelectorFrom(config: IndexerConfig): DatasetSelector {
+  return new RegistrySelector({
+    registry: new RegistryClient(config.registryEndpoint),
+    criteria: config.datasetCriteria,
+  });
+}
+
+/**
+ * The engine-writer factory the configuration describes: an
+ * {@link InPlaceRebuild} or {@link BlueGreenRebuild} per root type, its
+ * collection name derived from the type – prefixed when the deployment says
+ * so, so the read side must be configured with the same prefix.
+ */
+export function writerFactoryFrom(
+  client: Client,
+  config: IndexerConfig,
+): (searchType: RootType) => Writer<SearchDocument> {
+  return (searchType) => {
+    const options = config.collectionPrefix
+      ? {
+          name: `${config.collectionPrefix}${deriveCollectionName(searchType)}`,
+        }
+      : {};
+    return config.rebuildMode === 'blue-green'
+      ? new BlueGreenRebuild(client, searchType, options)
+      : new InPlaceRebuild(client, searchType, options);
+  };
+}
+
+/**
+ * The distribution resolver the configuration describes: with `QLEVER_IMAGE`
+ * set, an {@link ImportResolver} that imports data dumps into a
+ * pipeline-controlled QLever sibling container over the mounted Docker
+ * socket; without it, `undefined`, leaving the pipeline its endpoint-only
+ * default (a bare {@link SparqlDistributionResolver}).
+ */
+export function distributionResolverFrom(
+  config: IndexerConfig,
+): DistributionResolver | undefined {
+  if (!config.qlever) {
+    return undefined;
+  }
+  const { importer, server } = createQlever({
+    mode: 'docker',
+    image: config.qlever.image,
+    dataDir: config.qlever.dataDir,
+  });
+  return new ImportResolver(new SparqlDistributionResolver(), {
+    importer,
+    server,
+    strategy: config.qlever.strategy,
+  });
+}

--- a/packages/search-indexer/src/config.ts
+++ b/packages/search-indexer/src/config.ts
@@ -1,0 +1,260 @@
+import type { SearchCriteria } from '@lde/dataset-registry-client';
+
+/**
+ * The indexer’s complete runtime configuration, read from environment
+ * variables ({@link configFromEnvironment}) – the contract of the Docker
+ * image. Everything schema-shaped lives in the mounted schema module instead,
+ * the same file the served-API image mounts.
+ */
+export interface IndexerConfig {
+  /** Path of the mounted schema-declaration module (`SCHEMA_MODULE`). */
+  readonly schemaModulePath: string;
+  /** SPARQL endpoint of the DCAT dataset registry the selection queries
+   *  (`REGISTRY_ENDPOINT`). */
+  readonly registryEndpoint: URL;
+  /** Dataset selection within the registry: explicit IRIs (`DATASETS`),
+   *  search criteria (`DATASET_CRITERIA`), or every dataset when neither is
+   *  set. */
+  readonly datasetCriteria: SearchCriteria;
+  /** Where the Typesense engine writes (`TYPESENSE_*`). */
+  readonly typesense: TypesenseConnection;
+  /** How each type’s collection is rebuilt (`REBUILD_MODE`): update the live
+   *  collection in place, or build a fresh one and swap on commit. */
+  readonly rebuildMode: 'in-place' | 'blue-green';
+  /** Prefix prepended to every derived collection name
+   *  (`COLLECTION_PREFIX`), e.g. for a shared multi-tenant engine. */
+  readonly collectionPrefix?: string;
+  /** Per-dataset processing memory: skip unchanged datasets
+   *  (`PROVENANCE_FILE` + `PIPELINE_VERSION`). */
+  readonly provenance?: ProvenanceConfig;
+  /** The QLever import path (`QLEVER_IMAGE` + `IMPORT_STRATEGY` +
+   *  `DATA_DIR`): import data dumps into a pipeline-controlled QLever
+   *  container instead of relying on live SPARQL endpoints alone. */
+  readonly qlever?: QleverConfig;
+}
+
+/** Connection details of the Typesense node the indexer writes to. */
+export interface TypesenseConnection {
+  readonly host: string;
+  readonly port: number;
+  readonly protocol: 'http' | 'https';
+  /** An admin key: the indexer creates, writes and swaps collections. */
+  readonly apiKey: string;
+}
+
+/** File-backed provenance: both halves required, so a skip-enabled pipeline
+ *  can never run without the version that keys its skip decisions. */
+export interface ProvenanceConfig {
+  /** Path of the JSON provenance file; must sit on a durable volume. */
+  readonly path: string;
+  /** Consumer-declared version of the indexer’s output-affecting logic. */
+  readonly pipelineVersion: string;
+}
+
+/** The pipeline-controlled QLever sibling container (Docker socket mode). */
+export interface QleverConfig {
+  /** QLever Docker image to run, e.g. `adfreiburg/qlever:latest`. */
+  readonly image: string;
+  /** When to import a data dump instead of querying a live endpoint. */
+  readonly strategy: 'sparql' | 'sparqlWithImportFallback' | 'import';
+  /** Directory for downloaded dumps and QLever index caches. */
+  readonly dataDir: string;
+}
+
+const IMPORT_STRATEGIES = [
+  'sparql',
+  'sparqlWithImportFallback',
+  'import',
+] as const;
+
+/**
+ * Read the {@link IndexerConfig} from environment variables. Reports **all**
+ * problems in one error – a misconfigured deployment learns everything
+ * wrong with it from a single boot attempt, not one variable per crash loop.
+ */
+export function configFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+): IndexerConfig {
+  const problems: string[] = [];
+
+  const required = (name: string): string => {
+    const value = environment[name];
+    if (value === undefined || value.length === 0) {
+      problems.push(`${name} is required`);
+      return '';
+    }
+    return value;
+  };
+  const integer = (name: string, fallback: number): number => {
+    const value = environment[name];
+    if (value === undefined || value.length === 0) {
+      return fallback;
+    }
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      problems.push(`${name} must be a non-negative integer, got “${value}”`);
+      return fallback;
+    }
+    return parsed;
+  };
+  const url = (name: string, value: string): URL => {
+    try {
+      return new URL(value);
+    } catch {
+      // An empty value is already reported as missing by required().
+      if (value.length > 0) {
+        problems.push(`${name} must be an absolute URL, got “${value}”`);
+      }
+      return new URL('http://invalid.invalid');
+    }
+  };
+
+  const registryEndpoint = url(
+    'REGISTRY_ENDPOINT',
+    required('REGISTRY_ENDPOINT'),
+  );
+
+  const protocol = environment['TYPESENSE_PROTOCOL'] ?? 'http';
+  if (protocol !== 'http' && protocol !== 'https') {
+    problems.push(
+      `TYPESENSE_PROTOCOL must be “http” or “https”, got “${protocol}”`,
+    );
+  }
+
+  const rebuildMode = environment['REBUILD_MODE'] ?? 'in-place';
+  if (rebuildMode !== 'in-place' && rebuildMode !== 'blue-green') {
+    problems.push(
+      `REBUILD_MODE must be “in-place” or “blue-green”, got “${rebuildMode}”`,
+    );
+  }
+
+  const datasetCriteria = criteriaFromEnvironment(environment, problems);
+  const provenance = provenanceFromEnvironment(
+    environment,
+    rebuildMode,
+    problems,
+  );
+  const qlever = qleverFromEnvironment(environment, problems);
+
+  const config: IndexerConfig = {
+    schemaModulePath:
+      environment['SCHEMA_MODULE'] ?? '/config/search-schema.mjs',
+    registryEndpoint,
+    datasetCriteria,
+    typesense: {
+      host: required('TYPESENSE_HOST'),
+      port: integer('TYPESENSE_PORT', 8108),
+      protocol: protocol as 'http' | 'https',
+      apiKey: required('TYPESENSE_API_KEY'),
+    },
+    rebuildMode: rebuildMode as 'in-place' | 'blue-green',
+    collectionPrefix: environment['COLLECTION_PREFIX'],
+    provenance,
+    qlever,
+  };
+  if (problems.length > 0) {
+    throw new Error(
+      `Invalid configuration:\n${problems.map((problem) => `- ${problem}`).join('\n')}`,
+    );
+  }
+  return config;
+}
+
+/** `DATASETS` (whitespace-separated IRIs) or `DATASET_CRITERIA` (a JSON
+ *  object) – never both; neither selects the whole registry. */
+function criteriaFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+  problems: string[],
+): SearchCriteria {
+  const datasets = environment['DATASETS'];
+  const criteriaJson = environment['DATASET_CRITERIA'];
+  if (datasets && criteriaJson) {
+    problems.push(
+      'DATASETS and DATASET_CRITERIA are mutually exclusive; set at most one',
+    );
+    return {};
+  }
+  if (datasets) {
+    const iris = datasets.split(/[\s,]+/).filter((iri) => iri.length > 0);
+    for (const iri of iris) {
+      try {
+        new URL(iri);
+      } catch {
+        problems.push(`DATASETS contains “${iri}”, which is not an IRI`);
+      }
+    }
+    return { $id: iris };
+  }
+  if (criteriaJson) {
+    try {
+      const parsed: unknown = JSON.parse(criteriaJson);
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        problems.push('DATASET_CRITERIA must be a JSON object');
+        return {};
+      }
+      return parsed as SearchCriteria;
+    } catch {
+      problems.push('DATASET_CRITERIA must be valid JSON');
+      return {};
+    }
+  }
+  return {};
+}
+
+function provenanceFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+  rebuildMode: string,
+  problems: string[],
+): ProvenanceConfig | undefined {
+  const path = environment['PROVENANCE_FILE'];
+  const pipelineVersion = environment['PIPELINE_VERSION'];
+  if (!path && !pipelineVersion) {
+    return undefined;
+  }
+  if (!path || !pipelineVersion) {
+    problems.push(
+      'PROVENANCE_FILE and PIPELINE_VERSION must be set together: the version keys the skip decisions the file remembers',
+    );
+    return undefined;
+  }
+  if (rebuildMode === 'blue-green') {
+    problems.push(
+      'PROVENANCE_FILE cannot be combined with REBUILD_MODE=blue-green: a skipped dataset would be missing from the fresh collection the swap makes live',
+    );
+    return undefined;
+  }
+  return { path, pipelineVersion };
+}
+
+function qleverFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+  problems: string[],
+): QleverConfig | undefined {
+  const image = environment['QLEVER_IMAGE'];
+  const strategy = environment['IMPORT_STRATEGY'];
+  if (!image) {
+    if (strategy) {
+      problems.push(
+        'IMPORT_STRATEGY requires QLEVER_IMAGE: without an import engine there is nothing to import into',
+      );
+    }
+    return undefined;
+  }
+  if (
+    strategy !== undefined &&
+    !(IMPORT_STRATEGIES as readonly string[]).includes(strategy)
+  ) {
+    problems.push(
+      `IMPORT_STRATEGY must be one of ${IMPORT_STRATEGIES.map((name) => `“${name}”`).join(', ')}, got “${strategy}”`,
+    );
+  }
+  return {
+    image,
+    strategy: (strategy ?? 'sparql') as QleverConfig['strategy'],
+    dataDir: environment['DATA_DIR'] ?? '/data',
+  };
+}

--- a/packages/search-indexer/src/index.ts
+++ b/packages/search-indexer/src/index.ts
@@ -1,0 +1,13 @@
+// The bootable search indexer: the composition layer binding the
+// engine-agnostic @lde/search-pipeline indexer to Typesense rebuild writers,
+// a mounted schema-declaration module and environment config. The
+// `search-indexer` bin (src/cli.ts) and the Docker image are thin wrappers
+// over these.
+export { createSearchIndexer } from './indexer.js';
+export { configFromEnvironment } from './config.js';
+export type {
+  IndexerConfig,
+  ProvenanceConfig,
+  QleverConfig,
+  TypesenseConnection,
+} from './config.js';

--- a/packages/search-indexer/src/indexer.ts
+++ b/packages/search-indexer/src/indexer.ts
@@ -1,0 +1,49 @@
+import { FileProvenanceStore, type Pipeline } from '@lde/pipeline';
+import { ConsoleReporter } from '@lde/pipeline-console-reporter';
+import { loadSchemaModule } from '@lde/search/module';
+import {
+  searchIndexerPipeline,
+  type TypedSearchDocument,
+} from '@lde/search-pipeline';
+import { Client } from 'typesense';
+import {
+  datasetSelectorFrom,
+  distributionResolverFrom,
+  writerFactoryFrom,
+} from './composition.js';
+import type { IndexerConfig } from './config.js';
+
+/**
+ * Compose the ready-to-run search indexer from an {@link IndexerConfig}: load
+ * and validate the mounted schema module (the same file the served-API image
+ * mounts), select datasets from the registry, bind the Typesense rebuild
+ * writers, and wire the optional QLever import path and provenance store into
+ * `searchIndexerPipeline`. Every misconfiguration – an invalid schema, an
+ * underivable collection name – throws here, at boot, never mid-run.
+ */
+export async function createSearchIndexer(
+  config: IndexerConfig,
+): Promise<Pipeline<TypedSearchDocument>> {
+  const { schema } = await loadSchemaModule(config.schemaModulePath);
+  const client = new Client({
+    nodes: [
+      {
+        host: config.typesense.host,
+        port: config.typesense.port,
+        protocol: config.typesense.protocol,
+      },
+    ],
+    apiKey: config.typesense.apiKey,
+  });
+  return searchIndexerPipeline({
+    schema,
+    datasets: datasetSelectorFrom(config),
+    distributionResolver: distributionResolverFrom(config),
+    writerFor: writerFactoryFrom(client, config),
+    provenanceStore: config.provenance
+      ? new FileProvenanceStore({ path: config.provenance.path })
+      : undefined,
+    pipelineVersion: config.provenance?.pipelineVersion,
+    reporter: new ConsoleReporter(),
+  });
+}

--- a/packages/search-indexer/test/composition.test.ts
+++ b/packages/search-indexer/test/composition.test.ts
@@ -1,0 +1,86 @@
+import { ImportResolver, RegistrySelector } from '@lde/pipeline';
+import { searchSchema } from '@lde/search';
+import { BlueGreenRebuild, InPlaceRebuild } from '@lde/search-typesense';
+import { Client } from 'typesense';
+import { describe, expect, it } from 'vitest';
+import {
+  datasetSelectorFrom,
+  distributionResolverFrom,
+  writerFactoryFrom,
+} from '../src/composition.js';
+import { configFromEnvironment } from '../src/config.js';
+
+const minimal = {
+  REGISTRY_ENDPOINT: 'https://registry.example.org/sparql',
+  TYPESENSE_HOST: 'typesense.internal',
+  TYPESENSE_API_KEY: 'admin-key',
+};
+
+const client = new Client({
+  nodes: [{ host: 'typesense.internal', port: 8108, protocol: 'http' }],
+  apiKey: 'admin-key',
+});
+
+const schema = searchSchema({
+  name: 'Dataset',
+  class: 'http://www.w3.org/ns/dcat#Dataset',
+  fields: [{ name: 'title', kind: 'text', locales: ['en'], output: true }],
+});
+const datasetType = [...schema.values()][0]!;
+
+describe('datasetSelectorFrom', () => {
+  it('selects from the configured registry', () => {
+    const selector = datasetSelectorFrom(configFromEnvironment(minimal));
+    expect(selector).toBeInstanceOf(RegistrySelector);
+  });
+});
+
+describe('writerFactoryFrom', () => {
+  it('builds an in-place rebuild writer by default', () => {
+    const writerFor = writerFactoryFrom(client, configFromEnvironment(minimal));
+    const writer = writerFor(datasetType);
+    expect(writer).toBeInstanceOf(InPlaceRebuild);
+    expect((writer as InPlaceRebuild<never>).collectionName).toBe('datasets');
+  });
+
+  it('builds a blue-green rebuild writer when configured', () => {
+    const writerFor = writerFactoryFrom(
+      client,
+      configFromEnvironment({ ...minimal, REBUILD_MODE: 'blue-green' }),
+    );
+    const writer = writerFor(datasetType);
+    expect(writer).toBeInstanceOf(BlueGreenRebuild);
+    expect((writer as BlueGreenRebuild<never>).collectionName).toBe('datasets');
+  });
+
+  it('prefixes the derived collection name when configured', () => {
+    const writerFor = writerFactoryFrom(
+      client,
+      configFromEnvironment({ ...minimal, COLLECTION_PREFIX: 'staging_' }),
+    );
+    const writer = writerFor(datasetType);
+    expect((writer as InPlaceRebuild<never>).collectionName).toBe(
+      'staging_datasets',
+    );
+  });
+});
+
+describe('distributionResolverFrom', () => {
+  it('leaves the pipeline its endpoint-only default without QLEVER_IMAGE', () => {
+    expect(
+      distributionResolverFrom(configFromEnvironment(minimal)),
+    ).toBeUndefined();
+  });
+
+  it('builds the QLever import path when configured', () => {
+    const resolver = distributionResolverFrom(
+      configFromEnvironment({
+        ...minimal,
+        QLEVER_IMAGE: 'adfreiburg/qlever:latest',
+        IMPORT_STRATEGY: 'import',
+        DATA_DIR: '/tmp/qlever-data',
+      }),
+    );
+    expect(resolver).toBeInstanceOf(ImportResolver);
+  });
+});

--- a/packages/search-indexer/test/config.test.ts
+++ b/packages/search-indexer/test/config.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import { configFromEnvironment } from '../src/config.js';
+
+const minimal = {
+  REGISTRY_ENDPOINT: 'https://registry.example.org/sparql',
+  TYPESENSE_HOST: 'typesense.internal',
+  TYPESENSE_API_KEY: 'admin-key',
+};
+
+describe('configFromEnvironment', () => {
+  it('applies defaults with only the required variables set', () => {
+    const config = configFromEnvironment(minimal);
+    expect(config).toEqual({
+      schemaModulePath: '/config/search-schema.mjs',
+      registryEndpoint: new URL('https://registry.example.org/sparql'),
+      datasetCriteria: {},
+      typesense: {
+        host: 'typesense.internal',
+        port: 8108,
+        protocol: 'http',
+        apiKey: 'admin-key',
+      },
+      rebuildMode: 'in-place',
+      collectionPrefix: undefined,
+      provenance: undefined,
+      qlever: undefined,
+    });
+  });
+
+  it('reads every override', () => {
+    const config = configFromEnvironment({
+      ...minimal,
+      SCHEMA_MODULE: '/mnt/schema.mjs',
+      TYPESENSE_PORT: '443',
+      TYPESENSE_PROTOCOL: 'https',
+      REBUILD_MODE: 'blue-green',
+      COLLECTION_PREFIX: 'staging_',
+      QLEVER_IMAGE: 'adfreiburg/qlever:latest',
+      IMPORT_STRATEGY: 'import',
+      DATA_DIR: '/mnt/data',
+    });
+    expect(config).toEqual({
+      schemaModulePath: '/mnt/schema.mjs',
+      registryEndpoint: new URL('https://registry.example.org/sparql'),
+      datasetCriteria: {},
+      typesense: {
+        host: 'typesense.internal',
+        port: 443,
+        protocol: 'https',
+        apiKey: 'admin-key',
+      },
+      rebuildMode: 'blue-green',
+      collectionPrefix: 'staging_',
+      provenance: undefined,
+      qlever: {
+        image: 'adfreiburg/qlever:latest',
+        strategy: 'import',
+        dataDir: '/mnt/data',
+      },
+    });
+  });
+
+  it('reports all problems in one error', () => {
+    let message = '';
+    try {
+      configFromEnvironment({
+        TYPESENSE_PORT: 'eighty',
+        TYPESENSE_PROTOCOL: 'ftp',
+        REBUILD_MODE: 'green-blue',
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('REGISTRY_ENDPOINT is required');
+    expect(message).toContain('TYPESENSE_HOST is required');
+    expect(message).toContain('TYPESENSE_API_KEY is required');
+    expect(message).toContain('TYPESENSE_PORT must be a non-negative integer');
+    expect(message).toContain('TYPESENSE_PROTOCOL must be “http” or “https”');
+    expect(message).toContain(
+      'REBUILD_MODE must be “in-place” or “blue-green”',
+    );
+  });
+
+  it('rejects a malformed registry endpoint', () => {
+    expect(() =>
+      configFromEnvironment({ ...minimal, REGISTRY_ENDPOINT: 'not-a-url' }),
+    ).toThrowError(/REGISTRY_ENDPOINT must be an absolute URL/);
+  });
+
+  describe('dataset selection', () => {
+    it('turns DATASETS into $id criteria, splitting on whitespace and commas', () => {
+      const config = configFromEnvironment({
+        ...minimal,
+        DATASETS:
+          'https://example.org/dataset/1, https://example.org/dataset/2\nhttps://example.org/dataset/3',
+      });
+      expect(config.datasetCriteria).toEqual({
+        $id: [
+          'https://example.org/dataset/1',
+          'https://example.org/dataset/2',
+          'https://example.org/dataset/3',
+        ],
+      });
+    });
+
+    it('rejects a dataset entry that is not an IRI', () => {
+      expect(() =>
+        configFromEnvironment({ ...minimal, DATASETS: 'not-an-iri' }),
+      ).toThrowError(/DATASETS contains “not-an-iri”, which is not an IRI/);
+    });
+
+    it('parses DATASET_CRITERIA as a JSON object', () => {
+      const config = configFromEnvironment({
+        ...minimal,
+        DATASET_CRITERIA: '{"publisher": {"$id": "https://example.org/org"}}',
+      });
+      expect(config.datasetCriteria).toEqual({
+        publisher: { $id: 'https://example.org/org' },
+      });
+    });
+
+    it('rejects DATASET_CRITERIA that is not valid JSON', () => {
+      expect(() =>
+        configFromEnvironment({ ...minimal, DATASET_CRITERIA: '{oops' }),
+      ).toThrowError(/DATASET_CRITERIA must be valid JSON/);
+    });
+
+    it('rejects DATASET_CRITERIA that is not an object', () => {
+      expect(() =>
+        configFromEnvironment({ ...minimal, DATASET_CRITERIA: '["a"]' }),
+      ).toThrowError(/DATASET_CRITERIA must be a JSON object/);
+    });
+
+    it('rejects DATASETS combined with DATASET_CRITERIA', () => {
+      expect(() =>
+        configFromEnvironment({
+          ...minimal,
+          DATASETS: 'https://example.org/dataset/1',
+          DATASET_CRITERIA: '{}',
+        }),
+      ).toThrowError(/mutually exclusive/);
+    });
+  });
+
+  describe('provenance', () => {
+    it('requires the file and the version together', () => {
+      expect(() =>
+        configFromEnvironment({
+          ...minimal,
+          PROVENANCE_FILE: '/state/provenance.json',
+        }),
+      ).toThrowError(
+        /PROVENANCE_FILE and PIPELINE_VERSION must be set together/,
+      );
+      expect(() =>
+        configFromEnvironment({ ...minimal, PIPELINE_VERSION: '1' }),
+      ).toThrowError(
+        /PROVENANCE_FILE and PIPELINE_VERSION must be set together/,
+      );
+    });
+
+    it('reads both halves', () => {
+      const config = configFromEnvironment({
+        ...minimal,
+        PROVENANCE_FILE: '/state/provenance.json',
+        PIPELINE_VERSION: '2026-07-24',
+      });
+      expect(config.provenance).toEqual({
+        path: '/state/provenance.json',
+        pipelineVersion: '2026-07-24',
+      });
+    });
+
+    it('rejects provenance with blue-green rebuilds', () => {
+      expect(() =>
+        configFromEnvironment({
+          ...minimal,
+          REBUILD_MODE: 'blue-green',
+          PROVENANCE_FILE: '/state/provenance.json',
+          PIPELINE_VERSION: '1',
+        }),
+      ).toThrowError(/cannot be combined with REBUILD_MODE=blue-green/);
+    });
+  });
+
+  describe('QLever import', () => {
+    it('defaults to the sparql strategy and /data', () => {
+      const config = configFromEnvironment({
+        ...minimal,
+        QLEVER_IMAGE: 'adfreiburg/qlever:latest',
+      });
+      expect(config.qlever).toEqual({
+        image: 'adfreiburg/qlever:latest',
+        strategy: 'sparql',
+        dataDir: '/data',
+      });
+    });
+
+    it('rejects an unknown strategy', () => {
+      expect(() =>
+        configFromEnvironment({
+          ...minimal,
+          QLEVER_IMAGE: 'adfreiburg/qlever:latest',
+          IMPORT_STRATEGY: 'always',
+        }),
+      ).toThrowError(/IMPORT_STRATEGY must be one of/);
+    });
+
+    it('rejects a strategy without an image', () => {
+      expect(() =>
+        configFromEnvironment({ ...minimal, IMPORT_STRATEGY: 'import' }),
+      ).toThrowError(/IMPORT_STRATEGY requires QLEVER_IMAGE/);
+    });
+  });
+});

--- a/packages/search-indexer/test/fixtures/search-schema.mjs
+++ b/packages/search-indexer/test/fixtures/search-schema.mjs
@@ -1,0 +1,29 @@
+/**
+ * A minimal schema-declaration module, shaped exactly as a deployment mounts
+ * it into the image: plain data, no imports.
+ */
+export default [
+  {
+    name: 'Dataset',
+    class: 'http://www.w3.org/ns/dcat#Dataset',
+    fields: [
+      {
+        name: 'title',
+        kind: 'text',
+        path: '<http://purl.org/dc/terms/title>',
+        locales: ['nl', 'en'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+      {
+        name: 'keyword',
+        kind: 'keyword',
+        path: '<http://www.w3.org/ns/dcat#keyword>',
+        array: true,
+        facetable: true,
+        filterable: true,
+        output: true,
+      },
+    ],
+  },
+];

--- a/packages/search-indexer/test/indexer.test.ts
+++ b/packages/search-indexer/test/indexer.test.ts
@@ -1,0 +1,49 @@
+import { fileURLToPath } from 'node:url';
+import { Pipeline } from '@lde/pipeline';
+import { describe, expect, it } from 'vitest';
+import { configFromEnvironment } from '../src/config.js';
+import { createSearchIndexer } from '../src/indexer.js';
+
+const fixture = fileURLToPath(
+  new URL('./fixtures/search-schema.mjs', import.meta.url),
+);
+
+const minimal = {
+  REGISTRY_ENDPOINT: 'https://registry.example.org/sparql',
+  TYPESENSE_HOST: 'typesense.internal',
+  TYPESENSE_API_KEY: 'admin-key',
+};
+
+describe('createSearchIndexer', () => {
+  it('composes a ready-to-run pipeline from config and schema module', async () => {
+    const pipeline = await createSearchIndexer(
+      configFromEnvironment({
+        ...minimal,
+        SCHEMA_MODULE: fixture,
+        PROVENANCE_FILE: '/state/provenance.json',
+        PIPELINE_VERSION: '1',
+      }),
+    );
+    expect(pipeline).toBeInstanceOf(Pipeline);
+  });
+
+  it('composes without provenance when none is configured', async () => {
+    const pipeline = await createSearchIndexer(
+      configFromEnvironment({ ...minimal, SCHEMA_MODULE: fixture }),
+    );
+    expect(pipeline).toBeInstanceOf(Pipeline);
+  });
+
+  it('fails the boot on an unloadable schema module, naming the path', async () => {
+    await expect(
+      createSearchIndexer(
+        configFromEnvironment({
+          ...minimal,
+          SCHEMA_MODULE: '/no/such/module.mjs',
+        }),
+      ),
+    ).rejects.toThrowError(
+      /Cannot load schema module “\/no\/such\/module\.mjs”/,
+    );
+  });
+});

--- a/packages/search-indexer/tsconfig.json
+++ b/packages/search-indexer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  }
+}

--- a/packages/search-indexer/tsconfig.lib.json
+++ b/packages/search-indexer/tsconfig.lib.json
@@ -1,0 +1,49 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "types": ["node"],
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../sparql-qlever/tsconfig.lib.json"
+    },
+    {
+      "path": "../search-typesense/tsconfig.lib.json"
+    },
+    {
+      "path": "../search-pipeline/tsconfig.lib.json"
+    },
+    {
+      "path": "../search/tsconfig.lib.json"
+    },
+    {
+      "path": "../pipeline-console-reporter/tsconfig.lib.json"
+    },
+    {
+      "path": "../pipeline/tsconfig.lib.json"
+    },
+    {
+      "path": "../dataset-registry-client/tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx",
+    "test/**/*.test.js",
+    "test/**/*.spec.js",
+    "test/**/*.test.jsx",
+    "test/**/*.spec.jsx"
+  ]
+}

--- a/packages/search-indexer/tsconfig.spec.json
+++ b/packages/search-indexer/tsconfig.spec.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "types": ["node"],
+    "ignoreDeprecations": "6.0",
+    "rootDir": "."
+  },
+  "include": [
+    "vitest.config.ts",
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx",
+    "test/**/*.test.js",
+    "test/**/*.spec.js",
+    "test/**/*.test.jsx",
+    "test/**/*.spec.jsx",
+    "test/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/search-indexer/vite.config.ts
+++ b/packages/search-indexer/vite.config.ts
@@ -1,18 +1,19 @@
-/// <reference types='vitest' />
-import { defineConfig, mergeConfig } from 'vite';
+import { defineConfig, mergeConfig } from 'vitest/config';
 import baseConfig from '../../vite.base.config.js';
 
 export default mergeConfig(
   baseConfig,
   defineConfig({
     root: __dirname,
-    cacheDir: '../../node_modules/.vite/packages/search',
+    cacheDir: '../../node_modules/.vite/packages/search-indexer',
     test: {
       coverage: {
+        exclude: ['src/cli.ts'],
         thresholds: {
+          autoUpdate: true,
           functions: 100,
           lines: 100,
-          branches: 98.92,
+          branches: 100,
           statements: 100,
         },
       },

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -62,6 +62,11 @@ Exports are stratified by audience:
 - **`@lde/search/adapter`** – plumbing for engine adapters and API surfaces:
   `physicalFields`, the field selectors, `assertValidQuery`, the filter
   operators and storage codecs.
+- **`@lde/search/module`** – `loadSchemaModule`, the Node-only loader for a
+  mounted schema-declaration module (an `.mjs` default-exporting declarations
+  as plain data). The one loader both the indexer image and the served-API
+  image boot from, so the write and the read side cannot disagree about the
+  schema.
 - **`@lde/search/testing`** – `describeSearchEngineContract`, the executable
   port contract every engine adapter runs against a live instance of itself
   (vitest; optional peer).

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -16,6 +16,12 @@
       "development": "./src/index.ts",
       "default": "./dist/index.js"
     },
+    "./module": {
+      "types": "./dist/module.d.ts",
+      "import": "./dist/module.js",
+      "development": "./src/module.ts",
+      "default": "./dist/module.js"
+    },
     "./adapter": {
       "types": "./dist/adapter.d.ts",
       "import": "./dist/adapter.js",

--- a/packages/search/src/module.ts
+++ b/packages/search/src/module.ts
@@ -1,0 +1,65 @@
+// The `@lde/search/module` entry point: load a mounted schema-declaration
+// module. Node-only (it touches the filesystem), so it lives outside the main
+// entry point, which stays runtime-agnostic.
+import { pathToFileURL } from 'node:url';
+import { searchSchema, type SearchSchema, type SearchType } from './schema.js';
+
+/** What {@link loadSchemaModule} returns: the validated schema plus the raw
+ *  module exports, so each consumer validates its own optional exports (the
+ *  served API reads `schemaOptions`/`engineOptions`; the indexer reads none). */
+export interface LoadedSchemaModule {
+  /** The validated schema built from the module’s default export. */
+  readonly schema: SearchSchema;
+  /** Every export of the module, for consumer-specific optional exports. */
+  readonly moduleExports: Record<string, unknown>;
+}
+
+/**
+ * Load and validate a mounted schema-declaration module: an ES module whose
+ * default export is a non-empty array of {@link SearchType} declarations –
+ * **plain data with optional functions** (`derive`, `transform`), because a
+ * mounted file cannot resolve bare imports like `@lde/search`. The one schema
+ * source both the indexer image and the served-API image mount, so the write
+ * and the read side cannot disagree about the schema.
+ *
+ * Throws with the module path in the message for every failure mode – an
+ * unreadable file, a wrong export shape, an invalid declaration – so a bad
+ * mount fails the boot with a diagnosis, never the first query.
+ */
+export async function loadSchemaModule(
+  modulePath: string,
+): Promise<LoadedSchemaModule> {
+  let moduleExports: Record<string, unknown>;
+  try {
+    moduleExports = (await import(pathToFileURL(modulePath).href)) as Record<
+      string,
+      unknown
+    >;
+  } catch (cause) {
+    throw new Error(
+      `Cannot load schema module “${modulePath}”: ${messageOf(cause)}`,
+      { cause },
+    );
+  }
+  const declarations = moduleExports['default'];
+  if (!Array.isArray(declarations) || declarations.length === 0) {
+    throw new Error(
+      `Schema module “${modulePath}” must default-export a non-empty array of search type declarations.`,
+    );
+  }
+  try {
+    return {
+      schema: searchSchema(...(declarations as SearchType[])),
+      moduleExports,
+    };
+  } catch (cause) {
+    throw new Error(
+      `Schema module “${modulePath}” declares an invalid schema: ${messageOf(cause)}`,
+      { cause },
+    );
+  }
+}
+
+function messageOf(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}

--- a/packages/search/test/fixtures/module/empty-array.mjs
+++ b/packages/search/test/fixtures/module/empty-array.mjs
@@ -1,0 +1,1 @@
+export default [];

--- a/packages/search/test/fixtures/module/invalid-declaration.mjs
+++ b/packages/search/test/fixtures/module/invalid-declaration.mjs
@@ -1,0 +1,6 @@
+export default [
+  {
+    name: 'Dataset',
+    // Missing `class` and `fields`: fails searchSchema() validation.
+  },
+];

--- a/packages/search/test/fixtures/module/not-an-array.mjs
+++ b/packages/search/test/fixtures/module/not-an-array.mjs
@@ -1,0 +1,1 @@
+export default { name: 'Dataset' };

--- a/packages/search/test/fixtures/module/search-schema.mjs
+++ b/packages/search/test/fixtures/module/search-schema.mjs
@@ -1,0 +1,21 @@
+/**
+ * A minimal schema-declaration module, shaped exactly as a deployment mounts
+ * it into an image: plain data, no imports.
+ */
+export default [
+  {
+    name: 'Dataset',
+    class: 'http://www.w3.org/ns/dcat#Dataset',
+    fields: [
+      {
+        name: 'title',
+        kind: 'text',
+        locales: ['nl', 'en'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+    ],
+  },
+];
+
+export const schemaOptions = { maxPerPage: 50 };

--- a/packages/search/test/fixtures/module/throws-string.mjs
+++ b/packages/search/test/fixtures/module/throws-string.mjs
@@ -1,0 +1,2 @@
+// A module whose evaluation throws a non-Error value.
+throw 'boom';

--- a/packages/search/test/module.test.ts
+++ b/packages/search/test/module.test.ts
@@ -1,0 +1,48 @@
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { loadSchemaModule } from '../src/module.js';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/module/${name}`, import.meta.url));
+
+describe('loadSchemaModule', () => {
+  it('builds the validated schema from the default export', async () => {
+    const { schema, moduleExports } = await loadSchemaModule(
+      fixture('search-schema.mjs'),
+    );
+    const types = [...schema.values()];
+    expect(types).toHaveLength(1);
+    expect(types[0]!.name).toBe('Dataset');
+    expect(moduleExports['schemaOptions']).toEqual({ maxPerPage: 50 });
+  });
+
+  it('rejects a missing file, naming the path', async () => {
+    await expect(loadSchemaModule('/no/such/module.mjs')).rejects.toThrowError(
+      /Cannot load schema module “\/no\/such\/module\.mjs”/,
+    );
+  });
+
+  it('rejects a module that throws a non-Error value', async () => {
+    await expect(
+      loadSchemaModule(fixture('throws-string.mjs')),
+    ).rejects.toThrowError(/Cannot load schema module .*boom/);
+  });
+
+  it('rejects a default export that is not an array', async () => {
+    await expect(
+      loadSchemaModule(fixture('not-an-array.mjs')),
+    ).rejects.toThrowError(/must default-export a non-empty array/);
+  });
+
+  it('rejects an empty default export', async () => {
+    await expect(
+      loadSchemaModule(fixture('empty-array.mjs')),
+    ).rejects.toThrowError(/must default-export a non-empty array/);
+  });
+
+  it('rejects invalid declarations with the validation diagnosis', async () => {
+    await expect(
+      loadSchemaModule(fixture('invalid-declaration.mjs')),
+    ).rejects.toThrowError(/declares an invalid schema/);
+  });
+});

--- a/tools/docker-smoke-indexer.sh
+++ b/tools/docker-smoke-indexer.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the built search-indexer image by actually running it: boot with
+# a fixture schema module and `--check`, which loads the full module graph and
+# validates configuration, then exits. `nx … docker:build` only *builds* the
+# image, so a runtime-only failure – e.g. a runtime dependency missing from
+# the pruned image, surfacing as `ERR_MODULE_NOT_FOUND` at boot – passes the
+# build yet crashes in production. This is the gate that catches that class
+# before it ships. The indexer is a batch process, so unlike docker-smoke.sh
+# (the HTTP-server variant) there is no port to probe: a clean `--check` exit
+# is the startup signal.
+#
+# Usage: docker-smoke-indexer.sh <image-tag>
+set -euo pipefail
+
+image="$1"
+
+# Dummy values: we test module resolution and startup, not behaviour. Nothing
+# connects during --check. The schema module ships into the container only for
+# this smoke via the test fixture bind mount.
+if output="$(docker run --rm \
+  -e REGISTRY_ENDPOINT=https://registry.invalid/sparql \
+  -e TYPESENSE_HOST=localhost \
+  -e TYPESENSE_API_KEY=dummy \
+  -v "$(pwd)/packages/search-indexer/test/fixtures/search-schema.mjs:/config/search-schema.mjs:ro" \
+  "$image" node dist/cli.js --check 2>&1)"; then
+  if echo "$output" | grep -q "configuration and schema module .* are valid"; then
+    echo "PASS: $image booted, loaded the schema module and validated configuration"
+    exit 0
+  fi
+  echo "FAIL: $image exited 0 but did not report a valid configuration:"
+  echo "$output"
+  exit 1
+fi
+
+echo "FAIL: $image failed --check:"
+echo "$output"
+if echo "$output" | grep -qiE "ERR_MODULE_NOT_FOUND|Cannot find (package|module)"; then
+  echo "(module-resolution error: a runtime dependency is missing from the pruned image)"
+fi
+exit 1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,6 +85,9 @@
     },
     {
       "path": "./packages/search-api-server"
+    },
+    {
+      "path": "./packages/search-indexer"
     }
   ],
   "compilerOptions": {


### PR DESCRIPTION
Fix #652.

**Stacked on #646** (`feat/search-graphql-docker`): it reuses that PR’s whole delivery pattern (ADR 15 image staging, `docker:smoke` CI gate, `docker.yml`) and its schema-module contract, so it targets that branch – three commits on top of it. Retarget to `main` once #646 lands.

## What

`@lde/search-indexer`: the write-path counterpart of `@lde/search-api-server` – the object-grain search indexer as a Commander CLI, npm package and prebuilt Docker image (`ghcr.io/ldelements/search-indexer`), configured entirely from environment variables. Mount the same schema-declaration module into this image and the API-server image, point both at the same `TYPESENSE_*` coordinates, and the write and read sides cannot disagree about the schema.

- **Shared loader** (`feat(search)`): the schema-module load-and-validate logic moves from `search-api-server` into a new `@lde/search/module` entry point; both composition packages boot from it. The server keeps validating its read-side optional exports (`schemaOptions`, `engineOptions`), with a new test for the non-object export failure mode.
- **Config, boot-or-fail** (all problems in one error, mirroring ADR 15): registry endpoint + dataset IRIs (`DATASETS`) or registry criteria (`DATASET_CRITERIA`, JSON) → `RegistrySelector`; `TYPESENSE_*` (admin key); `REBUILD_MODE` `in-place` (default) / `blue-green` with optional `COLLECTION_PREFIX`; `PROVENANCE_FILE` + `PIPELINE_VERSION` → `FileProvenanceStore`; `ConsoleReporter` by default. Two combinations are rejected at boot: provenance with only one of its halves, and provenance with blue-green rebuilds (a skipped dataset would be missing from the fresh collection the swap makes live).
- **The QLever import path ships behind a flag** ([ADR 16](../blob/feat/search-indexer/docs/decisions/0016-ship-the-search-indexer-as-a-config-driven-image.md)): `QLEVER_IMAGE` enables `ImportResolver` + `DockerTaskRunner` – the indexer spawns and fully controls sibling QLever containers over the mounted Docker socket (dockerode, no docker CLI in the image). Default stays endpoint-only, which runs anywhere. Native mode in-image is the documented Kubernetes follow-up; the statically-declared-sidecar option is rejected in the ADR (no control plane for the per-dataset index/restart loop).
- **`--check`** validates configuration and schema module then exits – used by `tools/docker-smoke-indexer.sh` to boot the built image in CI, so pruned-image module-resolution failures (`ERR_MODULE_NOT_FOUND`) fail the PR. The image needs `npm ci --legacy-peer-deps` for the same reason as the server image: the `docker:lockfile` repair step installs with that flag, so peers it leaves out (typesense’s `@babel/runtime`) would otherwise fail `npm ci`.
- **`docker.yml` generalized**: the workflow now derives package name and version from the release tag (keeping the env-based, injection-safe ref handling) and serves both `@lde/search-api-server@*` and `@lde/search-indexer@*`.

## Out of scope (per #652)

Bespoke root selectors and per-stage tuning (library path), SHACL as schema source (#495), engines other than Typesense, native-mode QLever (follow-up).

## After merge

First publish needs the manual Trusted-Publishing bootstrap, like every new `@lde/*` package.
