### PR TITLE
feat(sparql-qlever): reach QLever by container name over a Docker network

### DIFF
--- a/packages/search-indexer/README.md
+++ b/packages/search-indexer/README.md
@@ -58,23 +58,24 @@ images.
 
 ## Configuration
 
-| Variable             | Default                     | Meaning                                                                      |
-| -------------------- | --------------------------- | ---------------------------------------------------------------------------- |
-| `SCHEMA_MODULE`      | `/config/search-schema.mjs` | Path of the mounted schema-declaration module                                |
-| `REGISTRY_ENDPOINT`  | **required**                | SPARQL endpoint of the DCAT dataset registry                                 |
-| `DATASETS`           | all registry datasets       | Dataset IRIs to index (whitespace- or comma-separated)                       |
-| `DATASET_CRITERIA`   | all registry datasets       | Registry search criteria as a JSON object (mutually exclusive w/ `DATASETS`) |
-| `TYPESENSE_HOST`     | **required**                | Typesense host                                                               |
-| `TYPESENSE_PORT`     | `8108`                      | Typesense port                                                               |
-| `TYPESENSE_PROTOCOL` | `http`                      | `http` or `https`                                                            |
-| `TYPESENSE_API_KEY`  | **required**                | An admin key: the indexer creates, writes and swaps collections              |
-| `REBUILD_MODE`       | `in-place`                  | `in-place` (update the live collection) or `blue-green` (swap on commit)     |
-| `COLLECTION_PREFIX`  | none                        | Prefix for every derived collection name (configure the read side to match)  |
-| `PROVENANCE_FILE`    | none                        | JSON file remembering per-dataset processing, to skip unchanged datasets     |
-| `PIPELINE_VERSION`   | none                        | Version keying the skip decisions; required with `PROVENANCE_FILE`           |
-| `QLEVER_IMAGE`       | none                        | Enables the QLever import path (see below), e.g. `adfreiburg/qlever:latest`  |
-| `IMPORT_STRATEGY`    | `sparql`                    | `sparql`, `sparqlWithImportFallback` or `import`; requires `QLEVER_IMAGE`    |
-| `DATA_DIR`           | `/data`                     | Directory for downloaded dumps and QLever index caches                       |
+| Variable             | Default                     | Meaning                                                                                             |
+| -------------------- | --------------------------- | --------------------------------------------------------------------------------------------------- |
+| `SCHEMA_MODULE`      | `/config/search-schema.mjs` | Path of the mounted schema-declaration module                                                       |
+| `REGISTRY_ENDPOINT`  | **required**                | SPARQL endpoint of the DCAT dataset registry                                                        |
+| `DATASETS`           | all registry datasets       | Dataset IRIs to index (whitespace- or comma-separated)                                              |
+| `DATASET_CRITERIA`   | all registry datasets       | Registry search criteria as a JSON object (mutually exclusive w/ `DATASETS`)                        |
+| `TYPESENSE_HOST`     | **required**                | Typesense host                                                                                      |
+| `TYPESENSE_PORT`     | `8108`                      | Typesense port                                                                                      |
+| `TYPESENSE_PROTOCOL` | `http`                      | `http` or `https`                                                                                   |
+| `TYPESENSE_API_KEY`  | **required**                | An admin key: the indexer creates, writes and swaps collections                                     |
+| `REBUILD_MODE`       | `in-place`                  | `in-place` (update the live collection) or `blue-green` (swap on commit)                            |
+| `COLLECTION_PREFIX`  | none                        | Prefix for every derived collection name (configure the read side to match)                         |
+| `PROVENANCE_FILE`    | none                        | JSON file remembering per-dataset processing, to skip unchanged datasets                            |
+| `PIPELINE_VERSION`   | none                        | Version keying the skip decisions; required with `PROVENANCE_FILE`                                  |
+| `QLEVER_IMAGE`       | none                        | Enables the QLever import path (see below), e.g. `adfreiburg/qlever:latest`                         |
+| `IMPORT_STRATEGY`    | `sparql`                    | `sparql`, `sparqlWithImportFallback` or `import`; requires `QLEVER_IMAGE`                           |
+| `DATA_DIR`           | `/data`                     | Directory for downloaded dumps and QLever index caches                                              |
+| `QLEVER_NETWORK`     | none                        | Docker network the spawned QLever joins; set when the indexer itself runs containerized (see below) |
 
 A misconfigured boot reports **all** problems in one error, not one per crash
 loop. `PROVENANCE_FILE` must sit on a durable volume, and cannot be combined
