### PR TITLE
ci: key docker image builds by release tag so batched releases stop cancelling each other

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,10 +17,15 @@ permissions:
   contents: read
   packages: write
 
-# Release runs tag several packages in quick succession; serialize the image
-# pushes so :latest cannot land out of order.
+# A multi-package nx release fires a burst of release events. GitHub keeps at
+# most one *pending* run per concurrency group (cancel-in-progress: false only
+# protects the in-progress run), so a single shared group silently cancelled
+# every image build in the batch except one. Key the group by release tag
+# instead: each package builds independently – safe, because every package
+# pushes to its own ghcr image, so their :latest tags never contend – while
+# duplicate runs for the same tag still coalesce.
 concurrency:
-  group: docker-publish
+  group: docker-publish-${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,10 +23,11 @@ permissions:
 # every image build in the batch except one. Key the group by release tag
 # instead: each package builds independently – safe, because every package
 # pushes to its own ghcr image, so their :latest tags never contend – while
-# duplicate runs for the same tag still coalesce.
+# duplicate runs for the same tag coalesce: builds of one immutable tag are
+# idempotent, so the newest run simply supersedes the older one.
 concurrency:
   group: docker-publish-${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
Fix #670

A multi-package `nx release` publishes its GitHub Releases near-simultaneously, firing a burst of `release: published` events. `docker.yml` funnelled them all through the single `docker-publish` concurrency group, and GitHub keeps at most one *pending* run per group – `cancel-in-progress: false` only protects the in-progress run. So every image build in the batch except one was silently cancelled: in the 2026-07-27 release, `@lde/search-api-server@0.0.3` never got an image, leaving ghcr at `0.0.2` without the #668 fix.

Two changes to the `concurrency` block:

- **Key the group by release tag** (or the `workflow_dispatch` ref), so each package’s image build runs in its own group and the burst stops self-cancelling. Dropping the cross-package serialization is safe: each package pushes to its own ghcr image (`ghcr.io/ldelements/<package>`), so their `:latest` tags never contend. nx bumps a package at most once per release run, so same-package races can’t happen within a batch.
- **`cancel-in-progress: true`**: within a per-tag group, every run builds the same immutable tag, so runs are idempotent – the newest run supersedes the older one instead of rebuilding the identical image serially. This also picks the newest content when a dispatch ref is a moving branch rather than a tag.

The dropped `0.0.3` image has been rebuilt via the manual `workflow_dispatch` workaround in the meantime.
