### PR TITLE
docs: present LDE capabilities as homepage feature tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LDE – Linked Data Elements
 
-**Shared building blocks for the full Linked Data lifecycle.**
+**Coherent, composable building blocks for your Linked Data apps and pipelines.**
 
 [![CI](https://github.com/ldelements/lde/actions/workflows/ci.yml/badge.svg)](https://github.com/ldelements/lde/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -99,7 +99,7 @@ export default withMermaid({
   },
   title: 'LDE',
   description:
-    'Linked Data Elements – shared building blocks for the full Linked Data lifecycle.',
+    'Linked Data Elements – coherent, composable building blocks for your Linked Data apps and pipelines, covering the whole lifecycle.',
   cleanUrls: true,
   lastUpdated: true,
   sitemap: {

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,32 +4,57 @@ layout: home
 hero:
   name: LDE
   text: Linked Data Elements
-  tagline: Shared building blocks for the full Linked Data lifecycle – from discovery and ingestion through transformation to publication.
+  tagline: Coherent, composable building blocks for your Linked Data apps and pipelines – covering the whole lifecycle, from discovery through transformation to publication.
   actions:
     - theme: brand
-      text: What is LDE?
-      link: /guide/what-is-lde
-    - theme: alt
       text: Get started
       link: /guide/build-a-pipeline
+    - theme: alt
+      text: What is LDE?
+      link: /guide/what-is-lde
     - theme: alt
       text: GitHub
       link: https://github.com/ldelements/lde
 
 features:
-  - title: Tutorials
-    icon: 🎓
-    details: Hands-on lessons – build your first Linked Data pipeline, then a full search API on top.
+  - title: Compose
+    icon: 🧩
+    details: Every capability is its own package behind a small interface. Adopt the whole lifecycle, or pick just the blocks you need.
+    link: /reference/packages
+    linkText: Browse the packages
+  - title: Discover
+    icon: 🔍
+    details: Find datasets in DCAT-AP 3.0 registries and resolve each one to a usable distribution.
+    link: /guide/select-datasets-from-a-registry
+    linkText: Select from a registry
+  - title: Import
+    icon: 📥
+    details: Download data dumps and import them into a local SPARQL endpoint, so every dataset is queryable – with or without a live endpoint.
+    link: /guide/import-data-dumps
+    linkText: Import data dumps
+  - title: Transform
+    icon: 🔄
+    details: Express transformations as plain SPARQL CONSTRUCT queries, and run them over datasets far larger than memory.
     link: /guide/build-a-pipeline
-    linkText: Start learning
-  - title: How-to guides
-    icon: 🛠️
-    details: Goal-oriented recipes for specific tasks, such as validating pipeline output or skipping unchanged datasets.
-    link: /guide/#how-to
-    linkText: Solve a problem
-  - title: Reference
-    icon: 📖
-    details: Technical descriptions of the packages, their APIs, the standards they implement and the design decisions behind them.
-    link: /reference/
-    linkText: Look it up
+    linkText: Build a pipeline
+  - title: Validate & analyze
+    icon: ✅
+    details: Check pipeline output against SHACL shapes and compute VoID statistics over datasets.
+    link: /guide/validate-pipeline-output
+    linkText: Validate with SHACL
+  - title: Search
+    icon: 🔎
+    details: Turn RDF into a fulltext, typo-tolerant, faceted search engine served over GraphQL, all from one declarative schema.
+    link: /guide/build-a-search-api
+    linkText: Build a search API
+  - title: Publish
+    icon: 🌐
+    details: Serve RDF over HTTP with content negotiation and generate documentation from SHACL shapes.
+    link: /guide/serve-rdf-with-content-negotiation
+    linkText: Serve RDF
+  - title: Monitor
+    icon: 📊
+    details: Watch pipeline runs with pluggable reporters and probe distribution health on a schedule.
+    link: /guide/observe-a-run-with-a-reporter
+    linkText: Observe a run
 ---


### PR DESCRIPTION
Reworks the docs homepage to present LDE’s capabilities rather than docs sections – the boxes previously mirrored the navigation (Tutorials / How-to / Reference), which the navbar and hero buttons already provide.

## Changes

- **Eight capability tiles** in lifecycle order, each linking into the guide that demonstrates it: Compose (🧩 use only the blocks you need), Discover, Import, Transform, Validate & analyze, Search, Publish, Monitor.
- **Import** reframed positively: ‘every dataset is queryable – with or without a live endpoint’ instead of leading with failing endpoints; kept engine-generic (SPARQL endpoint, not QLever).
- **Transform** untangled: one claim per clause – plain SPARQL CONSTRUCT, over datasets far larger than memory.
- **Headers aligned** across surfaces: the hero tagline, site meta description and README intro now use the GitHub repo description’s vocabulary (‘coherent, composable building blocks for your Linked Data apps and pipelines’).
- Hero buttons reordered: Get started is the primary action.