@@ -102,6 +103,19 @@ explains why a statically-declared QLever service cannot work). That requires:
 - `DATA_DIR` on a volume whose **host path is identical** for the indexer and
   the spawned QLever containers – the pipeline passes `DATA_DIR` as a bind
   mount to a sibling container, where it resolves against the host.
+
+How the indexer reaches the QLever it spawned depends on where the indexer
+itself runs:
+
+- **On the host** (`npx @lde/search-indexer` with Docker available): leave
+  `QLEVER_NETWORK` unset. QLever’s port is published on the host and
+  addressed as `localhost`.
+- **In a container on a bridge network** (the `docker compose` default): set
+  `QLEVER_NETWORK` to a network the indexer is attached to. QLever joins that
+  network and is addressed by container name (`qlever-<network>`) instead – a
+  containerized indexer’s `localhost` is its own network namespace, so it
+  cannot reach a host-published port. Alternatively, run the indexer with
+  `network_mode: host` and leave `QLEVER_NETWORK` unset.
 
 This mode does not work on container runtimes without a Docker socket
 (containerd-based Kubernetes); there, run endpoint-only for now.

--- a/packages/search-indexer/README.md
+++ b/packages/search-indexer/README.md
@@ -117,6 +117,14 @@ itself runs:
   cannot reach a host-published port. Alternatively, run the indexer with
   `network_mode: host` and leave `QLEVER_NETWORK` unset.
 
+`QLEVER_NETWORK` must name a network the indexer container is actually
+attached to – for compose, the prefixed name Docker creates (e.g.
+`myproject_default`), not the short service-file name. A wrong or unattached
+network is not caught at boot: each dataset imports fully, then fails when
+the endpoint never becomes reachable. And run at most one indexer per
+network – the QLever container name is derived from the network, so two
+indexers sharing one would remove each other’s QLever.
+
 This mode does not work on container runtimes without a Docker socket
 (containerd-based Kubernetes); there, run endpoint-only for now.
 

