### PR TITLE
feat(pipeline-void)!: iterate property partitions per property

### DIFF
--- a/docs/reference/pipeline-void.md
+++ b/docs/reference/pipeline-void.md
@@ -16,14 +16,15 @@ Returns all VoID stages in their recommended execution order. The ordering is op
 
 Accepts an optional `VoidStagesOptions` object:
 
-| Option           | Default | Description                                                                                                     |
-| ---------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
-| `batchSize`      | 10      | Maximum class bindings per reader call (per-class stages only)                                                  |
-| `maxConcurrency` | 10      | Maximum concurrent in-flight reader batches (per-class stages only)                                             |
-| `perClass`       | –       | Override per-class iteration for all five per-class stages                                                      |
-| `uriSpaces`      | –       | When provided, includes the object URI space stage                                                              |
-| `vocabularies`   | –       | Additional vocabulary namespace URIs to detect beyond the built-in defaults                                     |
-| `transforms`     | –       | Transforms to attach to bundled stages, keyed by `VOID_STAGE_NAMES` (see [Stage transforms](#stage-transforms)) |
+| Option           | Default | Description                                                                                                       |
+| ---------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `batchSize`      | 10      | Maximum item bindings per reader call (per-class stages and the per-property vocabularies stage)                  |
+| `maxConcurrency` | 10      | Maximum concurrent in-flight reader batches (per-class stages and the per-property vocabularies stage)            |
+| `perClass`       | –       | Override per-class iteration for all five per-class stages                                                        |
+| `perProperty`    | `true`  | Iterate the vocabularies (property-partition) stage per property, bounding its memory by batch instead of dataset |
+| `uriSpaces`      | –       | When provided, includes the object URI space stage                                                                |
+| `vocabularies`   | –       | Additional vocabulary namespace URIs to detect beyond the built-in defaults                                       |
+| `transforms`     | –       | Transforms to attach to bundled stages, keyed by `VOID_STAGE_NAMES` (see [Stage transforms](#stage-transforms))   |
 
 Per-request timeouts are configured at the `Pipeline` level via `PipelineOptions.timeout`, not per VoID stage.
 
@@ -77,10 +78,10 @@ The class selector that drives per-class iteration honours the distribution’s 
 
 #### Domain-specific stages:
 
-| Factory                  | Description                                                                                                                                                                                                                                                                                          |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `detectVocabularies()`   | [`entity-properties.rq`](https://github.com/ldelements/lde/blob/main/packages/pipeline-void/queries/entity-properties.rq) – Entity properties with automatic `void:vocabulary` detection. Accepts `DetectVocabulariesOptions` with an optional `vocabularies` array to extend the built-in defaults. |
-| `uriSpaces(uriSpaceMap)` | [`object-uri-space.rq`](https://github.com/ldelements/lde/blob/main/packages/pipeline-void/queries/object-uri-space.rq) – Object URI namespace linksets, aggregated against a provided URI space map                                                                                                 |
+| Factory                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `detectVocabularies()`   | [`entity-properties.rq`](https://github.com/ldelements/lde/blob/main/packages/pipeline-void/queries/entity-properties.rq) – Entity properties with automatic `void:vocabulary` detection. Accepts `DetectVocabulariesOptions`: an optional `vocabularies` array to extend the built-in defaults, plus `perProperty` (default `true`), `batchSize` and `maxConcurrency`. By default the query iterates per property – the single global `GROUP BY` over every property materializes the dataset’s full scan and exhausts the query-memory budget on large datasets (measured on a 608M-triple dataset); `perProperty: false` restores the single query. |
+| `uriSpaces(uriSpaceMap)` | [`object-uri-space.rq`](https://github.com/ldelements/lde/blob/main/packages/pipeline-void/queries/object-uri-space.rq) – Object URI namespace linksets, aggregated against a provided URI space map                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
 ## Namespace normalization
 
@@ -105,11 +106,11 @@ Use `namespacePartitionMergePlugin(aliases)` for namespaces other than schema.or
 
 ## Stage transforms
 
-A VoID stage decorates its reader’s output with a `QuadTransform<ReaderContext>` attached as data (see [@lde/pipeline](./pipeline)’s extension model and [ADR 2](../decisions/0002-unify-pipeline-extension-on-quad-transforms)). It runs once per reader call and may fire its own SPARQL queries against the `distribution` in scope – so write it to accept being called more than once: a global stage calls it once over the complete output, a per-class stage with batching enabled once per batch (one class at `batchSize: 1`).
+A VoID stage decorates its reader’s output with a `QuadTransform<ReaderContext>` attached as data (see [@lde/pipeline](./pipeline)’s extension model and [ADR 2](../decisions/0002-unify-pipeline-extension-on-quad-transforms)). It runs once per reader call and may fire its own SPARQL queries against the `distribution` in scope – so write it to accept being called more than once: a global stage calls it once over the complete output, an iterating stage once per batch (one class – or, on the vocabularies stage, one property – at `batchSize: 1`).
 
 Two transform factories are built in:
 
-- `withVocabularies(vocabularies?)` – passes through all quads and appends `void:vocabulary` triples for detected vocabulary namespace prefixes in `void:property` quads. The built-in defaults are exported as `defaultVocabularies` (sourced from `@zazuko/prefixes`); `detectVocabularies()` attaches it to the `entity-properties.rq` stage.
+- `withVocabularies(vocabularies?)` – passes through all quads and appends `void:vocabulary` triples for detected vocabulary namespace prefixes in `void:property` quads. The built-in defaults are exported as `defaultVocabularies` (sourced from `@zazuko/prefixes`); `detectVocabularies()` attaches it to the `entity-properties.rq` stage. The transform remembers which vocabularies it already emitted per distribution instance, so per-property batches yield each `void:vocabulary` quad once per stage run – reuse one transform instance within a run, and expect a fresh distribution (e.g. a fallback re-run) to start clean.
 - `withUriSpaces(uriSpaceMap)` – consumes `void:Linkset` quads, matches each `void:objectsTarget` against the configured URI space prefixes using `startsWith`, and aggregates triple counts per matched space. Emits `void:objectsTarget` pointing to the target dataset IRI (taken from the metadata quad subjects), not the raw prefix; unmatched linksets are discarded. `uriSpaces(uriSpaceMap)` attaches it to the `object-uri-space.rq` stage.
 
 ### Attaching your own transform

--- a/packages/pipeline-void/src/stage.ts
+++ b/packages/pipeline-void/src/stage.ts
@@ -81,11 +81,13 @@ export interface VoidStageOptions {
 /**
  * Options for per-class VoID stages that iterate over classes.
  *
- * `batchSize` and `maxConcurrency` control how class bindings are batched
- * and processed concurrently – they have no effect on global (non-per-class) stages.
+ * `batchSize` and `maxConcurrency` control how item bindings are batched and
+ * processed concurrently. They apply to every iterating stage – the five
+ * per-class stages and (via {@link VoidStagesOptions}) the per-property
+ * vocabularies stage – and have no effect on global one-query stages.
  */
 export interface PerClassVoidStageOptions extends VoidStageOptions {
-  /** Maximum number of class bindings per reader call. @default 10 */
+  /** Maximum number of item bindings per reader call. @default 10 */
   batchSize?: number;
   /** Maximum concurrent in-flight reader batches. @default 10 */
   maxConcurrency?: number;
@@ -166,11 +168,23 @@ function asTransforms(
   return Array.isArray(transform) ? [...transform] : [transform];
 }
 
-function classSelector(): ItemSelector {
+/**
+ * Build an {@link ItemSelector} that pages through the distinct bindings of
+ * one variable.
+ *
+ * The `ORDER BY` is load-bearing: the inner {@link SparqlItemSelector} pages
+ * with `LIMIT`/`OFFSET` (the query’s `LIMIT` is the page size), and SPARQL
+ * guarantees no result order without `ORDER BY` – unordered pages can skip or
+ * repeat items on endpoints with unstable ordering.
+ */
+function distinctItemSelector(
+  variable: string,
+  pattern: (subjectFilter: string) => string,
+): ItemSelector {
   return {
     // Forward `options` so the Pipeline’s per-dataset TimeoutPolicy
     // reaches the inner SparqlItemSelector – without this the adaptive
-    // budget is silently bypassed for class selection.
+    // budget is silently bypassed for item selection.
     select: (distribution, batchSize, options) => {
       const subjectFilter = distribution.subjectFilter ?? '';
       let fromClause = '';
@@ -178,13 +192,11 @@ function classSelector(): ItemSelector {
         assertSafeIri(distribution.namedGraph);
         fromClause = `FROM <${distribution.namedGraph}>`;
       }
-      // Exclude blank-node classes at the endpoint: the selector would drop
-      // them client-side anyway (no stable identity), but only after fetching
-      // them.
       const selectorQuery = [
-        'SELECT DISTINCT ?class',
+        `SELECT DISTINCT ?${variable}`,
         fromClause,
-        `WHERE { ${subjectFilter} ?s a ?class . FILTER(!isBlank(?class)) }`,
+        `WHERE { ${pattern(subjectFilter)} }`,
+        `ORDER BY ?${variable}`,
         'LIMIT 1000',
       ].join('\n');
 
@@ -193,6 +205,17 @@ function classSelector(): ItemSelector {
       }).select(distribution, batchSize, options);
     },
   };
+}
+
+function classSelector(): ItemSelector {
+  // Exclude blank-node classes at the endpoint: the selector would drop
+  // them client-side anyway (no stable identity), but only after fetching
+  // them.
+  return distinctItemSelector(
+    'class',
+    (subjectFilter) =>
+      `${subjectFilter} ?s a ?class . FILTER(!isBlank(?class))`,
+  );
 }
 
 /**
@@ -209,28 +232,10 @@ function classSelector(): ItemSelector {
  * working set is bounded by one batch’s triples regardless of dataset size.
  */
 function propertySelector(): ItemSelector {
-  return {
-    // Forward `options` so the Pipeline’s per-dataset TimeoutPolicy
-    // reaches the inner SparqlItemSelector – see classSelector.
-    select: (distribution, batchSize, options) => {
-      const subjectFilter = distribution.subjectFilter ?? '';
-      let fromClause = '';
-      if (distribution.namedGraph) {
-        assertSafeIri(distribution.namedGraph);
-        fromClause = `FROM <${distribution.namedGraph}>`;
-      }
-      const selectorQuery = [
-        'SELECT DISTINCT ?p',
-        fromClause,
-        `WHERE { ${subjectFilter} ?s ?p ?o . }`,
-        'LIMIT 1000',
-      ].join('\n');
-
-      return new SparqlItemSelector({
-        query: selectorQuery,
-      }).select(distribution, batchSize, options);
-    },
-  };
+  return distinctItemSelector(
+    'p',
+    (subjectFilter) => `${subjectFilter} ?s ?p ?o .`,
+  );
 }
 
 // Global stages
@@ -357,13 +362,12 @@ export function uriSpaces(
   });
 }
 
-export interface DetectVocabulariesOptions extends VoidStageOptions {
+export interface DetectVocabulariesOptions extends Omit<
+  PerClassVoidStageOptions,
+  'perClass'
+> {
   /** Additional vocabulary namespace URIs to detect beyond the built-in defaults. */
   vocabularies?: readonly string[];
-  /** Maximum number of property bindings per reader call. @default 10 */
-  batchSize?: number;
-  /** Maximum concurrent in-flight reader batches. @default 10 */
-  maxConcurrency?: number;
   /**
    * When true, iterate the property-partition query per property using a
    * property selector, so its memory use is bounded by the batch instead of

--- a/packages/pipeline-void/src/stage.ts
+++ b/packages/pipeline-void/src/stage.ts
@@ -57,8 +57,7 @@ export type VoidStageName =
 
 /** A transform, or transforms, decorating a VoID stage's reader output. */
 export type VoidStageTransform =
-  | QuadTransform<ReaderContext>
-  | QuadTransform<ReaderContext>[];
+  QuadTransform<ReaderContext> | QuadTransform<ReaderContext>[];
 
 /**
  * Options for configuring VoID stage execution.
@@ -110,6 +109,12 @@ export interface VoidStagesOptions extends Omit<
   /** Additional vocabulary namespace URIs to detect beyond the built-in defaults. */
   vocabularies?: readonly string[];
   /**
+   * When true, iterate the vocabularies (property-partition) stage per
+   * property (see {@link DetectVocabulariesOptions.perProperty}).
+   * @default true
+   */
+  perProperty?: boolean;
+  /**
    * Transforms to attach to bundled stages, keyed by {@link VOID_STAGE_NAMES}.
    *
    * Each transform decorates the reader of the named stage – so a consumer
@@ -125,6 +130,7 @@ async function createVoidStage(
   options?: {
     transform?: VoidStageTransform;
     perClass?: boolean;
+    perProperty?: boolean;
     batchSize?: number;
     maxConcurrency?: number;
     expectsOutput?: boolean;
@@ -141,7 +147,11 @@ async function createVoidStage(
   return new Stage({
     name: filename,
     readers: reader,
-    itemSelector: options?.perClass ? classSelector() : undefined,
+    itemSelector: options?.perClass
+      ? classSelector()
+      : options?.perProperty
+        ? propertySelector()
+        : undefined,
     batchSize: options?.batchSize,
     maxConcurrency: options?.maxConcurrency,
     expectsOutput: options?.expectsOutput,
@@ -175,6 +185,44 @@ function classSelector(): ItemSelector {
         'SELECT DISTINCT ?class',
         fromClause,
         `WHERE { ${subjectFilter} ?s a ?class . FILTER(!isBlank(?class)) }`,
+        'LIMIT 1000',
+      ].join('\n');
+
+      return new SparqlItemSelector({
+        query: selectorQuery,
+      }).select(distribution, batchSize, options);
+    },
+  };
+}
+
+/**
+ * Select the distinct properties of a dataset, so the property-partition
+ * query can iterate in bounded batches instead of aggregating every property
+ * at once.
+ *
+ * The chunking exists for memory, not style: the unchunked
+ * `entity-properties.rq` computes two `COUNT(DISTINCT …)` aggregates grouped
+ * over every property in one query, which materializes the dataset’s full
+ * scan – measured to exhaust a 16 GB query budget on a 608M-triple dataset,
+ * so large datasets got no property partitions (and, downstream, no
+ * `void:vocabulary`) at all. With a property batch injected as `VALUES`, the
+ * working set is bounded by one batch’s triples regardless of dataset size.
+ */
+function propertySelector(): ItemSelector {
+  return {
+    // Forward `options` so the Pipeline’s per-dataset TimeoutPolicy
+    // reaches the inner SparqlItemSelector – see classSelector.
+    select: (distribution, batchSize, options) => {
+      const subjectFilter = distribution.subjectFilter ?? '';
+      let fromClause = '';
+      if (distribution.namedGraph) {
+        assertSafeIri(distribution.namedGraph);
+        fromClause = `FROM <${distribution.namedGraph}>`;
+      }
+      const selectorQuery = [
+        'SELECT DISTINCT ?p',
+        fromClause,
+        `WHERE { ${subjectFilter} ?s ?p ?o . }`,
         'LIMIT 1000',
       ].join('\n');
 
@@ -312,17 +360,31 @@ export function uriSpaces(
 export interface DetectVocabulariesOptions extends VoidStageOptions {
   /** Additional vocabulary namespace URIs to detect beyond the built-in defaults. */
   vocabularies?: readonly string[];
+  /** Maximum number of property bindings per reader call. @default 10 */
+  batchSize?: number;
+  /** Maximum concurrent in-flight reader batches. @default 10 */
+  maxConcurrency?: number;
+  /**
+   * When true, iterate the property-partition query per property using a
+   * property selector, so its memory use is bounded by the batch instead of
+   * the whole dataset (see {@link propertySelector}). @default true
+   */
+  perProperty?: boolean;
 }
 
 export function detectVocabularies(
   options?: DetectVocabulariesOptions,
 ): Promise<Stage> {
-  const { vocabularies, transform } = options ?? {};
+  const { vocabularies, transform, batchSize, maxConcurrency, perProperty } =
+    options ?? {};
   const allVocabularies = vocabularies
     ? [...defaultVocabularies, ...vocabularies]
     : undefined;
   return createVoidStage(VOID_STAGE_NAMES.vocabularies, {
     transform: [withVocabularies(allVocabularies), ...asTransforms(transform)],
+    perProperty: perProperty ?? true,
+    batchSize,
+    maxConcurrency,
   });
 }
 
@@ -341,6 +403,10 @@ export async function voidStages(
     uriSpaces: uriSpaceMap,
     vocabularies,
     transforms,
+    // Destructured out of stageOptions so it cannot leak into the global
+    // stages’ createVoidStage options – it applies to the vocabularies stage
+    // only.
+    perProperty,
     ...stageOptions
   } = options ?? {};
 
@@ -378,6 +444,7 @@ export async function voidStages(
     detectVocabularies({
       ...withTransform(VOID_STAGE_NAMES.vocabularies),
       vocabularies,
+      perProperty,
     }),
     subjectUriSpaces(withTransform(VOID_STAGE_NAMES.subjectUriSpace)),
     ...(uriSpaceMap

--- a/packages/pipeline-void/src/vocabularyTransform.ts
+++ b/packages/pipeline-void/src/vocabularyTransform.ts
@@ -1,4 +1,5 @@
 import type { ReaderContext, QuadTransform } from '@lde/pipeline';
+import type { Distribution } from '@lde/dataset';
 import type { Quad } from '@rdfjs/types';
 import prefixes from '@zazuko/prefixes';
 import { DataFactory } from 'n3';
@@ -22,18 +23,37 @@ export const defaultVocabularies: readonly string[] = [
  * Attach it to the `entity-properties.rq` stage's reader – directly via
  * {@link detectVocabularies} or through the `transforms` map of
  * {@link voidStages}.
+ *
+ * With per-property iteration the transform sees one batch at a time, so it
+ * remembers which vocabularies it already emitted per {@link Distribution}
+ * and yields each `void:vocabulary` quad only once per stage run. The memory
+ * is keyed weakly on the distribution instance – one per run – so a fallback
+ * re-run of the same dataset (a fresh distribution) starts clean.
  */
 export function withVocabularies(
   vocabularies: readonly string[] = defaultVocabularies,
 ): QuadTransform<ReaderContext> {
-  return (quads, { dataset }) =>
-    appendVocabularies(quads, dataset.iri.toString(), vocabularies);
+  const emittedPerRun = new WeakMap<Distribution, Set<string>>();
+  return (quads, { dataset, distribution }) => {
+    let emitted = emittedPerRun.get(distribution);
+    if (!emitted) {
+      emitted = new Set();
+      emittedPerRun.set(distribution, emitted);
+    }
+    return appendVocabularies(
+      quads,
+      dataset.iri.toString(),
+      vocabularies,
+      emitted,
+    );
+  };
 }
 
 async function* appendVocabularies(
   quads: AsyncIterable<Quad>,
   datasetIri: string,
   vocabularies: readonly string[],
+  emitted: Set<string>,
 ): AsyncIterable<Quad> {
   const detectedVocabularies = new Set<string>();
 
@@ -53,6 +73,10 @@ async function* appendVocabularies(
 
   const datasetNode = namedNode(datasetIri);
   for (const vocabUri of detectedVocabularies) {
+    if (emitted.has(vocabUri)) {
+      continue;
+    }
+    emitted.add(vocabUri);
     yield quad(datasetNode, _void.vocabulary, namedNode(vocabUri));
   }
 }

--- a/packages/pipeline-void/test/perPropertyPartitions.integration.test.ts
+++ b/packages/pipeline-void/test/perPropertyPartitions.integration.test.ts
@@ -1,0 +1,153 @@
+import { detectVocabularies, Stage } from '../src/index.js';
+import { Dataset, Distribution } from '@lde/dataset';
+import type { DatasetWriter } from '@lde/pipeline';
+import {
+  startSparqlEndpoint,
+  teardownSparqlEndpoint,
+} from '@lde/local-sparql-endpoint';
+import type { Quad } from '@rdfjs/types';
+import { fetch as undiciFetch, setGlobalDispatcher, Agent } from 'undici';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+// Pin fetch + dispatcher to one undici copy – see
+// namespaceNormalization.integration.test.ts for the rationale.
+setGlobalDispatcher(new Agent());
+globalThis.fetch = undiciFetch as unknown as typeof globalThis.fetch;
+
+const fixture = fileURLToPath(
+  new URL('./fixtures/mixedNamespaces.ttl', import.meta.url),
+);
+
+const VOID = 'http://rdfs.org/ns/void#';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+const dataset = new Dataset({
+  iri: new URL('http://example.org/dataset'),
+  distributions: [],
+});
+
+function collectingWriter(): DatasetWriter & { quads: Quad[] } {
+  const quads: Quad[] = [];
+  return {
+    quads,
+    async write(_dataset, data) {
+      for await (const q of data) quads.push(q);
+    },
+  };
+}
+
+async function runStage(
+  stage: Stage,
+  distribution: Distribution,
+): Promise<Quad[]> {
+  const writer = collectingWriter();
+  await stage.run(dataset, distribution, writer);
+  return writer.quads;
+}
+
+/** The partition node for a property, from the stage output. */
+function partitionOf(quads: Quad[], property: string): string {
+  const partition = quads.find(
+    (q) =>
+      q.predicate.value === `${VOID}property` && q.object.value === property,
+  );
+  expect(partition, `partition for ${property}`).toBeDefined();
+  return partition!.subject.value;
+}
+
+function objectsOf(quads: Quad[], subject: string, predicate: string) {
+  return quads
+    .filter(
+      (q) => q.subject.value === subject && q.predicate.value === predicate,
+    )
+    .map((q) => q.object.value);
+}
+
+/** Canonical quad strings, deduplicated – chunked runs may repeat quads. */
+function canonical(quads: Quad[]): Set<string> {
+  return new Set(
+    quads.map(
+      (q) => `${q.subject.value} ${q.predicate.value} ${q.object.value}`,
+    ),
+  );
+}
+
+describe('per-property partition chunking (end to end)', () => {
+  const port = 3007;
+  const distribution = Distribution.sparql(
+    new URL(`http://localhost:${port}/sparql`),
+  );
+
+  beforeAll(async () => {
+    await startSparqlEndpoint(port, fixture);
+  }, 60_000);
+
+  afterAll(async () => {
+    await teardownSparqlEndpoint();
+  }, 30_000);
+
+  it('emits the same output chunked (batchSize 1) as unchunked', async () => {
+    const chunked = await runStage(
+      await detectVocabularies({ batchSize: 1 }),
+      distribution,
+    );
+    const unchunked = await runStage(
+      await detectVocabularies({ perProperty: false }),
+      distribution,
+    );
+
+    expect(canonical(chunked)).toEqual(canonical(unchunked));
+  }, 30_000);
+
+  it('counts entities and distinctObjects per property', async () => {
+    const out = await runStage(
+      await detectVocabularies({ batchSize: 1 }),
+      distribution,
+    );
+
+    // rdf:type: work1–4 + person1 → 5 subjects; 3 distinct class objects.
+    const typePartition = partitionOf(out, RDF_TYPE);
+    expect(objectsOf(out, typePartition, `${VOID}entities`)).toEqual(['5']);
+    expect(objectsOf(out, typePartition, `${VOID}distinctObjects`)).toEqual([
+      '3',
+    ]);
+
+    // http-namespace name: work1 ("A"), work2 ("Shared") → 2 subjects, 2 objects.
+    const namePartition = partitionOf(out, 'http://schema.org/name');
+    expect(objectsOf(out, namePartition, `${VOID}entities`)).toEqual(['2']);
+    expect(objectsOf(out, namePartition, `${VOID}distinctObjects`)).toEqual([
+      '2',
+    ]);
+  }, 30_000);
+
+  it('scopes property selection to the distribution’s named graph', async () => {
+    // The fixture loads into the default graph, so a named-graph-scoped
+    // distribution selects no properties and yields no partitions.
+    const namedGraphDistribution = Distribution.sparql(
+      new URL(`http://localhost:${port}/sparql`),
+      'http://example.org/other-graph',
+    );
+
+    const out = await runStage(
+      await detectVocabularies({ batchSize: 1 }),
+      namedGraphDistribution,
+    );
+
+    expect(
+      out.filter((q) => q.predicate.value === `${VOID}property`),
+    ).toHaveLength(0);
+  }, 30_000);
+
+  it('detects vocabularies across property batches', async () => {
+    const out = await runStage(
+      await detectVocabularies({ batchSize: 1 }),
+      distribution,
+    );
+
+    const vocabularies = out
+      .filter((q) => q.predicate.value === `${VOID}vocabulary`)
+      .map((q) => q.object.value);
+    expect(vocabularies).toContain('http://schema.org/');
+  }, 30_000);
+});

--- a/packages/pipeline-void/test/perPropertyPartitions.integration.test.ts
+++ b/packages/pipeline-void/test/perPropertyPartitions.integration.test.ts
@@ -74,7 +74,9 @@ function canonical(quads: Quad[]): Set<string> {
 }
 
 describe('per-property partition chunking (end to end)', () => {
-  const port = 3007;
+  // Unique across the repo's integration suites – nx runs packages' tests
+  // concurrently, so a shared port is a flaky EADDRINUSE.
+  const port = 3011;
   const distribution = Distribution.sparql(
     new URL(`http://localhost:${port}/sparql`),
   );
@@ -149,5 +151,9 @@ describe('per-property partition chunking (end to end)', () => {
       .filter((q) => q.predicate.value === `${VOID}vocabulary`)
       .map((q) => q.object.value);
     expect(vocabularies).toContain('http://schema.org/');
+
+    // Emitted once per vocabulary, not once per property batch that
+    // matches it – both schema.org name variants map to their namespace.
+    expect(new Set(vocabularies).size).toBe(vocabularies.length);
   }, 30_000);
 });

--- a/packages/pipeline-void/test/vocabularyTransform.test.ts
+++ b/packages/pipeline-void/test/vocabularyTransform.test.ts
@@ -1,7 +1,7 @@
 import { withVocabularies } from '../src/index.js';
 import { Dataset, Distribution } from '@lde/dataset';
 import type { ReaderContext } from '@lde/pipeline';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { DataFactory } from 'n3';
 import type { Quad } from '@rdfjs/types';
 
@@ -36,7 +36,13 @@ async function collect(stream: AsyncIterable<Quad>): Promise<Quad[]> {
 }
 
 describe('withVocabularies', () => {
-  const transform = withVocabularies();
+  // Fresh per test: the transform now remembers emitted vocabularies per
+  // distribution across batches, so a shared instance would leak state
+  // between tests.
+  let transform: ReturnType<typeof withVocabularies>;
+  beforeEach(() => {
+    transform = withVocabularies();
+  });
 
   it('passes through all input quads', async () => {
     const input = quad(

--- a/packages/pipeline-void/vite.config.ts
+++ b/packages/pipeline-void/vite.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           functions: 100,
-          lines: 98.64,
+          lines: 99.11,
           branches: 95.23,
-          statements: 98.69,
+          statements: 99.14,
         },
       },
     },

--- a/packages/pipeline-void/vite.config.ts
+++ b/packages/pipeline-void/vite.config.ts
@@ -11,9 +11,9 @@ export default mergeConfig(
       coverage: {
         thresholds: {
           functions: 100,
-          lines: 98.59,
-          branches: 94.91,
-          statements: 98.64,
+          lines: 98.64,
+          branches: 95.23,
+          statements: 98.69,
         },
       },
     },


### PR DESCRIPTION
`entity-properties.rq` computes `COUNT(DISTINCT ?s)` and `COUNT(DISTINCT ?o)` grouped over *every* property in a single query. On large datasets that materializes the full scan: measured on RKD’s 608M-triple dump (dataset-knowledge-graph), the query exhausts a 12 GB *and* a 16 GB QLever `memory-max-size` budget (‘Tried to allocate 24 B, but only 0 B were available’), so the dataset ends up with no property partitions and – because vocabulary detection derives from the `void:property` output – no `void:vocabulary` either. Raising memory further is not an option: the need scales linearly with dataset size, and the 86 per-class stages on the same dataset all pass because they are already chunked.

This applies the existing per-class chunking pattern to the property-partition stage:

- **`propertySelector()`** shares a `distinctItemSelector` helper with `classSelector()`: a cheap `SELECT DISTINCT` (now with `ORDER BY`, so `LIMIT`/`OFFSET` pagination is stable) feeds batches that the reader injects as a `VALUES` block into the innermost subquery, bounding the working set by batch instead of dataset.
- **`detectVocabularies`** defaults to per-property iteration (`perProperty: true`), reusing the per-class `batchSize`/`maxConcurrency` knobs; `perProperty: false` restores the single global query.
- **`withVocabularies`** now remembers which vocabularies it emitted per distribution instance, so per-property batches yield each `void:vocabulary` quad exactly once per stage run.
- The query file itself is unchanged – it dates from the original pipeline-void port (#48), before the per-class chunking machinery (#235/#236) existed; it was never deliberately kept global.

## Validated against the failing dataset

Measured on the RKD Knowledge Graph index (608.3M triples, 440 distinct properties) with QLever at the production 12 GB budget:

| Query | Result |
| --- | --- |
| Old global query | ✖ out of memory (also at 16 GB) |
| Chunked, worst property (`rdf:type`, 132M triples) | ✔ 38.7 s |
| Chunked, second-heaviest (86M triples) | ✔ 24.7 s |
| Chunked, 10 mid-tier properties in one `VALUES` batch | ✔ 2.7 s |

## BREAKING CHANGE

- The vocabularies stage iterates per property by default: a consumer transform attached via `transforms[VOID_STAGE_NAMES.vocabularies]` that aggregated over the stage’s complete output now sees per-batch windows (like the per-class stages). Pass `perProperty: false` for the old single-query behavior.
- `withVocabularies` is stateful per distribution instance: applying one transform instance to multiple streams for the same distribution emits each `void:vocabulary` quad only once.
- The shared `voidStages` `batchSize`/`maxConcurrency` now also apply to the vocabularies stage.

Known follow-up (pre-existing for per-class stages, now also relevant here): `SparqlItemSelector` requests have no retry, unlike the reader’s `pRetry` – a transient 5xx on a selector page fails the stage.

The integration test runs the stage chunked (`batchSize: 1`) and unchunked against a local SPARQL endpoint and asserts identical deduplicated output, correct per-property `void:entities`/`void:distinctObjects`, named-graph scoping of the selector, and single-emission vocabulary detection across batches.
