### PR TITLE
fix(search-api-graphql): serve labelOnly references to root types

### DIFF
--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -148,8 +148,11 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
 
 - **Output type** (the `SearchType`’s `name`): localized text → best-first `[LanguageString!]!`
   (`[0].language` is the language actually served); references → named per-shape
-  types (`Organization`, `Term`) with a `name`; scalars/booleans per kind; `date`
-  → ISO 8601 string; nullability from `required` / `array` / `kind`.
+  types (`Organization`, `Term`) with a `name` – a reference whose `typeName`
+  names a root type (`creator` → `Person`) is served under a derived name
+  (`PersonReference`), since GraphQL type names must be unique; scalars/booleans
+  per kind; `date` → ISO 8601 string; nullability from `required` / `array` /
+  `kind`.
 - **`where`** one input per `filterable` field (`StringFilter`, `IntRange` /
   `FloatRange` / `DateRange`, or `Boolean`); omitted entirely for a type with no
   filterable fields.

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -275,7 +275,11 @@ directly.
 
 A `reference` carries one of two strategies today: `labelOnly` (id + display
 label, resolved at query time from a label source) and `inline` (the referent’s
-own projected fields, carried inline). `idOnly` stays a forward declaration.
+own projected fields, carried inline). `idOnly` stays a forward declaration. A
+`labelOnly` reference’s `ref.typeName` is a name, not a key: it may name an
+indexed root type (`creator` → `Person`, with `labelSource: 'Person'`) – the
+standard way to reference entities of another collection; only an `inline`
+reference must resolve to a declared Reference Type.
 
 An **inline reference** resolves `ref.typeName` to a declared **Reference Type**
 and projects the referent through it – a nested `SearchDocument`, or an array

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -198,33 +198,45 @@ export function buildGraphQLSchema(
 
   // One reference type per referenced shape, shared across every root type and
   // reused by every field (Person and CreativeWork both referencing Agent yield
-  // one Agent type).
+  // one Agent type). A reference may name a root type – the `labelOnly` way to
+  // carry an id plus a label resolved from that root’s collection (`creator` →
+  // `Person`) – but GraphQL type names must be unique, so such a reference is
+  // served under `‹Name›Reference` instead. An `inline` reference can never
+  // collide: searchSchema resolves its typeName to a declared Reference Type
+  // and rejects duplicate names schema-wide.
   const referenceTypes = new Map<string, GraphQLObjectType>();
+  const takenTypeNames = new Set(rootTypeNames);
   for (const searchType of schema.values()) {
     for (const field of outputFields(searchType)) {
-      if (field.kind !== 'reference' || field.ref === undefined) {
+      if (
+        field.kind !== 'reference' ||
+        field.ref === undefined ||
+        referenceTypes.has(field.ref.typeName)
+      ) {
         continue;
       }
       const { typeName } = field.ref;
-      if (rootTypeNames.has(typeName)) {
+      const graphQLName = rootTypeNames.has(typeName)
+        ? `${typeName}Reference`
+        : typeName;
+      if (takenTypeNames.has(graphQLName)) {
         throw new Error(
-          `Reference type name “${typeName}” (field “${field.name}” of “${searchType.name}”) collides with a root type of the same name; rename one – a reference does not resolve to a root type.`,
+          `Reference type “${typeName}” (field “${field.name}” of “${searchType.name}”) would be served as “${graphQLName}”, which collides with another type name; rename one.`,
         );
       }
-      if (!referenceTypes.has(typeName)) {
-        referenceTypes.set(
-          typeName,
-          new GraphQLObjectType({
-            name: typeName,
-            fields: {
-              id: { type: new GraphQLNonNull(GraphQLString) },
-              name: labelList(
-                (source) => source.label as LocalizedValue | undefined,
-              ),
-            },
-          }),
-        );
-      }
+      takenTypeNames.add(graphQLName);
+      referenceTypes.set(
+        typeName,
+        new GraphQLObjectType({
+          name: graphQLName,
+          fields: {
+            id: { type: new GraphQLNonNull(GraphQLString) },
+            name: labelList(
+              (source) => source.label as LocalizedValue | undefined,
+            ),
+          },
+        }),
+      );
     }
   }
 

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -684,8 +684,8 @@ describe('buildGraphQLSchema', () => {
       );
     });
 
-    it('throws when a reference type name collides with a root type name', () => {
-      const withCollidingRef: SearchType = {
+    it('serves a labelOnly reference to a root type under ‹Name›Reference', () => {
+      const withReferenceToRoot: SearchType = {
         name: 'CreativeWork',
         class: 'https://schema.org/CreativeWork',
         fields: [
@@ -693,14 +693,49 @@ describe('buildGraphQLSchema', () => {
             name: 'author',
             kind: 'reference',
             output: true,
-            // Person is also a root type in this schema – same GraphQL name.
+            // Person is also a root type in this schema – the labelOnly way to
+            // carry an id plus a label resolved from the Person collection.
+            ref: { typeName: 'Person', strategy: 'labelOnly' },
+          },
+        ],
+      };
+      const sdl = printSchema(
+        buildGraphQLSchema(searchSchema(PERSON, withReferenceToRoot)),
+      );
+      // The root type keeps its name; the reference is served under a derived
+      // name, since GraphQL type names must be unique.
+      expect(sdl.match(/^type Person /gm)).toHaveLength(1);
+      expect(sdl).toMatch(/author: PersonReference/);
+      expect(sdl).toMatch(
+        /type PersonReference \{\s+id: String!\s+name: \[LanguageString!\]!\s+\}/,
+      );
+    });
+
+    it('throws when the derived reference name is itself taken', () => {
+      const takenDerivedName: SearchType = {
+        name: 'PersonReference',
+        class: 'https://example.org/PersonReference',
+        fields: [{ name: 'name', kind: 'keyword', output: true }],
+      };
+      const withReferenceToRoot: SearchType = {
+        name: 'CreativeWork',
+        class: 'https://schema.org/CreativeWork',
+        fields: [
+          {
+            name: 'author',
+            kind: 'reference',
+            output: true,
             ref: { typeName: 'Person', strategy: 'labelOnly' },
           },
         ],
       };
       expect(() =>
-        buildGraphQLSchema(searchSchema(PERSON, withCollidingRef)),
-      ).toThrow(/Reference type name “Person”.*collides with a root type/);
+        buildGraphQLSchema(
+          searchSchema(PERSON, takenDerivedName, withReferenceToRoot),
+        ),
+      ).toThrow(
+        /Reference type “Person”.*would be served as “PersonReference”, which collides/,
+      );
     });
 
     it('rejects a duplicate root type name at declaration time', () => {

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -22,7 +22,7 @@ export default mergeConfig(
           lines: 100,
           // Full-suite baseline, re-anchored when covered branches are
           // deleted (autoUpdate only ever raises; see AGENTS.md).
-          branches: 94.02,
+          branches: 94.07,
           statements: 100,
         },
       },

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -8,13 +8,7 @@ import type { SearchDocument } from './project.js';
  * *derived* from this by the engine adapter, never declared here.
  */
 export type FieldKind =
-  | 'text'
-  | 'keyword'
-  | 'integer'
-  | 'number'
-  | 'boolean'
-  | 'date'
-  | 'reference';
+  'text' | 'keyword' | 'integer' | 'number' | 'boolean' | 'date' | 'reference';
 
 /** The `where` operator a kind accepts, or `undefined` when it is not filterable
  *  through `where` (`text` feeds the free-text `query` instead). */
@@ -75,11 +69,7 @@ export function filterOperatorFor(kind: FieldKind): FilterOperator | undefined {
  * and a hand-written declaration is just as valid.
  */
 export type SearchField =
-  | TextField
-  | KeywordField
-  | ReferenceField
-  | NumericField
-  | BooleanField;
+  TextField | KeywordField | ReferenceField | NumericField | BooleanField;
 
 /** The declaration members every {@link SearchField} kind shares. */
 export interface SearchFieldBase {
@@ -177,9 +167,13 @@ export interface ReferenceField extends SearchFieldBase, Searchable {
     /** Logical API type name of the referenced entity (PascalCase, e.g.
      *  `Organization`) – names the reference’s type in the API surfaces, the
      *  way {@link SearchType.name} names a root type; fields sharing it share
-     *  one emitted type. A name, not a key: it need not correspond to any
-     *  indexed root type (and until cross-collection references exist, it must
-     *  not collide with one). */
+     *  one emitted type. For a `labelOnly`/`idOnly` reference it is a name,
+     *  not a key: it need not correspond to any indexed root type, and it may
+     *  name one (`creator` → `Person`, with the labels resolved from that
+     *  root’s collection via `labelSource`) – an API surface then serves the
+     *  reference under a derived name (GraphQL: `‹Name›Reference`) to keep
+     *  type names unique. An `inline` reference’s typeName instead resolves to
+     *  a declared {@link ReferenceType}, so it can never name a root type. */
     readonly typeName: string;
     /** How much of the referenced entity the reference carries. `labelOnly`
      *  (id + display label, resolved from a label source) and `inline` (the


### PR DESCRIPTION
Fix #667

`buildGraphQLSchema` threw for **any** `kind: 'reference'` output field whose `ref.typeName` matched a root type, regardless of `ref.strategy`. That rejected `labelOnly` references to root types (`creator` → `Person`, `isPartOf` → `Dataset`) – the standard way to carry a reference’s id plus a label resolved from a root collection – so a schema that `search-indexer` accepted and indexed crash-looped `search-api-server` on boot.

## Changes

- **`build-schema.ts`**: a reference whose `typeName` names a root type is no longer an error; its GraphQL output type is served under the derived name **`‹Name›Reference`** (e.g. `PersonReference`), keeping GraphQL type names unique while the root type keeps its own name. Non-colliding references are served exactly as before, so existing SDLs are unchanged.
- No strategy branch is needed: an `inline` reference can never collide, because `searchSchema` resolves its `typeName` against the declared Reference Types and rejects duplicate names schema-wide – so the old throw was unreachable for `inline` and only ever hit the legitimate `labelOnly`/`idOnly` case.
- A clear error remains for the one true conflict: when the derived name is itself already taken (e.g. a root type literally named `PersonReference`).
- **`@lde/search` `schema.ts`**: updated the `ref.typeName` JSDoc, which still claimed a collision with a root type was forbidden.
- **Docs**: `search.md` (reference strategies) and `search-api-graphql.md` (what it builds) now document the derived-name behavior.

## Example

```ts
{ kind: 'reference', ref: { typeName: 'Person', strategy: 'labelOnly' }, labelSource: 'Person', output: true }
```

with `Person` as a root type now yields:

```graphql
type CreativeWork {
  author: PersonReference
}

type PersonReference {
  id: String!
  name: [LanguageString!]!
}
```

Related: #652, #660, #661.