--- a/packages/search-indexer/src/composition.ts
+++ b/packages/search-indexer/src/composition.ts
@@ -62,17 +62,23 @@ export function distributionResolverFrom(
   if (!config.qlever) {
     return undefined;
   }
-  const { importer, server } = createQlever({
-    mode: 'docker',
-    image: config.qlever.image,
-    dataDir: config.qlever.dataDir,
-    // The network-scoped name keeps two stacks on one host from removing
-    // each other's QLever, and doubles as the endpoint hostname.
-    ...(config.qlever.network && {
-      network: config.qlever.network,
-      containerName: `qlever-${config.qlever.network}`,
-    }),
-  });
+  const { importer, server } = config.qlever.network
+    ? createQlever({
+        mode: 'docker',
+        image: config.qlever.image,
+        dataDir: config.qlever.dataDir,
+        network: config.qlever.network,
+        // The network-scoped name doubles as the endpoint hostname. It keeps
+        // stacks on different networks from removing each other’s QLever;
+        // indexers sharing one network would still collide, so run at most
+        // one indexer per network.
+        containerName: `qlever-${config.qlever.network}`,
+      })
+    : createQlever({
+        mode: 'docker',
+        image: config.qlever.image,
+        dataDir: config.qlever.dataDir,
+      });
   return new ImportResolver(new SparqlDistributionResolver(), {
     importer,
     server,

--- a/packages/search-indexer/src/composition.ts
+++ b/packages/search-indexer/src/composition.ts
@@ -66,6 +66,12 @@ export function distributionResolverFrom(
     mode: 'docker',
     image: config.qlever.image,
     dataDir: config.qlever.dataDir,
+    // The network-scoped name keeps two stacks on one host from removing
+    // each other's QLever, and doubles as the endpoint hostname.
+    ...(config.qlever.network && {
+      network: config.qlever.network,
+      containerName: `qlever-${config.qlever.network}`,
+    }),
   });
   return new ImportResolver(new SparqlDistributionResolver(), {
     importer,

--- a/packages/search-indexer/src/config.ts
+++ b/packages/search-indexer/src/config.ts
@@ -59,6 +59,11 @@ export interface QleverConfig {
   readonly strategy: 'sparql' | 'sparqlWithImportFallback' | 'import';
   /** Directory for downloaded dumps and QLever index caches. */
   readonly dataDir: string;
+  /** Docker network the spawned QLever joins (`QLEVER_NETWORK`), reached by
+   *  container name. Required when the indexer itself runs containerized on
+   *  a bridge network; without it QLever is published on the host and
+   *  addressed as `localhost`. */
+  readonly network?: string;
 }
 
 const IMPORT_STRATEGIES = [
@@ -236,10 +241,16 @@ function qleverFromEnvironment(
 ): QleverConfig | undefined {
   const image = environment['QLEVER_IMAGE'];
   const strategy = environment['IMPORT_STRATEGY'];
+  const network = environment['QLEVER_NETWORK'];
   if (!image) {
     if (strategy) {
       problems.push(
         'IMPORT_STRATEGY requires QLEVER_IMAGE: without an import engine there is nothing to import into',
+      );
+    }
+    if (network) {
+      problems.push(
+        'QLEVER_NETWORK requires QLEVER_IMAGE: without an import engine there is no QLever container to attach',
       );
     }
     return undefined;
@@ -256,5 +267,6 @@ function qleverFromEnvironment(
     image,
     strategy: (strategy ?? 'sparql') as QleverConfig['strategy'],
     dataDir: environment['DATA_DIR'] ?? '/data',
+    network,
   };
 }

--- a/packages/search-indexer/test/composition.test.ts
+++ b/packages/search-indexer/test/composition.test.ts
@@ -83,4 +83,17 @@ describe('distributionResolverFrom', () => {
     );
     expect(resolver).toBeInstanceOf(ImportResolver);
   });
+
+  it('builds the QLever import path on a Docker network', () => {
+    const resolver = distributionResolverFrom(
+      configFromEnvironment({
+        ...minimal,
+        QLEVER_IMAGE: 'adfreiburg/qlever:latest',
+        IMPORT_STRATEGY: 'import',
+        DATA_DIR: '/tmp/qlever-data',
+        QLEVER_NETWORK: 'app_default',
+      }),
+    );
+    expect(resolver).toBeInstanceOf(ImportResolver);
+  });
 });

--- a/packages/search-indexer/test/config.test.ts
+++ b/packages/search-indexer/test/config.test.ts
@@ -211,5 +211,20 @@ describe('configFromEnvironment', () => {
         configFromEnvironment({ ...minimal, IMPORT_STRATEGY: 'import' }),
       ).toThrowError(/IMPORT_STRATEGY requires QLEVER_IMAGE/);
     });
+
+    it('reads the Docker network QLever joins', () => {
+      const config = configFromEnvironment({
+        ...minimal,
+        QLEVER_IMAGE: 'adfreiburg/qlever:latest',
+        QLEVER_NETWORK: 'app_default',
+      });
+      expect(config.qlever?.network).toBe('app_default');
+    });
+
+    it('rejects a network without an image', () => {
+      expect(() =>
+        configFromEnvironment({ ...minimal, QLEVER_NETWORK: 'app_default' }),
+      ).toThrowError(/QLEVER_NETWORK requires QLEVER_IMAGE/);
+    });
   });
 });

--- a/packages/sparql-qlever/README.md
+++ b/packages/sparql-qlever/README.md
@@ -10,6 +10,20 @@ Only **one** index is cached at a time. In a multi-dataset pipeline, each datase
 
 Caching is enabled by default. Disable it by passing `cacheIndex: false` to `createQlever()` or the `Importer` constructor (e.g. driven by a `QLEVER_CACHE_INDEX=false` environment variable).
 
+## Networking (Docker mode)
+
+By default `createQlever({ mode: 'docker' })` publishes QLever’s port on the host and addresses the query endpoint as `localhost` – correct when the consumer runs on the host, or shares the QLever container’s network namespace. A consumer that itself runs in a container on a bridge network cannot reach a host-published port; pass `network` (a Docker network the consumer is attached to) together with `containerName`, and QLever joins that network with the endpoint addressed by container name instead:
+
+```ts
+const { importer, server } = createQlever({
+  mode: 'docker',
+  image: 'adfreiburg/qlever:latest',
+  network: 'app_default',
+  containerName: 'qlever',
+});
+server.queryEndpoint.toString(); // 'http://qlever:7001/sparql'
+```
+
 ## Configuration
 
 `createQlever()` accepts `indexOptions` and `serverOptions` to tune QLever's index builder and server respectively.

