### PR TITLE
feat(search)!: look documents up by their IRI on every type

### DIFF
--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -154,8 +154,10 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
   per kind; `date` → ISO 8601 string; nullability from `required` / `array` /
   `kind`.
 - **`where`** one input per `filterable` field (`StringFilter`, `IntRange` /
-  `FloatRange` / `DateRange`, or `Boolean`); omitted entirely for a type with no
-  filterable fields.
+  `FloatRange` / `DateRange`, or `Boolean`), plus **`id: StringFilter`** on every
+  type – the document’s IRI, declared by no type and filterable on all of them
+  ([Lookup by IRI](./search#lookup-by-iri)). So the input always exists, even for
+  a type that declares no filterable field of its own.
 - **`orderBy`**: `RELEVANCE` plus every `sortable` field, as an enum – field
   names SCREAMING_SNAKE_CASEd (`datePosted` → `DATE_POSTED`); `direction`
   defaults to `DESC`.

--- a/docs/reference/search-typesense.md
+++ b/docs/reference/search-typesense.md
@@ -118,6 +118,16 @@ facet-only queries (e.g. a faceted listing’s skip-own-filter variants) as a
 every facet result in the batch. A failed entry is reported in place as a
 per-query outcome, so its siblings’ facets survive.
 
+**Every query travels as a `multi_search` POST** – the root search included, not
+just the facet batch and the label lookup. Typesense’s per-collection search
+endpoint is a GET, so a long `filter_by` (a batch [lookup by
+IRI](./search#lookup-by-iri), or any membership over many IRIs, which URL-encode
+to several times their length) would overflow its 4000-character query-string
+limit. In the POST body the filter is bounded by the request instead. Because
+`multi_search` reports a failure as an inline entry rather than rejecting, the
+adapter translates a failed root entry back into a throw: `search()` still
+rejects on engine failure.
+
 The pure halves `buildSearchParams` and `parseSearchResponse` are exported for
 direct use and testing.
 

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -254,7 +254,7 @@ time).
 **Declarations are also validated at runtime** (for declarations built
 outside TypeScript – a SHACL generator, plain JS): `searchSchema()`
 rejects a structurally invalid declaration (duplicate or non-identifier field
-names, a locale containing `_`, an `output`
+names, a field named `id` – see [Lookup by IRI](#lookup-by-iri) –, a locale containing `_`, an `output`
 reference without `ref`, `text` without locales, `locales` on a non-text kind,
 `facetRanges` on a non-numeric kind, `searchable`/`transform` on a kind whose
 projection cannot honour it, `filterable`/`facetable` on `text`, two types
@@ -418,11 +418,46 @@ engine adapters and surfaces compile through the shared `SearchQuery` IR and the
 
 Queries are **always validated**: the port contract requires every engine
 adapter to reject a structurally invalid `SearchQuery` (`assertValidQuery`) –
-unknown or non-`filterable` fields in `where`, an operator not matching the
+unknown or non-`filterable` fields in `where` (bar `id`, filterable on every
+type – see [Lookup by IRI](#lookup-by-iri)), an operator not matching the
 field’s kind, non-`facetable` facet requests – no matter which surface or
 policy produced it. A typed surface like GraphQL makes most of these
 unrepresentable; the port enforces them for everyone else (deployment
 `queryDefaults`, in-process callers, weaker-typed surfaces).
+
+### Lookup by IRI
+
+Every type is filterable on **`id`** – the document’s IRI – without declaring
+it, and every surface returns it. It is the one field no `SearchType` declares,
+because every indexed thing already carries it: it is the hit’s identity
+(`SearchHit.id`), not a value in its `ResultDocument`. `searchSchema()` rejects
+a declared field named `id` (`reserved-field-name`) so nothing can shadow it.
+
+Membership only – an IRI has no range and no truth value – so a lookup is also a
+batch lookup:
+
+```graphql
+{
+  organizations(where: { id: { in: ["https://id.drapo.nl/ffed9f91-…"] } }) {
+    items {
+      id
+      name {
+        value
+      }
+    }
+  }
+}
+```
+
+This is what makes an IRI a usable entry point: a client holding a reference’s
+`id` (from `publisher`, `isPartOf`, `creator`, …) fetches that entity’s own
+fields from its own collection, rather than the schema having to carry them
+inline on every referring document.
+
+Keep `id` distinct from a domain identifier. `id` is _what the thing is_; a
+declared field like `identifier` (`schema:identifier`) is _what a source system
+calls it_ – an inventory or catalogue number. Both may exist on one type; they
+answer different questions.
 
 Sorting has two deliberate wrinkles. `orderBy` accepts the sentinel field
 **`relevance`** – text-match ranking, not a declared field (Typesense compiles

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -454,6 +454,21 @@ This is what makes an IRI a usable entry point: a client holding a reference’s
 fields from its own collection, rather than the schema having to carry them
 inline on every referring document.
 
+Two consequences of treating identity as its own kind of filter:
+
+- **An empty `in` on `id` matches nothing**, where an empty `in` on any other
+  field is a no-op the compilers skip. An identity filter enumerates the
+  documents wanted, so the empty set wants none; a value filter constrains a
+  dimension, so an empty set constrains nothing (a facet UI with nothing
+  selected sends exactly that). `isUnsatisfiable` reports the case, and an
+  adapter must answer it with an empty result instead of dispatching – otherwise
+  a client mapping a possibly-empty reference array into a lookup gets the whole
+  collection. Facets for such a query are empty too.
+- **The batch is bounded by the request, not by a URL.** The Typesense adapter
+  sends every query – root search, facet batch, label lookup – as a
+  `multi_search` POST, so a long `filter_by` cannot overflow the 4000-character
+  GET query-string limit that a few dozen IRIs would breach.
+
 Keep `id` distinct from a domain identifier. `id` is _what the thing is_; a
 declared field like `identifier` (`schema:identifier`) is _what a source system
 calls it_ – an inventory or catalogue number. Both may exist on one type; they

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -30,6 +30,7 @@ import {
   facetableFields,
   filterableFields,
   filterOperatorFor,
+  ID_FIELD,
   isRangeFacet,
   outputFields,
   pageForOffset,
@@ -340,23 +341,22 @@ export function buildGraphQLSchema(
       },
     });
 
-    // A GraphQL input object must have at least one field, so a type with no
-    // filterable fields gets no `where` arg at all rather than an invalid
-    // empty input.
+    // Every type is filterable on `id`, so the input always has at least one
+    // field and always exists – no type is unaddressable by IRI, whatever it
+    // declares.
     const filterable = filterableFields(searchType);
-    const whereInput =
-      filterable.length === 0
-        ? undefined
-        : new GraphQLInputObjectType({
-            name: `${typeName}Where`,
-            fields: () => {
-              const fields: Record<string, GraphQLInputFieldConfig> = {};
-              for (const field of filterable) {
-                fields[field.name] = { type: whereFieldType(field) };
-              }
-              return fields;
-            },
-          });
+    const whereInput = new GraphQLInputObjectType({
+      name: `${typeName}Where`,
+      fields: () => {
+        const fields: Record<string, GraphQLInputFieldConfig> = {
+          [ID_FIELD]: { type: stringFilter },
+        };
+        for (const field of filterable) {
+          fields[field.name] = { type: whereFieldType(field) };
+        }
+        return fields;
+      },
+    });
 
     const sortValues: GraphQLEnumValueConfigMap = {
       RELEVANCE: { value: 'relevance' },
@@ -410,7 +410,7 @@ export function buildGraphQLSchema(
       type: new GraphQLNonNull(resultType),
       args: {
         query: { type: GraphQLString },
-        ...(whereInput && { where: { type: whereInput } }),
+        where: { type: whereInput },
         orderBy: { type: orderByInput },
         page: { type: GraphQLInt, defaultValue: 1 },
         perPage: { type: GraphQLInt, defaultValue: 20 },
@@ -564,6 +564,11 @@ function whereToFilters(
     return [];
   }
   const filters: Filter[] = [];
+  // `id` first: it is declared by no type, so the field loop below never sees it.
+  const id = where[ID_FIELD] as { in?: string[] } | undefined | null;
+  if (id !== undefined && id !== null) {
+    filters.push({ field: ID_FIELD, in: id.in ?? [] });
+  }
   for (const field of filterableFields(searchType)) {
     const value = where[field.name];
     if (value === undefined || value === null) {

--- a/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
+++ b/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
@@ -56,6 +56,7 @@ type ValueBucket {
 }
 
 input ThingWhere {
+  id: StringFilter
   keyword: StringFilter
   creator: StringFilter
   publisher: StringFilter

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -529,6 +529,29 @@ describe('buildGraphQLSchema', () => {
     expect(query.offset).toBe(20);
   });
 
+  it('maps a where on the undeclared `id` into an IRI membership filter', async () => {
+    const { engine, received } = fakeEngine(canned);
+    await run(
+      `{
+        datasets(where: { id: { in: ["https://id.example.org/a", "urn:b"] } }) {
+          pagination { total }
+        }
+      }`,
+      { engine, acceptLanguage: ['nl'] },
+    );
+    expect(received().where).toEqual([
+      { field: 'id', in: ['https://id.example.org/a', 'urn:b'] },
+    ]);
+
+    // An empty StringFilter compiles to an empty membership, as for any field.
+    const empty = fakeEngine(canned);
+    await run(`{ datasets(where: { id: {} }) { pagination { total } } }`, {
+      engine: empty.engine,
+      acceptLanguage: ['nl'],
+    });
+    expect(empty.received().where).toEqual([{ field: 'id', in: [] }]);
+  });
+
   it('falls back to the und locale when no Accept-Language is given', async () => {
     const { engine, received } = fakeEngine(canned);
     await run(`{ datasets { pagination { total } } }`, {
@@ -658,9 +681,9 @@ describe('buildGraphQLSchema', () => {
       );
       expect(sdl).toMatch(/enum PersonSortField/);
       expect(sdl).toMatch(/input CreativeWorkWhere/);
-      // Person has no filterable fields, so it gets no `where` arg (an empty
-      // input object would be invalid GraphQL) – CreativeWork keeps its own.
-      expect(sdl).not.toMatch(/PersonWhere/);
+      // Person declares no filterable field, yet still gets a `where` input:
+      // `id` is filterable on every type, so no type is unaddressable by IRI.
+      expect(sdl).toMatch(/input PersonWhere \{\s*id: StringFilter\s*\}/);
       // The shared reference shape is emitted once, reused by both types.
       expect(sdl.match(/^type Agent /gm)).toHaveLength(1);
       // One shared Pagination type across every ‹Type›SearchResult, so a

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -22,7 +22,7 @@ export default mergeConfig(
           lines: 100,
           // Full-suite baseline, re-anchored when covered branches are
           // deleted (autoUpdate only ever raises; see AGENTS.md).
-          branches: 94.07,
+          branches: 94.16,
           statements: 100,
         },
       },

--- a/packages/search-typesense/src/query-compiler.ts
+++ b/packages/search-typesense/src/query-compiler.ts
@@ -12,6 +12,7 @@ import {
   fieldNamed,
   filterOperator,
   filterOperatorFor,
+  ID_FIELD,
   isoToUnixSeconds,
   isRangeFacet,
   pageForOffset,
@@ -20,14 +21,14 @@ import {
 } from '@lde/search/adapter';
 
 /**
- * Options for {@link buildSearchParams} — the query half of the engine
+ * Options for {@link buildSearchParams} – the query half of the engine
  * adapter. {@link TypesenseSearchEngineOptions} extends this, so each knob is
  * declared once and the engine forwards its options wholesale.
  */
 export interface BuildSearchParamsOptions {
   /**
    * Cap on the number of buckets returned per facet (`max_facet_values`). Left
-   * unset, Typesense defaults to 10 — too few for high-cardinality facets
+   * unset, Typesense defaults to 10 – too few for high-cardinality facets
    * (publisher, keyword), so a deployment with such facets must raise it. Range
    * facets return one bucket per declared range regardless, but a value > the
    * range count is still safe.
@@ -47,7 +48,7 @@ export interface BuildSearchParamsOptions {
 
 /**
  * Compile the engine-neutral {@link SearchQuery} into Typesense search
- * parameters — the query half of the engine adapter. Pure (no client, no env),
+ * parameters – the query half of the engine adapter. Pure (no client, no env),
  * so the mapping is asserted directly in unit tests. Field names come from
  * {@link physicalFields}, the same convention the projection and the collection
  * schema use, so a query can never reference a field the index does not carry.
@@ -186,12 +187,20 @@ function compileFilter(
   filter: Filter,
   searchType: SearchType,
 ): string | undefined {
+  // `id` is the Typesense document key, not a declared field: filter it by
+  // exact membership, the same clause `fetchLabels` uses to resolve a
+  // reference’s label from its own collection.
+  if (filter.field === ID_FIELD) {
+    return 'in' in filter && filter.in.length > 0
+      ? `${ID_FIELD}:=[${filter.in.map(escapeFilterValue).join(',')}]`
+      : undefined;
+  }
   const field = fieldNamed(searchType, filter.field);
   if (field === undefined) {
     return undefined;
   }
   // A clause whose operator does not match the field's kind (e.g. `range` on a
-  // keyword) would reach the engine as garbage syntax — skip it instead.
+  // keyword) would reach the engine as garbage syntax – skip it instead.
   if (filterOperatorFor(field.kind) !== filterOperator(filter)) {
     return undefined;
   }

--- a/packages/search-typesense/src/query-compiler.ts
+++ b/packages/search-typesense/src/query-compiler.ts
@@ -187,9 +187,11 @@ function compileFilter(
   filter: Filter,
   searchType: SearchType,
 ): string | undefined {
-  // `id` is the Typesense document key, not a declared field: filter it by
-  // exact membership, the same clause `fetchLabels` uses to resolve a
-  // reference’s label from its own collection.
+  // `id` is the Typesense document key, not a declared field. Exact `:=`
+  // membership, like a non-facet field ({@link compileMembership}), so an IRI
+  // cannot partial-match on a shared path segment. (`fetchLabels` resolves
+  // labels with the looser `id:[…]`; these are deliberately not the same
+  // clause.)
   if (filter.field === ID_FIELD) {
     return 'in' in filter && filter.in.length > 0
       ? `${ID_FIELD}:=[${filter.in.map(escapeFilterValue).join(',')}]`

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -1,4 +1,5 @@
 import type { Client } from 'typesense';
+import type { SearchParams } from 'typesense/lib/Typesense/Documents.js';
 import {
   type FacetBucket,
   type FacetsOutcome,
@@ -24,6 +25,7 @@ import {
   displayLangOf,
   fieldNamed,
   isRangeFacet,
+  isUnsatisfiable,
   labelFieldOf,
   outputFields,
   physicalFields,
@@ -310,8 +312,7 @@ export function createTypesenseSearchEngine<
   // so the cached and source-less paths never pay for collecting the IRIs.
   async function resolveLabels(
     cachedLabelsPromise:
-      | Promise<ReadonlyMap<string, LocalizedValue>>
-      | undefined,
+      Promise<ReadonlyMap<string, LocalizedValue>> | undefined,
     groups: () => readonly LabelLookupGroup[],
   ): Promise<ReadonlyMap<string, LocalizedValue>> {
     if (cachedLabelsPromise !== undefined) {
@@ -340,12 +341,25 @@ export function createTypesenseSearchEngine<
       // rejected up front, for EVERY caller.
       assertTypeInSchema(schema, searchType);
       assertValidQuery(query, searchType);
+      // Asks for no document (an empty `id` membership): answer it without a
+      // round-trip rather than dispatching a query whose only filter compiles
+      // away, which would hand back the whole collection.
+      if (isUnsatisfiable(query)) {
+        return { total: 0, hits: [], facets: {} };
+      }
       const params = buildSearchParams(query, searchType, options);
       const cachedLabelsPromise = startCachedLabels(searchType);
-      const response = (await client
-        .collections(collections.get(searchType.class) as string)
-        .documents()
-        .search(params)) as TypesenseSearchResponse;
+      // ONE search, but through `multi_search` (POST) like the facet batch and
+      // the label lookup: `documents().search()` is a GET, so a long
+      // `filter_by` – a batch `id` lookup, or any membership over many IRIs –
+      // would overflow Typesense's 4000-char query-string limit. POST puts it
+      // in the body, so the filter is bounded by the caller's request, not by
+      // the URL.
+      const response = await performSingleSearch(
+        client,
+        collections.get(searchType.class) as string,
+        params,
+      );
       const labels = await resolveLabels(cachedLabelsPromise, () =>
         labelLookupGroups(
           [response],
@@ -368,12 +382,23 @@ export function createTypesenseSearchEngine<
       }
       const collection = collections.get(searchType.class) as string;
       const cachedLabelsPromise = startCachedLabels(searchType);
+      // A query asking for no document faces the same inversion as in
+      // `search()`: its only filter would compile away and it would count
+      // facets over the whole collection. Such a query is answered with empty
+      // facets and kept OUT of the batch, so `dispatched` maps each sent search
+      // back to its caller position.
+      const dispatched = queries
+        .map((query, index) => ({ query, index }))
+        .filter(({ query }) => !isUnsatisfiable(query));
+      if (dispatched.length === 0) {
+        return queries.map(() => ({ facets: {} }));
+      }
       // The whole batch travels as ONE multi_search round-trip. Each query
       // compiles as facet-only regardless of what it carries: no hits
       // (per_page 0) and no ordering – nothing is transferred or sorted that
       // this method cannot return.
       const { results } = (await client.multiSearch.perform({
-        searches: queries.map((query) => ({
+        searches: dispatched.map(({ query }) => ({
           collection,
           ...buildSearchParams(
             { ...query, orderBy: [], limit: 0, offset: 0 },
@@ -398,18 +423,26 @@ export function createTypesenseSearchEngine<
       // multi_search reports a failed entry inline instead of rejecting the
       // call; pass that through as a per-query outcome – naming the facets,
       // not the position, since the batch order is the caller's internal –
-      // so one failed query never discards its siblings' facets.
-      return results.map((result, index) =>
-        'error' in result
-          ? {
-              error: new Error(
-                `Typesense facet search for “${queries[index].facets.join('”, “')}” failed${
-                  result.code !== undefined ? ` (${result.code})` : ''
-                }: ${result.error}`,
-              ),
-            }
-          : { facets: parseSearchResponse(result, searchType, labels).facets },
-      );
+      // so one failed query never discards its siblings' facets. Every caller
+      // position is answered: a dispatched query by its entry, an
+      // unsatisfiable one by empty facets.
+      const outcomes: FacetsOutcome[] = queries.map(() => ({ facets: {} }));
+      dispatched.forEach(({ index }, entry) => {
+        const result = results[entry];
+        outcomes[index] =
+          result === undefined || 'error' in result
+            ? {
+                error: new Error(
+                  `Typesense facet search for “${queries[index].facets.join('”, “')}” failed${
+                    result?.code !== undefined ? ` (${result.code})` : ''
+                  }: ${result?.error ?? 'no result entry'}`,
+                ),
+              }
+            : {
+                facets: parseSearchResponse(result, searchType, labels).facets,
+              };
+      });
+      return outcomes;
     },
   };
   // The runtime object is string-keyed; the literal-schema typing narrows it.
@@ -547,6 +580,38 @@ function labelLookupGroups(
     source,
     iris: [...iris],
   }));
+}
+
+/**
+ * Dispatch one search as a single-entry `multi_search` (POST). `multi_search`
+ * reports a failed entry inline instead of rejecting the call, so the entry is
+ * translated back into a throw: `search()` rejects on engine failure, and that
+ * contract must not weaken just because the transport moved off GET.
+ */
+async function performSingleSearch(
+  client: Pick<Client, 'multiSearch'>,
+  collection: string,
+  params: SearchParams<object>,
+): Promise<TypesenseSearchResponse> {
+  const { results } = (await client.multiSearch.perform({
+    searches: [{ collection, ...params }],
+  })) as {
+    results: readonly (TypesenseSearchResponse | TypesenseErrorEntry)[];
+  };
+  const [result] = results;
+  if (result === undefined) {
+    throw new Error(
+      `Typesense search of “${collection}” returned no result entry.`,
+    );
+  }
+  if ('error' in result) {
+    throw new Error(
+      `Typesense search of “${collection}” failed${
+        result.code !== undefined ? ` (${result.code})` : ''
+      }: ${result.error}`,
+    );
+  }
+  return result;
 }
 
 /**

--- a/packages/search-typesense/test/collection-name.test.ts
+++ b/packages/search-typesense/test/collection-name.test.ts
@@ -261,7 +261,7 @@ describe('label sources', () => {
 
     // The label lookup must target the collection the Organization writer
     // would have built – the same convention, never a second naming map.
-    expect(fake.performs[0][0].collection).toBe('organizations');
+    expect(fake.labelPerforms()[0][0].collection).toBe('organizations');
     expect(result.hits[0].document.publisher).toEqual({
       id: 'https://org/1',
       label: { nl: ['Het Archief'] },
@@ -284,6 +284,6 @@ describe('label sources', () => {
 
     await engine.search(dataset, browse);
 
-    expect(fake.performs[0][0].collection).toBe('labels');
+    expect(fake.labelPerforms()[0][0].collection).toBe('labels');
   });
 });

--- a/packages/search-typesense/test/fake-typesense-client.ts
+++ b/packages/search-typesense/test/fake-typesense-client.ts
@@ -20,7 +20,12 @@ export function labelLookup(
 }
 
 export interface FakeTypesenseClientOptions {
-  /** Answer for `collections().documents().search()`. */
+  /**
+   * Answer for a root search. The engine dispatches one through `multi_search`
+   * (POST) like every other query – a GET could not carry a long `filter_by` –
+   * so this answers the compiled entries, told apart from a label lookup by the
+   * `query_by_weights` only {@link buildSearchParams} emits.
+   */
   readonly searchResponse?: Record<string, unknown>;
   /** The documents export endpoint (JSONL) per collection; calls are counted. */
   readonly exportJsonl?: (collection: string) => Promise<string>;
@@ -35,8 +40,12 @@ export interface FakeTypesenseClientOptions {
 export interface FakeTypesenseClient {
   readonly client: Client;
   /** Every `multi_search` POST’s `searches` array, in call order, so batching
-   *  is observable. */
+   *  is observable. Includes the root search, which travels the same way. */
   readonly performs: readonly (readonly Record<string, unknown>[])[];
+  /** Just the label-lookup performs – those carrying no compiled query
+   *  (`query_by_weights`) – so a test can count label round-trips without
+   *  counting the root search that triggered them. */
+  readonly labelPerforms: () => readonly (readonly Record<string, unknown>[])[];
   /** How often the documents export endpoint was called, so the label cache’s
    *  load behaviour is observable. */
   readonly exportCalls: () => number;
@@ -56,8 +65,8 @@ export function fakeTypesenseClient(
   const client = {
     collections: (name?: string) => ({
       documents: () => ({
-        search: () =>
-          Promise.resolve(options.searchResponse ?? { found: 0, hits: [] }),
+        // No `search`: every query the engine issues – root, facet batch and
+        // label lookup alike – goes through `multi_search` below.
         export: () => {
           exportCalls += 1;
           return options.exportJsonl === undefined
@@ -69,16 +78,33 @@ export function fakeTypesenseClient(
     multiSearch: {
       perform: async (request: { searches: Record<string, unknown>[] }) => {
         performs.push(request.searches);
-        if (options.multiSearch === undefined) {
-          throw new Error('No multiSearch configured.');
-        }
-        return { results: request.searches.map(options.multiSearch) };
+        return {
+          results: request.searches.map((search, index) => {
+            // A compiled root/facet search carries query_by_weights; a label
+            // lookup does not. So `searchResponse` answers the former without
+            // shadowing a configured label-lookup answerer.
+            if (
+              options.searchResponse !== undefined &&
+              'query_by_weights' in search
+            ) {
+              return options.searchResponse;
+            }
+            if (options.multiSearch === undefined) {
+              throw new Error('No multiSearch configured.');
+            }
+            return options.multiSearch(search, index);
+          }),
+        };
       },
     },
   };
   return {
     client: client as unknown as Client,
     performs,
+    labelPerforms: () =>
+      performs.filter(
+        (searches) => !searches.some((search) => 'query_by_weights' in search),
+      ),
     exportCalls: () => exportCalls,
   };
 }

--- a/packages/search-typesense/test/label-sources.test.ts
+++ b/packages/search-typesense/test/label-sources.test.ts
@@ -151,14 +151,18 @@ describe('per-reference label sources', () => {
     expect(result.hits[0].document.license).toEqual([
       { id: 'https://license/1' },
     ]);
-    const requestedIds = fake.performs
+    const requestedIds = fake
+      .labelPerforms()
       .flat()
       .flatMap((search) => filterByIds(String(search.filter_by)));
     expect(requestedIds).not.toContain('https://license/1');
     // Each source was asked in its own collection, in ONE round-trip.
-    expect(fake.performs).toHaveLength(1);
+    expect(fake.labelPerforms()).toHaveLength(1);
     const byCollection = new Map(
-      fake.performs.flat().map((search) => [String(search.collection), search]),
+      fake
+        .labelPerforms()
+        .flat()
+        .map((search) => [String(search.collection), search]),
     );
     expect(
       filterByIds(String(byCollection.get('organizations')?.filter_by)),
@@ -240,7 +244,8 @@ describe('per-reference label sources', () => {
 
     await engine.search(dataset, baseQuery);
 
-    const orgSearch = fake.performs
+    const orgSearch = fake
+      .labelPerforms()
       .flat()
       .find((search) => String(search.collection) === 'organizations');
     // Organization declares locales ['und', 'nl']; the lookup must query both
@@ -318,8 +323,8 @@ describe('per-reference label sources', () => {
 
     await engine.search(dataset, baseQuery);
 
-    expect(fake.performs).toHaveLength(1);
-    const batches = fake.performs[0];
+    expect(fake.labelPerforms()).toHaveLength(1);
+    const batches = fake.labelPerforms()[0];
     expect(batches).toHaveLength(3); // 401 ids in batches of 200
     expect(
       batches.every((search) => search.collection === 'organizations'),
@@ -357,7 +362,7 @@ describe('per-reference label sources', () => {
 
     // Both collections were exported once; no per-search lookup travelled.
     expect(fake.exportCalls()).toBe(2);
-    expect(fake.performs).toHaveLength(0);
+    expect(fake.labelPerforms()).toHaveLength(0);
     expect(result.hits[0].document.publisher).toEqual([
       { id: 'https://org/1', label: { nl: ['Het Archief'] } },
     ]);
@@ -470,6 +475,6 @@ describe('per-reference label sources', () => {
     const result = await engine.search(bare.get(dataset.class)!, baseQuery);
 
     expect(result.hits[0].document.license).toEqual([{ id: 'https://l/1' }]);
-    expect(fake.performs).toHaveLength(0);
+    expect(fake.labelPerforms()).toHaveLength(0);
   });
 });

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -467,6 +467,72 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
     expect(performs).toHaveLength(0);
   });
 
+  it('makes no request when every query in the batch is unsatisfiable', async () => {
+    const { client, performs } = fakeTypesenseClient({
+      multiSearch: () => ({ found: 0, hits: [] }),
+    });
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
+    });
+
+    await expect(
+      engine.searchFacets(schema, [
+        {
+          ...facetBrowse,
+          where: [{ field: 'id', in: [] }],
+          facets: ['status'],
+        },
+        {
+          ...facetBrowse,
+          where: [{ field: 'id', in: [] }],
+          facets: ['keyword'],
+        },
+      ]),
+    ).resolves.toEqual([{ facets: {} }, { facets: {} }]);
+    expect(performs).toHaveLength(0);
+  });
+
+  it('fails loudly when the fake declares no multi_search answerer', async () => {
+    // Guards the fake's own contract: an undeclared endpoint rejects, so no
+    // test can silently exercise a path it did not configure.
+    const { client } = fakeTypesenseClient();
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
+    });
+
+    await expect(engine.search(schema, facetBrowse)).rejects.toThrow(
+      /No multiSearch configured/,
+    );
+  });
+
+  it('translates a failed root-search entry into a rejection', async () => {
+    // `multi_search` reports a failure inline; `search()` must still reject, as
+    // it did when the root search was a GET that threw on a 4xx.
+    const { client } = fakeTypesenseClient({
+      multiSearch: () => ({ code: 404, error: 'collection not found' }),
+    });
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
+    });
+
+    await expect(engine.search(schema, facetBrowse)).rejects.toThrow(
+      /search of “datasets” failed \(404\): collection not found/,
+    );
+  });
+
+  it('rejects when the root search comes back with no entry at all', async () => {
+    const client = {
+      multiSearch: { perform: async () => ({ results: [] }) },
+    } as unknown as Parameters<typeof createTypesenseSearchEngine>[0];
+    const engine = createTypesenseSearchEngine(client, labelledSchema(), {
+      collections: labelledCollections,
+    });
+
+    await expect(engine.search(schema, facetBrowse)).rejects.toThrow(
+      /search of “datasets” returned no result entry/,
+    );
+  });
+
   it('reports a failed entry as an in-place error outcome, keeping its siblings', async () => {
     const { client } = fakeTypesenseClient({
       multiSearch: (_search, index) =>

--- a/packages/search-typesense/test/query-compiler.test.ts
+++ b/packages/search-typesense/test/query-compiler.test.ts
@@ -115,13 +115,52 @@ describe('buildSearchParams', () => {
     );
   });
 
+  it('compiles an `id` clause to exact membership on the document key', () => {
+    // `id` is declared by no type: it is the document's IRI, filtered by the
+    // same exact clause label resolution uses. Backtick-wrapped, so the IRI's
+    // `:` and `/` stay literal.
+    const params = buildSearchParams(
+      {
+        ...base,
+        where: [
+          { field: 'id', in: ['https://id.example.org/a', 'urn:b'] },
+          { field: 'status', in: ['valid'] },
+        ],
+      },
+      schema,
+    );
+    expect(params.filter_by).toBe(
+      'id:=[`https://id.example.org/a`,`urn:b`] && status:[`valid`]',
+    );
+  });
+
+  it('skips a vacuous or non-membership `id` clause', () => {
+    const ignored: unknown[] = [];
+    const params = buildSearchParams(
+      {
+        ...base,
+        where: [
+          { field: 'id', in: [] },
+          { field: 'id', range: { min: 1 } },
+        ],
+      },
+      schema,
+      { onIgnoredFilter: (filter) => ignored.push(filter) },
+    );
+    expect(params.filter_by).toBeUndefined();
+    expect(ignored).toEqual([
+      { field: 'id', in: [] },
+      { field: 'id', range: { min: 1 } },
+    ]);
+  });
+
   it('skips a clause that compiles to nothing and reports it via onIgnoredFilter', () => {
     const ignored: unknown[] = [];
     const params = buildSearchParams(
       {
         ...base,
         where: [
-          { field: 'status', in: ['valid'] }, // fine — kept
+          { field: 'status', in: ['valid'] }, // fine – kept
           { field: 'nonexistent', in: ['x'] }, // unknown field
           { field: 'keyword', range: { min: 1 } }, // operator ≠ field kind
           { field: 'status', in: [] }, // empty membership

--- a/packages/search-typesense/test/search-engine.test.ts
+++ b/packages/search-typesense/test/search-engine.test.ts
@@ -220,6 +220,58 @@ describe('createTypesenseSearchEngine (integration)', () => {
     expect(result.hits.map((hit) => hit.id).sort()).toEqual(['d1', 'd3']);
   });
 
+  it('carries an id batch far past the GET query-string limit', async () => {
+    // The clause travels in the multi_search POST body, so the batch is bounded
+    // by the request rather than by 4000 URL chars: 400 IRIs of realistic
+    // length encode to ~30 000, which the old GET transport could not send.
+    const iris = Array.from(
+      { length: 400 },
+      (_, index) =>
+        `https://id.drapo.nl/ffed9f91-4f5d-5eca-978f-ded1628${String(
+          index,
+        ).padStart(5, '0')}`,
+    );
+    const result = await engine.search(datasetSchema, {
+      ...baseQuery,
+      where: [{ field: 'id', in: [...iris, 'd2'] }],
+    });
+
+    // Only the one real id matches; the rest simply are not there.
+    expect(result.total).toBe(1);
+    expect(result.hits.map((hit) => hit.id)).toEqual(['d2']);
+  });
+
+  it('answers an empty id membership with nothing, not with everything', async () => {
+    // A client mapping a possibly-empty reference array into a batch lookup
+    // asked for no document; the whole collection would be the wrong answer.
+    const result = await engine.search(datasetSchema, {
+      ...baseQuery,
+      where: [{ field: 'id', in: [] }],
+    });
+
+    expect(result.total).toBe(0);
+    expect(result.hits).toEqual([]);
+  });
+
+  it('answers facets for an unsatisfiable query as empty, siblings intact', async () => {
+    const [unsatisfiable, sibling] = await engine.searchFacets(datasetSchema, [
+      {
+        ...baseQuery,
+        limit: 0,
+        where: [{ field: 'id', in: [] }],
+        facets: ['status'],
+      },
+      { ...baseQuery, limit: 0, facets: ['status'] },
+    ]);
+
+    if ('error' in unsatisfiable || 'error' in sibling) {
+      throw new Error('expected both facet outcomes to succeed');
+    }
+    expect(unsatisfiable.facets).toEqual({});
+    // The satisfiable sibling still gets its real counts, positionally aligned.
+    expect(sibling.facets.status?.length).toBeGreaterThan(0);
+  });
+
   it('ranks a full-text query through the weighted query_by fields', async () => {
     const result = await engine.search(datasetSchema, {
       ...baseQuery,

--- a/packages/search-typesense/test/search-engine.test.ts
+++ b/packages/search-typesense/test/search-engine.test.ts
@@ -207,6 +207,19 @@ describe('createTypesenseSearchEngine (integration)', () => {
     ]);
   });
 
+  it('looks documents up by `id`, the field no type declares', async () => {
+    const result = await engine.search(datasetSchema, {
+      ...baseQuery,
+      where: [{ field: 'id', in: ['d3', 'd1'] }],
+      orderBy: [{ field: 'statusRank', direction: 'asc' }],
+    });
+
+    // Membership, so an id lookup is also a batch lookup – and it reaches
+    // documents a `status` filter would exclude (d3 is invalid).
+    expect(result.total).toBe(2);
+    expect(result.hits.map((hit) => hit.id).sort()).toEqual(['d1', 'd3']);
+  });
+
   it('ranks a full-text query through the weighted query_by fields', async () => {
     const result = await engine.search(datasetSchema, {
       ...baseQuery,

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these – see AGENTS.md.
-          functions: 98.65,
-          lines: 98.83,
-          branches: 93.75,
-          statements: 98.86,
+          functions: 98.72,
+          lines: 99.07,
+          branches: 94.07,
+          statements: 99.09,
         },
       },
     },

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -20,8 +20,8 @@ export default mergeConfig(
           // partial vitest run must never rewrite these – see AGENTS.md.
           functions: 98.65,
           lines: 98.83,
-          branches: 93.61,
-          statements: 98.85,
+          branches: 93.75,
+          statements: 98.86,
         },
       },
     },

--- a/packages/search/CONTEXT.md
+++ b/packages/search/CONTEXT.md
@@ -53,6 +53,14 @@ A capability a Search Field opts into: `output`, `searchable`, `filterable`,
 `facetable`, `sortable`. Independent; a field exposes exactly what it declares.
 _Avoid_: flag, capability
 
+**Id**:
+A document’s IRI – the one field every indexed thing carries and no Search Type
+declares. Not a Search Field: it declares no Roles, yet is surfaced by every
+type and filterable on every type (membership only). Its identity, not one of
+its values, so it lives on the hit rather than in the Search Document. A
+declaration naming a field `id` is rejected.
+_Avoid_: identifier, key, URI field
+
 **Internal Field**:
 A Search Field declaring no Role. Projected into the Search Document so later
 Derives can read it, then pruned before the writer sees it. Never stored, never
@@ -68,11 +76,19 @@ _Avoid_: sh:path, predicate, selector
 
 **Derive**:
 A Search Field’s computation – what to compute from what was already read. Runs
-in declaration order over the Search Document; never touches the graph.
+in declaration order over the Search Document; never touches the graph, and
+never reaches outside it. Pure and synchronous: a Derive cannot fail.
 _Avoid_: transform, resolver, mapper
 
 A field has a Path or a Derive, never both. **Path says what to read; Derive
 says what to compute from what was read.**
+
+A value obtained from beyond the record – a service, a store, anything the
+projection did not read – is an **enrichment**, which belongs to
+`@lde/search-pipeline` and runs _after_ projection. Used here, never redefined.
+The boundary is what each is a function of: **a Derive is a function of the
+Search Document; an enrichment is a function of the world.** A Derive therefore
+cannot read an enriched value.
 
 Two absences declare intent, and both are load-bearing: **a field without a Role
 is an Internal Field; a type without a `class` is a Reference Type.**
@@ -142,6 +158,11 @@ _Avoid_: column, engine field
 **Field**: unqualified, ambiguous between a **Search Field** (the declaration)
 and a **Physical Field** (what the engine stores). One declaration becomes
 several stored fields, so the two are never one-to-one. Qualify which you mean.
+
+**Identifier**: not the **Id**. The Id is what a thing _is_ (its IRI); an
+identifier is what some source system _calls_ it – an inventory or catalogue
+number, carried by an ordinary Search Field (`schema:identifier`). A type may
+declare `identifier`; none may declare `id`.
 
 ## Example dialogue
 

--- a/packages/search/src/adapter.ts
+++ b/packages/search/src/adapter.ts
@@ -35,6 +35,7 @@ export { physicalNameTokens } from './physical-name.js';
 export {
   filterOperatorFor,
   filterOperator,
+  isUnsatisfiable,
   validateQuery,
   assertValidQuery,
   pageForOffset,

--- a/packages/search/src/adapter.ts
+++ b/packages/search/src/adapter.ts
@@ -24,6 +24,7 @@ export {
   referenceTypeNamed,
   inlineFramingDepth,
   fieldNamed,
+  ID_FIELD,
   labelFieldOf,
   isRangeFacet,
   isoToUnixSeconds,

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -18,6 +18,7 @@ export {
   searchSchema,
   validateSearchType,
   assertValidSearchType,
+  ID_FIELD,
 } from './schema.js';
 export type {
   FieldKind,

--- a/packages/search/src/query.ts
+++ b/packages/search/src/query.ts
@@ -63,6 +63,29 @@ export function filterOperator(filter: Filter): FilterOperator {
 }
 
 /**
+ * Whether the query asks for nothing, so no engine can answer it with a hit.
+ * True for an empty `in` on {@link ID_FIELD} – and only there, deliberately:
+ *
+ * An **identity** filter enumerates the documents wanted, so the empty set
+ * wants none. A **value** filter constrains a dimension, so an empty set
+ * constrains nothing – which is why every other vacuous clause is a no-op the
+ * compilers skip (a facet UI with nothing selected sends exactly that). The
+ * readings differ because the fields differ in kind, and only for `id` would
+ * “no constraint” hand back the whole collection to a caller who asked for
+ * specific things – the likely shape being a client mapping a possibly-empty
+ * reference array (`id: { in: doc.publisher }`) into a batch lookup.
+ *
+ * An adapter MUST answer an unsatisfiable query with an empty result rather
+ * than dispatching it.
+ */
+export function isUnsatisfiable(query: SearchQuery): boolean {
+  return query.where.some(
+    (filter) =>
+      filter.field === ID_FIELD && 'in' in filter && filter.in.length === 0,
+  );
+}
+
+/**
  * One structural problem {@link validateQuery} found: the query references a
  * field the search type does not declare, or uses it in a role it does not
  * opt into. Vacuous-but-valid clauses (an empty `in` list, a `range` with no

--- a/packages/search/src/query.ts
+++ b/packages/search/src/query.ts
@@ -1,4 +1,9 @@
-import { fieldNamed, filterOperatorFor, type SearchType } from './schema.js';
+import {
+  fieldNamed,
+  filterOperatorFor,
+  ID_FIELD,
+  type SearchType,
+} from './schema.js';
 
 /**
  * The engine- and protocol-neutral query IR. Every API surface compiles its
@@ -26,7 +31,7 @@ export interface SearchQuery {
  * One `where` clause. The operator is fixed by the target field’s {@link FieldKind}
  * ({@link filterOperatorFor}): keyword/reference use `in` (OR within the field),
  * the numeric/date kinds use an inclusive `range`, boolean uses `is`. Bounds are
- * inclusive only — no `gt`/`gte`/`lt`/`lte`.
+ * inclusive only – no `gt`/`gte`/`lt`/`lte`.
  */
 export type Filter =
   | { readonly field: string; readonly in: readonly string[] }
@@ -61,29 +66,27 @@ export function filterOperator(filter: Filter): FilterOperator {
  * One structural problem {@link validateQuery} found: the query references a
  * field the search type does not declare, or uses it in a role it does not
  * opt into. Vacuous-but-valid clauses (an empty `in` list, a `range` with no
- * bound) are NOT issues — a compiler skips those as no-ops.
+ * bound) are NOT issues – a compiler skips those as no-ops.
  */
 export interface QueryIssue {
   readonly part: 'where' | 'facets' | 'orderBy';
   readonly field: string;
   readonly reason:
-    | 'unknown-field'
-    | 'not-filterable'
-    | 'operator-mismatch'
-    | 'not-facetable';
+    'unknown-field' | 'not-filterable' | 'operator-mismatch' | 'not-facetable';
 }
 
 /**
  * Structurally validate a query against its search type: every `where` clause
  * targets a declared, `filterable` field with the operator its kind accepts
- * ({@link filterOperatorFor}); every requested facet is a declared, `facetable`
+ * ({@link filterOperatorFor}) – or the undeclared, always-filterable
+ * {@link ID_FIELD}, which takes `in`; every requested facet is a declared, `facetable`
  * field; every sort is `relevance` or a declared field. Sorting deliberately
  * checks declaration only, not the `sortable` flag: that flag means *publicly
  * selectable*, and a deployment policy may sort on a private tie-break field.
  *
  * This is the port’s always-on guard: every {@link SearchEngine} adapter MUST
  * reject a query with issues ({@link assertValidQuery}) instead of passing
- * garbage to its engine, so validation holds for every caller — including
+ * garbage to its engine, so validation holds for every caller – including
  * `queryDefaults` policies and surfaces weaker than GraphQL.
  */
 export function validateQuery(
@@ -92,6 +95,19 @@ export function validateQuery(
 ): readonly QueryIssue[] {
   const issues: QueryIssue[] = [];
   for (const filter of query.where) {
+    // `id` is filterable on every type without being declared by any: it is the
+    // document’s IRI, so the lookup exists wherever documents do. Membership
+    // only – an IRI has no range and no truth value.
+    if (filter.field === ID_FIELD) {
+      if (filterOperator(filter) !== 'in') {
+        issues.push({
+          part: 'where',
+          field: filter.field,
+          reason: 'operator-mismatch',
+        });
+      }
+      continue;
+    }
     const field = fieldNamed(searchType, filter.field);
     if (field === undefined) {
       issues.push({
@@ -154,7 +170,7 @@ export function assertValidQuery(
 }
 
 /**
- * The 1-based page an `offset` falls on — the numbered-pagination presentation
+ * The 1-based page an `offset` falls on – the numbered-pagination presentation
  * of the IR, shared by the surfaces and the adapters. `limit: 0` (a facet-only
  * query) fetches no hits and has no meaningful page, so it pins to 1 rather
  * than dividing by zero.

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -586,8 +586,23 @@ export interface SearchTypeIssue {
     | 'transform-not-allowed'
     | 'derive-with-path'
     | 'text-not-filterable'
-    | 'text-not-facetable';
+    | 'text-not-facetable'
+    | 'reserved-field-name';
 }
+
+/**
+ * The reserved logical name of a document’s IRI – the one field every indexed
+ * thing carries, and the only one no {@link SearchType} declares. It is the
+ * hit’s identity ({@link SearchHit.id}), not a value in its
+ * {@link ResultDocument}, so it is surfaced and filtered by name alone.
+ *
+ * `id` answers *what the thing is*; a domain field like `schema:identifier`
+ * answers *what a source system calls it* (a catalogue or record number). Those
+ * are different questions, so a declaration may still carry an `identifier`
+ * field of its own – but never an `id` one, which
+ * {@link validateSearchType} rejects as `reserved-field-name`.
+ */
+export const ID_FIELD = 'id';
 
 /** Kinds that can feed full-text search (project a folded search field). */
 const SEARCHABLE_KINDS: readonly FieldKind[] = ['text', 'keyword', 'reference'];
@@ -620,7 +635,7 @@ const LOCALE_PATTERN = /^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$/;
  * - field names are unique (a duplicate would silently shadow in every
  *   consumer, each picking a different winner) and a metacharacter-free
  *   identifier (the name is interpolated into physical field names and the
- *   display RE2 pattern);
+ *   display RE2 pattern), and is not the reserved {@link ID_FIELD};
  * - a `text` field’s declared locales are BCP-47-shaped (no `_`, which is the
  *   reserved name↔locale separator);
  * - a `reference` field that is `output` declares `ref` (the API surfaces
@@ -662,6 +677,12 @@ export function validateSearchType(
     // pattern, so it must be a metacharacter-free identifier.
     if (!FIELD_NAME_PATTERN.test(field.name)) {
       issue('invalid-field-name');
+    }
+    // `id` is the document’s IRI, surfaced and filtered for every type; a
+    // declared field of that name would shadow it in the API output and in
+    // `where`, silently answering a different question.
+    if (field.name === ID_FIELD) {
+      issue('reserved-field-name');
     }
     // Every kind-dependent rule below would silently pass for a kind outside
     // the union, so a typo’d kind in a plain-JS declaration must fail here.

--- a/packages/search/src/testing.ts
+++ b/packages/search/src/testing.ts
@@ -6,7 +6,12 @@ import {
   type FilterOperator,
   type SearchQuery,
 } from './query.js';
-import { facetableFields, filterableFields, type RootType } from './schema.js';
+import {
+  facetableFields,
+  filterableFields,
+  ID_FIELD,
+  type RootType,
+} from './schema.js';
 
 /**
  * The executable {@link SearchEngine} port contract (import from
@@ -14,8 +19,9 @@ import { facetableFields, filterableFields, type RootType } from './schema.js';
  * live instance of itself, so the port rules hold by test rather than by
  * prose. Covers schema binding (a type outside the bound schema is rejected),
  * the always-on query validation (a structurally invalid query is rejected
- * before it reaches the engine) and the result shape of a browse query and a
- * `searchFacets` batch – for every type in the schema.
+ * before it reaches the engine), the undeclared `id` lookup, and the result
+ * shape of a browse query and a `searchFacets` batch – for every type in the
+ * schema.
  *
  * ```ts
  * describeSearchEngineContract('TypesenseSearchEngine', () => engine);
@@ -67,6 +73,23 @@ export function describeSearchEngineContract(
         await expect(engine().search(searchType, query)).rejects.toThrow(
           /unknown-field/,
         );
+      }
+    });
+
+    it('applies an `id` lookup rather than ignoring the clause', async () => {
+      // `id` is filterable on every type without being declared by any, so an
+      // adapter that resolves `where` fields through its declaration alone
+      // takes the unknown-field path and drops the clause – returning EVERY
+      // document where the caller asked for one. Pinned here because that
+      // failure is silent: no error, just the wrong result set.
+      for (const searchType of types()) {
+        const query: SearchQuery = {
+          ...browse(searchType),
+          where: [{ field: ID_FIELD, in: ['urn:test:no-such-document'] }],
+        };
+        const result = await engine().search(searchType, query);
+        expect(result.total).toBe(0);
+        expect(result.hits).toEqual([]);
       }
     });
 

--- a/packages/search/test/query.test.ts
+++ b/packages/search/test/query.test.ts
@@ -3,6 +3,7 @@ import {
   assertValidQuery,
   filterOperator,
   filterOperatorFor,
+  isUnsatisfiable,
   pageForOffset,
   validateQuery,
   type SearchQuery,
@@ -26,6 +27,37 @@ describe('filterOperatorFor', () => {
     expect(filterOperatorFor('number')).toBe('range');
     expect(filterOperatorFor('date')).toBe('range');
     expect(filterOperatorFor('boolean')).toBe('is');
+  });
+});
+
+describe('isUnsatisfiable', () => {
+  const base: SearchQuery = {
+    where: [],
+    orderBy: [],
+    limit: 10,
+    offset: 0,
+    facets: [],
+    locale: 'nl',
+  };
+
+  it('holds only for an empty `id` membership – the request for no document', () => {
+    expect(isUnsatisfiable({ ...base, where: [{ field: 'id', in: [] }] })).toBe(
+      true,
+    );
+    // A non-empty lookup asks for something.
+    expect(
+      isUnsatisfiable({ ...base, where: [{ field: 'id', in: ['urn:a'] }] }),
+    ).toBe(false);
+    // A value field's empty membership stays a no-op: no values means no
+    // constraint (a facet UI with nothing selected), not "no documents".
+    expect(
+      isUnsatisfiable({ ...base, where: [{ field: 'status', in: [] }] }),
+    ).toBe(false);
+    // Other operators on `id` are already an operator-mismatch, not this.
+    expect(
+      isUnsatisfiable({ ...base, where: [{ field: 'id', is: true }] }),
+    ).toBe(false);
+    expect(isUnsatisfiable(base)).toBe(false);
   });
 });
 

--- a/packages/search/test/query.test.ts
+++ b/packages/search/test/query.test.ts
@@ -61,7 +61,7 @@ describe('validateQuery', () => {
           facets: ['status'],
           orderBy: [
             { field: 'relevance', direction: 'desc' },
-            // Declared but not `sortable`: allowed — `sortable` means publicly
+            // Declared but not `sortable`: allowed – `sortable` means publicly
             // selectable, and deployment policy may sort on a private tie-break.
             { field: 'statusRank', direction: 'asc' },
           ],
@@ -108,6 +108,24 @@ describe('validateQuery', () => {
       { part: 'facets', field: 'size', reason: 'not-facetable' },
       { part: 'orderBy', field: 'nonexistent', reason: 'unknown-field' },
     ]);
+  });
+
+  it('accepts `id`, which no type declares but every type carries', () => {
+    expect(
+      validateQuery(
+        { ...base, where: [{ field: 'id', in: ['https://example.org/1'] }] },
+        searchType,
+      ),
+    ).toEqual([]);
+  });
+
+  it('rejects a non-membership operator on `id`: an IRI has no range', () => {
+    expect(
+      validateQuery(
+        { ...base, where: [{ field: 'id', range: { min: 1 } }] },
+        searchType,
+      ),
+    ).toEqual([{ part: 'where', field: 'id', reason: 'operator-mismatch' }]);
   });
 
   it('assertValidQuery names the type and every issue', () => {

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -347,6 +347,18 @@ describe('validateSearchType', () => {
     ).toEqual([{ field: 'v1.2', reason: 'invalid-field-name' }]);
   });
 
+  it('rejects a field named `id`, which every document already carries', () => {
+    // The IRI is surfaced and filtered under that name for every type; a
+    // declared `id` would shadow it and answer a different question. A domain
+    // identifier belongs under its own name (e.g. `identifier`).
+    expect(
+      validateSearchType(typeWith({ name: 'id', kind: 'keyword' })),
+    ).toEqual([{ field: 'id', reason: 'reserved-field-name' }]);
+    expect(
+      validateSearchType(typeWith({ name: 'identifier', kind: 'keyword' })),
+    ).toEqual([]);
+  });
+
   it('rejects a declared locale containing an underscore', () => {
     // `_` is the reserved name↔locale separator; a locale carrying one would
     // collide with the physical/display field naming.

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 98.94,
+          branches: 98.95,
           statements: 100,
         },
       },

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 98.92,
+          branches: 98.94,
           statements: 100,
         },
       },


### PR DESCRIPTION
Nothing could be looked up by its own IRI. `id` was surfaced on every output type but declared by none, so it never reached `filterableFields()` and `validateQuery` rejected it as `unknown-field`. A client holding a reference’s `id` – from `publisher`, `isPartOf`, `creator` – could not fetch that entity’s own fields, which made an IRI unusable as an entry point.

Raised on [limburg/lol#28](https://codeberg.org/limburg/lol/issues/28#issuecomment-20295886): an organization URI is the natural deep link into a work’s source organization, and there was no way to resolve one.

Generic rather than per-type: the gap is that no type is addressable, not that Organization in particular isn’t.

## The lookup

**`@lde/search`** – `ID_FIELD`, and `validateQuery` accepts `id` in `where` on any type, membership-only (an IRI has no range and no truth value, so `range`/`is` is an `operator-mismatch`). `validateSearchType` rejects a declared field named `id` with a new `reserved-field-name` reason: `whereToFilters` and the `{ id: hit.id, ...hit.document }` spread would both have been silently shadowed by one.

**`@lde/search-typesense`** – compiles to exact `id:=[…]` membership on the document key, backtick-escaped so an IRI’s `:` and `/` stay literal and cannot partial-match a shared path segment.

**`@lde/search-api-graphql`** – `id: StringFilter` in every `‹Type›Where`. The input is now always emitted: a type declaring no filterable field previously got no `where` arg at all, so it was unaddressable. One line moves in the frozen SDL snapshot.

Retrieval needed no change: root hits already map through `{ id: hit.id, ...hit.document }` and every reference type is already `{ id: String!, name: [LanguageString!]! }`.

Membership means a lookup is also a batch lookup, which is the shape a client wants after reading a page of results and collecting their reference ids:

```graphql
query Organization($uri: String!) {
  organizations(where: { id: { in: [$uri] } }, perPage: 1) {
    items {
      id
      label { language value }
      location { id name { value } }
    }
  }
}
```

## Making the batch actually work

Two defects surfaced in review, both on that primary path.

**The batch overflowed the URL.** `documents().search()` is a GET, so `filter_by` travelled in the query string against Typesense’s 4000-character limit – which a few dozen IRIs breach, since they URL-encode to several times their length. The root search now goes out as a `multi_search` POST, which is what the facet batch and the label lookup already did (`fetchLabels` documents this exact hazard as its reason). One transport for every query, and the filter is bounded by the request rather than the URL. Because `multi_search` reports failures as inline entries instead of rejecting, a failed root entry is translated back into a throw so `search()` still rejects on engine failure.

This was not introduced by the lookup – any membership over many IRIs (`creator: { in: […] }`) had the same ceiling. It is fixed for all of them.

**An empty lookup returned everything.** `where: { id: { in: [] } }` compiled away to an unfiltered query, so a client mapping a possibly-empty reference array into a batch lookup (`id: { in: doc.publisher }`) got the first page of the whole collection instead of nothing. `isUnsatisfiable` now reports it and the adapter answers with an empty result without dispatching; an unsatisfiable query is also kept out of the facet batch, answered with empty facets while its siblings keep their counts.

This deliberately makes `id` differ from every other field, where an empty `in` stays a no-op. The reason is that the fields differ in kind: an **identity** filter enumerates the documents wanted, so the empty set wants none, while a **value** filter constrains a dimension, so an empty set constrains nothing – which is exactly what a facet UI with nothing selected sends.

The port contract gained a case pinning that an `id` lookup is *applied*, not ignored: an adapter resolving `where` through the declaration alone takes the unknown-field path and returns every document, with no error to notice.

## Breaking

Two marked changes, neither reached by existing code:

- a deployment declaring a field named `id` now fails at startup instead of silently shadowing the IRI (no such declaration exists);
- an empty `in` on `id` matches nothing rather than everything.

## Naming

`id` is what a thing **is** (its IRI); a declared `identifier` (`schema:identifier`) is what a source system **calls** it – an inventory or catalogue number. Both may exist on one type, and in a real deployment they now sit side by side in one input. Recorded in `docs/reference/search.md` (“Lookup by IRI”) and in `CONTEXT.md` as the term *Id* plus an *Identifier* flagged ambiguity, since this is the distinction most likely to be conflated.

## Note

`packages/search/CONTEXT.md` also carries the pending Derive/enrichment boundary wording that was already in the working tree – unrelated to this change, included rather than discarded.
