### PR TITLE
feat(search-api-graphql)!: group result pagination into a shared Pagination type

### DIFF
--- a/docs/decisions/0004-search-api-graphql-surface.md
+++ b/docs/decisions/0004-search-api-graphql-surface.md
@@ -220,11 +220,15 @@ type DatasetFacets {
   size: [RangeBucket!]!
 }
 
-type DatasetSearchResult {
-  items: [Dataset!]!
+type Pagination {
+  # shared across every ‹Type›SearchResult, so one client pager fragment serves all root types
   total: Int!
   page: Int!
   perPage: Int!
+}
+type DatasetSearchResult {
+  items: [Dataset!]!
+  pagination: Pagination!
   facets: DatasetFacets!
 }
 
@@ -239,8 +243,11 @@ type Query {
 }
 ```
 
-Numbered pagination (`page`/`perPage` + `total`), per
-[ADR 3](./0003-search-api-core-query-model.md) – no Relay connection. The reference types
+Numbered pagination (`page`/`perPage` args; applied values + `total` grouped
+in the shared `Pagination` result type), per
+[ADR 3](./0003-search-api-core-query-model.md) – no Relay connection. The
+arguments stay flat: GraphQL has no input fragments, so a `pagination` input
+object would group without the reuse payoff the output grouping buys. The reference types
 carry `id + name` (labelOnly) from DR’s sidecar labels collection, resolved by the adapter.
 `publisher` is single (`dct:publisher` `maxCount 1`); `creator` is search-only (its name feeds
 full-text `query` but it has no output field); `catalog` is filter-only (in `where`, not output);

--- a/docs/guide/build-a-search-api.md
+++ b/docs/guide/build-a-search-api.md
@@ -105,7 +105,7 @@ Open the playground at `http://localhost:4000/graphql`, or query directly. Each 
 ```sh
 curl -s http://localhost:4000/graphql \
   -H 'Content-Type: application/json' \
-  -d '{"query": "{ datasets(query: \"map\") { total items { id title { language value } } } }"}'
+  -d '{"query": "{ datasets(query: \"map\") { pagination { total } items { id title { language value } } } }"}'
 ```
 
 Try a typo – `"musem"` still finds your museums – and note the ranking: title matches come first, thanks to the field weights. `GET /graphql?sdl` returns the schema as SDL; `GET /health` reports liveness.
@@ -115,7 +115,7 @@ The `keyword` field was declared `facetable`, so the result also carries facets.
 ```sh
 curl -s http://localhost:4000/graphql \
   -H 'Content-Type: application/json' \
-  -d '{"query": "{ datasets(query: \"map\") { total facets { keyword { value count } } } }"}'
+  -d '{"query": "{ datasets(query: \"map\") { pagination { total } facets { keyword { value count } } } }"}'
 ```
 
 Feed the buckets to filter checkboxes and pass the chosen values back as `where: { keyword: { in: ["maps"] } }`; a facet’s own filter is skipped when computing its buckets, so the other options stay visible.

--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -178,8 +178,11 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
   dispatched as one `engine.searchFacets` call, so a typical page costs the
   listing search plus one batched facet round-trip.
 
-- **Result envelope**: `items` plus `total` (the full match count), `page`
-  and `perPage` (the pagination actually applied, after `queryDefaults`).
+- **Result envelope**: `items` plus `pagination` – `total` (the full match
+  count), `page` and `perPage` (the pagination actually applied, after
+  `queryDefaults`). `Pagination` is one shared type across every
+  `‹Type›SearchResult`, so a client pager fragment on it serves all root
+  types.
 
 **Output language order**: localized values flatten to a best-first
 `[LanguageString!]!` – by default the requested `Accept-Language` languages

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -167,6 +167,16 @@ export function buildGraphQLSchema(
       count: { type: new GraphQLNonNull(GraphQLInt) },
     },
   });