--- a/packages/sparql-qlever/src/createQlever.ts
+++ b/packages/sparql-qlever/src/createQlever.ts
@@ -26,6 +26,16 @@ export type QleverOptions = {
       mode: 'docker';
       image: string;
       containerName?: string;
+      /**
+       * Docker network to attach the QLever containers to. Set this when the
+       * consumer itself runs in a container on that network: the query
+       * endpoint is then addressed by `containerName` as hostname instead of
+       * a host-published `localhost` port, which a containerized consumer on
+       * a bridge network cannot reach. Leave unset when the consumer runs on
+       * the host (or shares the QLever container’s network namespace), where
+       * `localhost` is correct. Requires `containerName`.
+       */
+      network?: string;
     }
   | { mode: 'native' }
 );
@@ -38,13 +48,21 @@ export type QleverOptions = {
  */
 export function createQlever(options: QleverOptions) {
   const port = options.port ?? 7001;
+  if (options.mode === 'docker' && options.network && !options.containerName) {
+    throw new Error(
+      'network requires containerName: it is the hostname at which consumers on the network reach the QLever endpoint',
+    );
+  }
   const taskRunner: TaskRunner<unknown> =
     options.mode === 'docker'
       ? new DockerTaskRunner({
           image: options.image,
           containerName: options.containerName,
           mountDir: options.dataDir,
-          port,
+          network: options.network,
+          // On a shared network the endpoint is reached by container name,
+          // so don't claim a host port.
+          port: options.network ? undefined : port,
         })
       : new NativeTaskRunner({ cwd: options.dataDir });
 
@@ -61,6 +79,10 @@ export function createQlever(options: QleverOptions) {
       taskRunner,
       indexName: options.indexName ?? 'data',
       port,
+      hostname:
+        options.mode === 'docker' && options.network
+          ? options.containerName
+          : undefined,
       qleverOptions: options.serverOptions,
     }),
   };

--- a/packages/sparql-qlever/src/createQlever.ts
+++ b/packages/sparql-qlever/src/createQlever.ts
@@ -26,6 +26,11 @@ export type QleverOptions = {
       mode: 'docker';
       image: string;
       containerName?: string;
+      network?: never;
+    }
+  | {
+      mode: 'docker';
+      image: string;
       /**
        * Docker network to attach the QLever containers to. Set this when the
        * consumer itself runs in a container on that network: the query
@@ -33,9 +38,11 @@ export type QleverOptions = {
        * a host-published `localhost` port, which a containerized consumer on
        * a bridge network cannot reach. Leave unset when the consumer runs on
        * the host (or shares the QLever container’s network namespace), where
-       * `localhost` is correct. Requires `containerName`.
+       * `localhost` is correct.
        */
-      network?: string;
+      network: string;
+      /** The hostname at which consumers on the network reach the endpoint. */
+      containerName: string;
     }
   | { mode: 'native' }
 );
@@ -48,11 +55,12 @@ export type QleverOptions = {
  */
 export function createQlever(options: QleverOptions) {
   const port = options.port ?? 7001;
-  if (options.mode === 'docker' && options.network && !options.containerName) {
-    throw new Error(
-      'network requires containerName: it is the hostname at which consumers on the network reach the QLever endpoint',
-    );
-  }
+  // On a shared network the endpoint is reached by container name, so don't
+  // claim a host port.
+  const hostname =
+    options.mode === 'docker' && options.network
+      ? options.containerName
+      : undefined;
   const taskRunner: TaskRunner<unknown> =
     options.mode === 'docker'
       ? new DockerTaskRunner({
@@ -60,9 +68,7 @@ export function createQlever(options: QleverOptions) {
           containerName: options.containerName,
           mountDir: options.dataDir,
           network: options.network,
-          // On a shared network the endpoint is reached by container name,
-          // so don't claim a host port.
-          port: options.network ? undefined : port,
+          port: hostname ? undefined : port,
         })
       : new NativeTaskRunner({ cwd: options.dataDir });
 
@@ -79,10 +85,7 @@ export function createQlever(options: QleverOptions) {
       taskRunner,
       indexName: options.indexName ?? 'data',
       port,
-      hostname:
-        options.mode === 'docker' && options.network
-          ? options.containerName
-          : undefined,
+      hostname,
       qleverOptions: options.serverOptions,
     }),
   };

--- a/packages/sparql-qlever/src/server.ts
+++ b/packages/sparql-qlever/src/server.ts
@@ -26,13 +26,21 @@ export class Server<Task> implements SparqlServer {
   private readonly indexName: string;
   private task?: Task;
   private readonly port: number;
+  private readonly hostname: string;
   private readonly qleverOptions: RequiredQleverServerOptions &
     Pick<QleverServerOptions, 'cache-max-size'>;
 
-  constructor({ taskRunner, indexName, port, qleverOptions }: Arguments<Task>) {
+  constructor({
+    taskRunner,
+    indexName,
+    port,
+    hostname,
+    qleverOptions,
+  }: Arguments<Task>) {
     this.taskRunner = taskRunner;
     this.indexName = indexName;
     this.port = port ?? 7001;
+    this.hostname = hostname ?? 'localhost';
     this.qleverOptions = { ...defaultQleverServerOptions, ...qleverOptions };
   }
 
@@ -63,7 +71,7 @@ export class Server<Task> implements SparqlServer {
   }
 
   public get queryEndpoint(): URL {
-    return new URL(`http://localhost:${this.port}/sparql`);
+    return new URL(`http://${this.hostname}:${this.port}/sparql`);
   }
 }
 
@@ -72,5 +80,12 @@ export interface Arguments<Task> {
   indexName: string;
   /** @default 7001 */
   port?: number;
+  /**
+   * Hostname at which consumers reach the query endpoint. Defaults to
+   * `localhost`, which is right whenever the server shares the consumer’s
+   * network namespace: a native process, a host-published Docker port, or
+   * QLever running inside the consumer’s own container.
+   */
+  hostname?: string;
   qleverOptions?: QleverServerOptions;
 }

--- a/packages/sparql-qlever/test/createQlever.test.ts
+++ b/packages/sparql-qlever/test/createQlever.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { createQlever } from '../src/createQlever.js';
+
+describe('createQlever', () => {
+  it('addresses the endpoint as localhost by default', () => {
+    const { server } = createQlever({
+      mode: 'docker',
+      image: 'adfreiburg/qlever:latest',
+    });
+    expect(server.queryEndpoint.toString()).toBe(
+      'http://localhost:7001/sparql',
+    );
+  });
+
+  it('addresses the endpoint as localhost in native mode', () => {
+    const { server } = createQlever({ mode: 'native', port: 7002 });
+    expect(server.queryEndpoint.toString()).toBe(
+      'http://localhost:7002/sparql',
+    );
+  });
+
+  it('addresses the endpoint by container name on a Docker network', () => {
+    const { server } = createQlever({
+      mode: 'docker',
+      image: 'adfreiburg/qlever:latest',
+      network: 'app_default',
+      containerName: 'qlever',
+    });
+    expect(server.queryEndpoint.toString()).toBe('http://qlever:7001/sparql');
+  });
+
+  it('rejects a network without a container name', () => {
+    expect(() =>
+      createQlever({
+        mode: 'docker',
+        image: 'adfreiburg/qlever:latest',
+        network: 'app_default',
+      }),
+    ).toThrow('network requires containerName');
+  });
+});

--- a/packages/sparql-qlever/test/createQlever.test.ts
+++ b/packages/sparql-qlever/test/createQlever.test.ts
@@ -29,13 +29,12 @@ describe('createQlever', () => {
     expect(server.queryEndpoint.toString()).toBe('http://qlever:7001/sparql');
   });
 
-  it('rejects a network without a container name', () => {
-    expect(() =>
-      createQlever({
-        mode: 'docker',
-        image: 'adfreiburg/qlever:latest',
-        network: 'app_default',
-      }),
-    ).toThrow('network requires containerName');
+  it('rejects a network without a container name at the type level', () => {
+    createQlever({
+      mode: 'docker',
+      image: 'adfreiburg/qlever:latest',
+      // @ts-expect-error network requires containerName, the endpoint hostname
+      network: 'app_default',
+    });
   });
 });

--- a/packages/sparql-qlever/vite.config.ts
+++ b/packages/sparql-qlever/vite.config.ts
@@ -13,10 +13,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 96.13,
+          lines: 96.25,
           functions: 100,
-          branches: 85.26,
-          statements: 96.17,
+          branches: 88.79,
+          statements: 96.29,
         },
       },
     },