+  // The pagination actually applied (after queryDefaults), shared across every
+  // ‹Type›SearchResult so one client pager fragment serves all root types.
+  const paginationType = new GraphQLObjectType({
+    name: 'Pagination',
+    fields: {
+      total: { type: new GraphQLNonNull(GraphQLInt) },
+      page: { type: new GraphQLNonNull(GraphQLInt) },
+      perPage: { type: new GraphQLNonNull(GraphQLInt) },
+    },
+  });
   const sortDirection = new GraphQLEnumType({
     name: 'SortDirection',
     values: { ASC: { value: 'asc' }, DESC: { value: 'desc' } },
@@ -384,9 +394,7 @@ export function buildGraphQLSchema(
       name: `${typeName}SearchResult`,
       fields: {
         items: { type: nonNullListOf(outputType) },
-        total: { type: new GraphQLNonNull(GraphQLInt) },
-        page: { type: new GraphQLNonNull(GraphQLInt) },
-        perPage: { type: new GraphQLNonNull(GraphQLInt) },
+        pagination: { type: new GraphQLNonNull(paginationType) },
         // Resolved lazily, per selected key (skip-own-filter); the result object
         // (which carries the per-request facet loader) is the facets source.
         ...(facetsType && {
@@ -424,9 +432,11 @@ export function buildGraphQLSchema(
         });
         return {
           items: result.hits.map((hit) => ({ id: hit.id, ...hit.document })),
-          total: result.total,
-          page: pageForOffset(finalQuery.offset, finalQuery.limit),
-          perPage: finalQuery.limit,
+          pagination: {
+            total: result.total,
+            page: pageForOffset(finalQuery.offset, finalQuery.limit),
+            perPage: finalQuery.limit,
+          },
           // Carried for the facet field resolvers (see facet-batch.ts).
           loadFacet: createFacetLoader(
             context.engine,

--- a/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
+++ b/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
@@ -7,9 +7,7 @@ exports[`GraphQL generator stability > emits a stable SDL for a representative s
 
 type ThingSearchResult {
   items: [Thing!]!
-  total: Int!
-  page: Int!
-  perPage: Int!
+  pagination: Pagination!
   facets: ThingFacets!
 }
 
@@ -35,6 +33,12 @@ type LanguageString {
 type Agent {
   id: String!
   name: [LanguageString!]!
+}
+
+type Pagination {
+  total: Int!
+  page: Int!
+  perPage: Int!
 }
 
 type ThingFacets {

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -159,9 +159,11 @@ describe('buildGraphQLSchema', () => {
     const result = await run(
       `{
         datasets(query: "kaart") {
-          total
-          page
-          perPage
+          pagination {
+            total
+            page
+            perPage
+          }
           items {
             id
             title { language value }
@@ -182,8 +184,7 @@ describe('buildGraphQLSchema', () => {
 
     expect(result.errors).toBeUndefined();
     const data = result.data?.datasets as Record<string, unknown>;
-    expect(data.total).toBe(1);
-    expect(data.page).toBe(1);
+    expect(data.pagination).toEqual({ total: 1, page: 1, perPage: 20 });
     const item = (data.items as Record<string, unknown>[])[0];
     expect(item.id).toBe('https://d/1');
     expect(item.title).toEqual([
@@ -212,10 +213,13 @@ describe('buildGraphQLSchema', () => {
   it('rejects out-of-bounds paging before it reaches the engine', async () => {
     const { engine } = fakeEngine(canned);
     const context = { engine, acceptLanguage: ['nl'] };
-    const badPage = await run(`{ datasets(page: 0) { total } }`, context);
+    const badPage = await run(
+      `{ datasets(page: 0) { pagination { total } } }`,
+      context,
+    );
     expect(badPage.errors?.[0]?.message).toMatch(/page must be at least 1/);
     const badPerPage = await run(
-      `{ datasets(perPage: 101) { total } }`,
+      `{ datasets(perPage: 101) { pagination { total } } }`,
       context,
     );
     expect(badPerPage.errors?.[0]?.message).toMatch(
@@ -456,7 +460,7 @@ describe('buildGraphQLSchema', () => {
     };
     const result = await run(
       `{ datasets {
-        total
+        pagination { total }
         items { id }
         facets { keyword { value count } status { value count } }
       } }`,
@@ -471,7 +475,7 @@ describe('buildGraphQLSchema', () => {
     // non-null result and discarding the items.
     expect(result.errors).toBeUndefined();
     const data = result.data?.datasets as Record<string, unknown>;
-    expect(data.total).toBe(1);
+    expect((data.pagination as Record<string, unknown>).total).toBe(1);
     expect((data.items as Record<string, unknown>[])[0].id).toBe('https://d/1');
     // Every facet in the failed batch degraded to an empty list, and the
     // cause was reported once per selected field.
@@ -482,13 +486,16 @@ describe('buildGraphQLSchema', () => {
 
   it('guards perPage: 0, resolving page to 1 rather than failing on NaN', async () => {
     const { engine } = fakeEngine(canned);
-    const result = await run(`{ datasets(perPage: 0) { page total } }`, {
-      engine,
-      acceptLanguage: ['nl'],
-    });
+    const result = await run(
+      `{ datasets(perPage: 0) { pagination { page total } } }`,
+      {
+        engine,
+        acceptLanguage: ['nl'],
+      },
+    );
     expect(result.errors).toBeUndefined();
     const data = result.data?.datasets as Record<string, unknown>;
-    expect(data.page).toBe(1);
+    expect((data.pagination as Record<string, unknown>).page).toBe(1);
   });
 
   it('maps where, orderBy and pagination into the SearchQuery', async () => {
@@ -500,7 +507,7 @@ describe('buildGraphQLSchema', () => {
           orderBy: { field: SIZE, direction: ASC }
           page: 3
           perPage: 10
-        ) { total }
+        ) { pagination { total } }
       }`,
       { engine, acceptLanguage: ['nl'] },
     );
@@ -524,7 +531,10 @@ describe('buildGraphQLSchema', () => {
 
   it('falls back to the und locale when no Accept-Language is given', async () => {
     const { engine, received } = fakeEngine(canned);
-    await run(`{ datasets { total } }`, { engine, acceptLanguage: [] });
+    await run(`{ datasets { pagination { total } } }`, {
+      engine,
+      acceptLanguage: [],
+    });
     expect(received().locale).toBe('und');
   });
 
@@ -551,7 +561,7 @@ describe('buildGraphQLSchema', () => {
     });
     await graphql({
       schema: gqlSchema,
-      source: `{ datasets { total } }`,
+      source: `{ datasets { pagination { total } } }`,
       contextValue: { engine, acceptLanguage: ['nl'] },
     });
     expect(captured?.where).toEqual([{ field: 'status', in: ['valid'] }]);
@@ -653,6 +663,10 @@ describe('buildGraphQLSchema', () => {
       expect(sdl).not.toMatch(/PersonWhere/);
       // The shared reference shape is emitted once, reused by both types.
       expect(sdl.match(/^type Agent /gm)).toHaveLength(1);
+      // One shared Pagination type across every ‹Type›SearchResult, so a
+      // client pager fragment on Pagination serves all root types.
+      expect(sdl.match(/^type Pagination /gm)).toHaveLength(1);
+      expect(sdl.match(/pagination: Pagination!/g)).toHaveLength(2);
     });
 
     it('routes each root field through the schema-bound engine', async () => {
@@ -667,7 +681,7 @@ describe('buildGraphQLSchema', () => {
       };
       const result = await graphql({
         schema: twoTypeSchema,
-        source: `{ people { total } creativeWorks { total } }`,
+        source: `{ people { pagination { total } } creativeWorks { pagination { total } } }`,
         contextValue: { engine, acceptLanguage: ['nl'] },
       });
       expect(result.errors).toBeUndefined();

--- a/packages/search-api-graphql/test/handler.test.ts
+++ b/packages/search-api-graphql/test/handler.test.ts
@@ -92,13 +92,13 @@ describe('createSearchGraphQLHandler', () => {
 
     const response = await post(
       handler,
-      '{ datasets(query: "kaart") { total items { id keyword } } }',
+      '{ datasets(query: "kaart") { pagination { total } items { id keyword } } }',
     );
     expect(response.status).toBe(200);
     const { data, errors } = await response.json();
 
     expect(errors).toBeUndefined();
-    expect(data.datasets.total).toBe(1);
+    expect(data.datasets.pagination.total).toBe(1);
     expect(data.datasets.items[0].id).toBe('https://d/1');
     expect(received().text).toBe('kaart');
   });
@@ -213,7 +213,10 @@ describe('createSearchGraphQLHandler', () => {
       maxDepth: 1,
     });
 
-    const response = await post(handler, '{ datasets { total } }');
+    const response = await post(
+      handler,
+      '{ datasets { pagination { total } } }',
+    );
     const { data, errors } = await response.json();
 
     expect(data).toBeUndefined();
@@ -230,7 +233,7 @@ describe('createSearchGraphQLHandler', () => {
 
     const response = await post(
       handler,
-      '{ datasets { total items { id keyword } } }',
+      '{ datasets { pagination { total } items { id keyword } } }',
     );
     const { data, errors } = await response.json();
 
@@ -261,12 +264,15 @@ describe('createSearchGraphQLHandler', () => {
     merged.getQueryType()!.getFields().hello.resolve = () => 'world';
     const handler = createSearchGraphQLHandler({ schema: merged, engine });
 
-    const response = await post(handler, '{ hello datasets { total } }');
+    const response = await post(
+      handler,
+      '{ hello datasets { pagination { total } } }',
+    );
     const { data, errors } = await response.json();
 
     expect(errors).toBeUndefined();
     expect(data.hello).toBe('world');
-    expect(data.datasets.total).toBe(1);
+    expect(data.datasets.pagination.total).toBe(1);
   });
 
   it('requires exactly one of searchSchema and schema', () => {


### PR DESCRIPTION
Groups the search result envelope’s pagination fields into a single shared `Pagination` type. Every `‹Type›SearchResult` now serves `items` / `pagination` / `facets`:

```graphql
type Pagination {
  total: Int!
  page: Int!
  perPage: Int!
}
```

## Why

- **Fragment reuse**: `total`/`page`/`perPage` were stamped into every per-type result type, so a client pager could not share one fragment across root types. With one shared type, `fragment Pager on Pagination { total page perPage }` serves them all.
- **Extensibility**: derived conveniences (`totalPages`, `hasNextPage`) get an obvious home later, instead of piling onto the result root next to `items` and `facets`.

The request arguments deliberately stay flat (`page`, `perPage`): GraphQL has no input fragments, so a `pagination` input object would add nesting without the reuse payoff. A Relay-style connection was considered and rejected – Typesense is natively offset-based, so cursors could only wrap offsets without cursor-stability guarantees, and a page-numbered faceted search UI wants totals and arbitrary page jumps (see ADR 3/4).

## Changes

- `build-schema.ts`: build one shared `Pagination` object type; nest the applied pagination in the resolver result.
- Tests: queries and assertions updated; SDL stability snapshot regenerated; new assertion that `Pagination` is emitted once and referenced by every result type.
- Docs: result-envelope description in the `search-api-graphql` reference, sample queries in the build-a-search-api guide, and the ADR 4 SDL sketch (including the flat-arguments rationale).

**Breaking change** (minor bump under the zero-major scheme): clients selecting `total`, `page` or `perPage` at the result root must select `pagination { total page perPage }` instead. Known downstream: LOL’s search frontend and guide queries.