--- a/packages/sparql-qlever/vite.config.ts
+++ b/packages/sparql-qlever/vite.config.ts
@@ -13,10 +13,10 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           autoUpdate: true,
-          lines: 96.25,
+          lines: 96.23,
           functions: 100,
-          branches: 88.79,
-          statements: 96.29,
+          branches: 88.28,
+          statements: 96.27,
         },
       },
     },

--- a/packages/task-runner-docker/README.md
+++ b/packages/task-runner-docker/README.md
@@ -32,7 +32,8 @@ await runner.stop(container);
 | `image`         | `string` | Yes      | Docker image to use                                  |
 | `containerName` | `string` | No       | Name for the container (auto-removed on restart)     |
 | `mountDir`      | `string` | No       | Host directory to mount at `/mount` in the container |
-| `port`          | `number` | No       | Port to expose from the container                    |
+| `port`          | `number` | No       | Container port to publish on the same host port      |
+| `network`       | `string` | No       | Docker network to attach the container to            |
 | `docker`        | `Docker` | No       | Custom Dockerode instance                            |
 
 ## Features
@@ -40,7 +41,9 @@ await runner.stop(container);
 - Automatically pulls the Docker image before running
 - Mounts a host directory as `/mount` with the `mountDir` option
 - Runs commands as the current user (UID/GID) for file permissions
-- Exposes ports with `port` option
+- Publishes ports on the host with the `port` option
+- Attaches the container to a Docker network with the `network` option, where
+  other containers reach it by its `containerName` as hostname
 - Stops containers (without removing) so logs remain available via `docker logs`
 - Removes previous containers with the same name on restart
 - Streams container logs to stdout

--- a/packages/task-runner-docker/src/index.ts
+++ b/packages/task-runner-docker/src/index.ts
@@ -5,8 +5,15 @@ import Docker, { Container, ContainerCreateOptions } from 'dockerode';
 export interface DockerTaskRunnerOptions {
   image: string;
   containerName?: string;
+  /** Publish this container port to the same port on the host. */
   port?: number;
   mountDir?: string;
+  /**
+   * Docker network to attach the container to. On a user-defined network,
+   * other containers reach it by its `containerName` as hostname, so
+   * publishing a host `port` becomes unnecessary.
+   */
+  network?: string;
   docker?: Docker;
 }
 
@@ -78,6 +85,13 @@ export class DockerTaskRunner implements TaskRunner<Container> {
             },
           ],
         },
+      };
+    }
+
+    if (this.options.network) {
+      containerOptions.HostConfig = {
+        ...containerOptions.HostConfig,
+        NetworkMode: this.options.network,
       };
     }
 

--- a/packages/task-runner-docker/test/index.test.ts
+++ b/packages/task-runner-docker/test/index.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type Docker from 'dockerode';
+import type { ContainerCreateOptions } from 'dockerode';
+import { DockerTaskRunner } from '../src/index.js';
+
+/** A fake Docker daemon that records the container options passed to it. */
+function createFakeDocker(): Docker & { created: ContainerCreateOptions[] } {
+  const fake = {
+    created: [] as ContainerCreateOptions[],
+    async pull() {
+      return {};
+    },
+    modem: {
+      followProgress(
+        _stream: unknown,
+        onFinished: (error: Error | null) => void,
+      ) {
+        onFinished(null);
+      },
+    },
+    getContainer() {
+      return {
+        remove: () => Promise.resolve(),
+      };
+    },
+    async createContainer(options: ContainerCreateOptions) {
+      fake.created.push(options);
+      return {
+        start: () => Promise.resolve(),
+      };
+    },
+  };
+  return fake as unknown as Docker & { created: ContainerCreateOptions[] };
+}
+
+describe('DockerTaskRunner', () => {
+  it('publishes the port on the host when configured', async () => {
+    const docker = createFakeDocker();
+    const runner = new DockerTaskRunner({
+      image: 'example/image',
+      port: 7001,
+      docker,
+    });
+
+    await runner.run('true');
+
+    expect(docker.created[0].HostConfig?.PortBindings).toEqual({
+      '7001/tcp': [{ HostPort: '7001' }],
+    });
+    expect(docker.created[0].HostConfig?.NetworkMode).toBeUndefined();
+  });
+
+  it('attaches the container to the configured network', async () => {
+    const docker = createFakeDocker();
+    const runner = new DockerTaskRunner({
+      image: 'example/image',
+      containerName: 'task',
+      network: 'app_default',
+      docker,
+    });
+
+    await runner.run('true');
+
+    expect(docker.created[0].HostConfig?.NetworkMode).toBe('app_default');
+    expect(docker.created[0].HostConfig?.PortBindings).toBeUndefined();
+  });
+});

--- a/packages/task-runner-docker/tsconfig.spec.json
+++ b/packages/task-runner-docker/tsconfig.spec.json
@@ -3,11 +3,10 @@
   "compilerOptions": {
     "outDir": "./out-tsc/vitest",
     "types": ["node"],
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "6.0",
+    "rootDir": "."
   },
   "include": [
-    "vite.config.ts",
-    "vitest.config.ts",
     "test/**/*.test.ts",
     "test/**/*.spec.ts",
     "test/**/*.test.tsx",

--- a/packages/task-runner-docker/vite.config.ts
+++ b/packages/task-runner-docker/vite.config.ts
@@ -1,0 +1,21 @@
+/// <reference types='vitest' />
+import { defineConfig, mergeConfig } from 'vite';
+import baseConfig from '../../vite.base.config.js';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    root: __dirname,
+    cacheDir: '../../node_modules/.vite/packages/task-runner-docker',
+    test: {
+      coverage: {
+        thresholds: {
+          functions: 0,
+          lines: 0,
+          branches: 0,
+          statements: 0,
+        },
+      },
+    },
+  }),
+);


### PR DESCRIPTION
Fix #660

`createQlever({ mode: 'docker' })` published QLever on the host and hardcoded the endpoint to `http://localhost:<port>/sparql`, so a containerized consumer on a bridge network – the `docker compose` default for the search-indexer image – could not reach it without `network_mode: host`.

QLever can now join a Docker network and be addressed by container name, strictly opt-in; `localhost` stays the default for every setup where it is correct (native mode, a host-run consumer, or QLever sharing the consumer’s container/network namespace).

## Changes

- **task-runner-docker**: new `network` option attaches the spawned container to a Docker network (`HostConfig.NetworkMode`). `port` keeps meaning “publish on the host”. Adds the package’s first tests (unit tests against an injected fake Dockerode).
- **sparql-qlever**: `Server` takes an injectable endpoint `hostname` (default `localhost`). `createQlever` docker mode accepts `network`, whose options arm requires `containerName` at the type level: the endpoint is then `http://<containerName>:<port>/sparql` and no host port is claimed.
- **search-indexer**: new `QLEVER_NETWORK` environment variable (requires `QLEVER_IMAGE`). When set, the QLever container is named `qlever-<network>` – unique per network, so stacks on different networks cannot force-remove each other’s QLever – and reached by that name. The README documents when to set it versus relying on `localhost` or `network_mode: host`, that it must be a network the indexer is actually attached to (a wrong name fails per dataset, not at boot), and that at most one indexer may run per network.

## Deployment

A compose deployment of the indexer next to Typesense now works on the default bridge network:

```yaml
services:
  indexer:
    image: ghcr.io/ldelements/search-indexer
    environment:
      QLEVER_IMAGE: adfreiburg/qlever:latest
      IMPORT_STRATEGY: import
      QLEVER_NETWORK: myapp_default
    ...
```

## Known trade-offs

- A misconfigured `QLEVER_NETWORK` (unattached or misspelled) surfaces per dataset after the import completes, not at boot; a boot-time reachability preflight is a possible follow-up.
- In network mode the index-build container and the server container share one name, so the server start removes the finished build container and its `docker logs`; the importer already captures the build log in-process.

Related: #638, #639, #652.
