### PR TITLE
feat(search)!: nest an inline reference’s blank-node referents

### DIFF
--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -294,6 +294,13 @@ construct serves two jobs (see
 - an **API device** declares `output`, deliberately surfacing the nested
   Reference Type.
 
+A referent needs no identity of its own: the nesting carries its fields, not a
+document key. A blank-node referent – whose `@id` JSON-LD 1.1 framing prunes –
+nests exactly like a named one, minus the `id`, so a profile that allows a blank
+node here needs no flattening workaround. A blank node label (`_:b0`) never
+becomes that `id`: framing mints it per call. Only a root, which is keyed, must
+be an IRI.
+
 So RDF depth and API shape stay independent: inline as deep as the source
 demands, expose exactly the flat fields you want. Framing follows the inline
 reference graph to the depth the schema declares (`Dataset → Subset →

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -299,7 +299,8 @@ document key. A blank-node referent – whose `@id` JSON-LD 1.1 framing prunes �
 nests exactly like a named one, minus the `id`, so a profile that allows a blank
 node here needs no flattening workaround. A blank node label (`_:b0`) never
 becomes that `id`: framing mints it per call. Only a root, which is keyed, must
-be an IRI.
+be an IRI. Fields are what make a referent, so a value that projects none – a
+literal under the reference’s alias, say – nests nothing.
 
 So RDF depth and API shape stay independent: inline as deep as the source
 demands, expose exactly the flat fields you want. Framing follows the inline

--- a/packages/search/CONTEXT.md
+++ b/packages/search/CONTEXT.md
@@ -115,6 +115,13 @@ apart only by Roles:
   nested reaches the engine or the API.
 - _API device_ (`output`): deliberately surface a nested Reference Type.
 
+A referent needs **no identity**: nesting carries the referent’s fields, not a
+document key. A blank-node referent nests exactly like a named one, minus the
+`id` – so a profile that allows a blank node (a SCHEMA-AP-NDE `MediaObject`, say)
+needs no flattening workaround. A blank node label (`_:b0`) is never that `id`:
+framing mints it per call, so it recurs across documents and changes when
+unrelated triples do. Only a Root, which _is_ keyed, requires an IRI.
+
 RDF depth and API shape are therefore independent: inline as deep as the source
 demands, expose exactly the flat fields you want
 ([ADR 11](../../docs/decisions/0011-decouple-rdf-depth-from-the-api-surface.md)).

--- a/packages/search/CONTEXT.md
+++ b/packages/search/CONTEXT.md
@@ -120,7 +120,9 @@ document key. A blank-node referent nests exactly like a named one, minus the
 `id` – so a profile that allows a blank node (a SCHEMA-AP-NDE `MediaObject`, say)
 needs no flattening workaround. A blank node label (`_:b0`) is never that `id`:
 framing mints it per call, so it recurs across documents and changes when
-unrelated triples do. Only a Root, which _is_ keyed, requires an IRI.
+unrelated triples do. Only a Root, which _is_ keyed, requires an IRI. Fields are
+what make a referent: a value projecting none (a literal under the reference’s
+alias) nests nothing.
 
 RDF depth and API shape are therefore independent: inline as deep as the source
 demands, expose exactly the flat fields you want

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -8,7 +8,7 @@
 // unified SearchField/SearchType model. A `derive` reads the projected document,
 // never the graph, so the IR readers stay internal to projection.
 export { projectRoots } from './project.js';
-export type { SearchDocument } from './project.js';
+export type { ProjectedNode, SearchDocument } from './project.js';
 
 // Unified field model: one declaration drives projection, engine collection
 // schema, query semantics and the GraphQL surface – a discriminated union by

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -352,7 +352,13 @@ function applyInlineReference(
   }
   const referents = valuesOf(node, alias)
     .filter(isObject)
-    .map((referent) => projectFields(referent, referenceType, schema));
+    .map((referent) => projectFields(referent, referenceType, schema))
+    // Fields, not identity, are what makes something a referent: a literal
+    // value object under the alias (dirty source data), or a node this
+    // reference type reads nothing from, projects nothing and is no referent.
+    // Nesting it would hand the writer a content-free document – and, for a
+    // single-valued reference, let it win the slot over a real referent.
+    .filter((referent) => Object.keys(referent).length > 0);
   if (referents.length === 0) {
     return;
   }

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -24,8 +24,17 @@ import {
   type TextField,
 } from './schema.js';
 
+/**
+ * A projected node: the fields of one {@link SearchType}, flat. A root always
+ * carries the `id` that keys it – it is a {@link SearchDocument} – but an inline
+ * referent carries one only when the referent is a named node: a nested document
+ * is not a document key, so nesting needs the referent’s fields, not its
+ * identity.
+ */
+export type ProjectedNode = Record<string, unknown>;
+
 /** A flat search document. `id` is the engine document key. */
-export type SearchDocument = { id: string } & Record<string, unknown>;
+export type SearchDocument = { id: string } & ProjectedNode;
 
 /**
  * Project one framed JSON-LD node into a flat search document: apply each field
@@ -46,7 +55,14 @@ export function projectDocument(
   searchType: SearchType,
   schema?: SearchSchema,
 ): SearchDocument {
-  const document = projectFields(node, searchType, schema);
+  if (documentKey(node) === undefined) {
+    throw new Error(
+      `Cannot project a “${searchType.name}” node without an @id (a blank node label is not one): every search document needs a stable key, and an empty one would collide with other keyless nodes.`,
+    );
+  }
+  // The guard above is what makes this a SearchDocument: projectFields sets `id`
+  // for exactly the nodes documentKey resolves.
+  const document = projectFields(node, searchType, schema) as SearchDocument;
   pruneInternalFields(document, searchType, schema);
   return document;
 }
@@ -62,7 +78,7 @@ export function projectDocument(
  * true at every depth of the reference graph, not just at the root.
  */
 function pruneInternalFields(
-  document: SearchDocument,
+  document: ProjectedNode,
   searchType: SearchType,
   schema: SearchSchema | undefined,
 ): void {
@@ -71,7 +87,7 @@ function pruneInternalFields(
       delete document[field.name];
       continue;
     }
-    // A surfaced inline reference nests its referent(s) as SearchDocument(s);
+    // A surfaced inline reference nests its referent(s) as projected node(s);
     // prune those too, by their reference type.
     if (schema === undefined || field.kind !== 'reference') {
       continue;
@@ -86,7 +102,7 @@ function pruneInternalFields(
       continue;
     }
     for (const referent of Array.isArray(nested) ? nested : [nested]) {
-      pruneInternalFields(referent as SearchDocument, referenceType, schema);
+      pruneInternalFields(referent as ProjectedNode, referenceType, schema);
     }
   }
 }
@@ -100,18 +116,25 @@ function projectFields(
   node: FramedNode,
   searchType: SearchType,
   schema: SearchSchema | undefined,
-): SearchDocument {
-  const id = node['@id'];
-  if (typeof id !== 'string') {
-    throw new Error(
-      `Cannot project a “${searchType.name}” node without an @id: every search document needs a stable key, and an empty one would collide with other keyless nodes.`,
-    );
-  }
-  const document: SearchDocument = { id };
+): ProjectedNode {
+  const id = documentKey(node);
+  const document: ProjectedNode = id === undefined ? {} : { id };
   for (const field of searchType.fields) {
     applyField(document, node, field, searchType, schema);
   }
   return document;
+}
+
+/**
+ * The document key a framed node carries, if any. A blank node label (`_:b0`) is
+ * not one: framing mints it per call, so it recurs across documents and can
+ * change when unrelated triples do. A node bearing one is therefore projected as
+ * if framing had pruned its `@id` – which it does whenever the label occurs only
+ * once in the framing results.
+ */
+function documentKey(node: FramedNode): string | undefined {
+  const id = node['@id'];
+  return typeof id === 'string' && !id.startsWith('_:') ? id : undefined;
 }
 
 /**
@@ -146,7 +169,7 @@ export async function* projectRoots(
 }
 
 function applyField(
-  document: SearchDocument,
+  document: ProjectedNode,
   node: FramedNode,
   field: SearchField,
   searchType: SearchType,
@@ -229,7 +252,7 @@ function applyField(
  * languages emit nothing.
  */
 function applyText(
-  document: SearchDocument,
+  document: ProjectedNode,
   values: readonly LangValue[],
   field: TextField,
 ): void {
@@ -281,7 +304,7 @@ function foldedSearchValue(values: readonly string[]): string {
  * already-read raw values).
  */
 function applyFacet(
-  document: SearchDocument,
+  document: ProjectedNode,
   raw: readonly string[],
   field: KeywordField | ReferenceField,
 ): void {
@@ -301,7 +324,10 @@ function applyFacet(
  * {@link irAlias IR Alias} are each projected through the reference’s
  * {@link ReferenceType} (whose own fields read their own aliases, minted against
  * the reference type) and attached under the field’s name – a nested
- * {@link SearchDocument} for a single reference, an array for an `array` one.
+ * {@link ProjectedNode} for a single reference, an array for an `array` one.
+ * A referent needs **no identity**: nesting carries its fields, not a document
+ * key, so a blank-node referent – whose `@id` JSON-LD 1.1 framing prunes when its
+ * label occurs once – nests exactly like a named one, minus the `id`.
  * The referent is projected in full – internal fields included – so the
  * declaring type’s (or the reference type’s own) derives can read them;
  * {@link pruneInternalFields} then removes the internal fields from a *surfaced*
@@ -311,7 +337,7 @@ function applyFacet(
  * {@link searchSchema}.
  */
 function applyInlineReference(
-  document: SearchDocument,
+  document: ProjectedNode,
   node: FramedNode,
   alias: string,
   field: ReferenceField & { readonly ref: { readonly typeName: string } },
@@ -326,7 +352,6 @@ function applyInlineReference(
   }
   const referents = valuesOf(node, alias)
     .filter(isObject)
-    .filter((referent) => typeof referent['@id'] === 'string')
     .map((referent) => projectFields(referent, referenceType, schema));
   if (referents.length === 0) {
     return;
@@ -428,7 +453,7 @@ function toNumber(literal: string | undefined): number | undefined {
 }
 
 function setNumber(
-  document: SearchDocument,
+  document: ProjectedNode,
   field: string,
   value: number | undefined,
 ): void {
@@ -442,7 +467,7 @@ function dedupe(values: readonly string[]): string[] {
 }
 
 function setString(
-  document: SearchDocument,
+  document: ProjectedNode,
   field: string,
   value: string | undefined,
 ): void {
@@ -452,7 +477,7 @@ function setString(
 }
 
 function setArray(
-  document: SearchDocument,
+  document: ProjectedNode,
   field: string,
   values: readonly string[],
 ): void {

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -1,4 +1,4 @@
-import type { SearchDocument } from './project.js';
+import type { ProjectedNode } from './project.js';
 
 /**
  * The engine-neutral kind of a queryable field. It drives every downstream
@@ -103,9 +103,12 @@ export interface SearchFieldBase {
    * {@link isInternalField internal} field). Return `undefined` to leave the
    * field absent. The field still carries full query/schema/output behaviour
    * like any other. Reading only the document is what keeps `path` the complete
-   * statement of what the projection reads from the graph.
+   * statement of what the projection reads from the graph. The node it receives
+   * is the search document for a root type, and the referent’s own
+   * projected fields for a Reference Type – which carry an `id` only when the
+   * referent is a named node, never for a blank-node one.
    */
-  readonly derive?: (document: SearchDocument) => unknown;
+  readonly derive?: (document: ProjectedNode) => unknown;
 }
 
 /** Full-text inclusion with a `query_by` weight (folded; per-locale for

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -791,6 +791,53 @@ describe('projectDocument', () => {
     expect(referent).not.toHaveProperty('rawSort');
   });
 
+  it('never keys a nested document by a blank node label', () => {
+    // Framing prunes a blank node identifier that occurs once, but keeps it when
+    // the same referent is referenced twice. That label is minted per framing
+    // call: it recurs across documents and changes when unrelated triples do, so
+    // it is never a document key – the referent keeps its fields and no `id`,
+    // exactly as when framing pruned the label.
+    const creator = defineSearchType({
+      name: 'Creator',
+      fields: [
+        {
+          name: 'label',
+          kind: 'text',
+          path: 'https://schema.org/name',
+          locales: ['nl'],
+          output: true,
+        },
+      ],
+    });
+    const dataset = defineSearchType({
+      name: 'Dataset',
+      class: DATASET,
+      fields: [
+        {
+          name: 'creator',
+          kind: 'reference',
+          output: true,
+          path: `${DR}creator`,
+          ref: { typeName: 'Creator', strategy: 'inline' },
+        },
+      ],
+    });
+
+    const document = projectDocument(
+      {
+        '@id': 'https://ex/d/blank',
+        [dsKey('creator')]: {
+          '@id': '_:b0',
+          [alias('Creator', 'label')]: { '@language': 'nl', '@value': 'Naam' },
+        },
+      },
+      dataset,
+      searchSchema(dataset, creator),
+    );
+
+    expect(document.creator).toEqual({ label_nl: 'Naam' });
+  });
+
   it('buckets untagged literals into the reserved und locale', () => {
     const document = projectDocument(
       {
@@ -897,6 +944,22 @@ describe('projectDocument', () => {
       projectDocument(
         { [dsKey('title')]: { '@value': 'No id' } },
         { name: 'Dataset', class: DATASET, fields },
+      ),
+    ).toThrow(/without an @id/);
+  });
+
+  it('throws when the framed node is keyed by a blank node label', () => {
+    // A blank node has no stable document key: `_:b0` is minted per framing
+    // call. A root bearing one is as keyless as one carrying no `@id` at all,
+    // and must be rejected rather than emitted under an unstable id.
+    expect(() =>
+      projectDocument(
+        { '@id': '_:b0' },
+        {
+          name: 'Dataset',
+          class: DATASET,
+          fields,
+        },
       ),
     ).toThrow(/without an @id/);
   });
@@ -1016,6 +1079,126 @@ describe('projectRoots', () => {
     }
 
     expect(ids).toEqual(['https://ex/d/1']);
+  });
+
+  it('keeps a blank-node referent of an inline reference', async () => {
+    // JSON-LD 1.1 framing prunes a blank node identifier that occurs only once
+    // in the results, so a blank-node referent arrives without an `@id`. A
+    // nested document is not a document key – nesting needs the referent’s
+    // fields – so it must survive framing with them intact.
+    const mediaObject = defineSearchType({
+      name: 'MediaObject',
+      fields: [
+        {
+          name: 'encodingFormat',
+          kind: 'keyword',
+          output: true,
+          path: 'https://schema.org/encodingFormat',
+        },
+      ],
+    });
+    const creativeWork = defineSearchType({
+      name: 'CreativeWork',
+      class: 'https://schema.org/CreativeWork',
+      fields: [
+        {
+          name: 'media',
+          kind: 'reference',
+          array: true,
+          output: true,
+          path: 'https://schema.org/associatedMedia',
+          ref: { typeName: 'MediaObject', strategy: 'inline' },
+        },
+      ],
+    });
+    const nestedSchema = searchSchema(creativeWork, mediaObject);
+    const quads = new Parser({ format: 'N-Triples' }).parse(`
+      <https://ex/w/1> <${alias('CreativeWork', 'media')}> _:b0 .
+      _:b0 <${alias('MediaObject', 'encodingFormat')}> "image/jpeg" .
+    `);
+
+    const documents: SearchDocument[] = [];
+    for await (const document of projectRoots(
+      quads,
+      ['https://ex/w/1'],
+      nestedSchema,
+      creativeWork,
+    )) {
+      documents.push(document);
+    }
+
+    expect(documents[0].media).toEqual([{ encodingFormat: ['image/jpeg'] }]);
+  });
+
+  it('keeps blank-node and named referents of one inline reference side by side', async () => {
+    // The reproduction from the field: a work whose media are one blank node
+    // (an image) and one named node (a IIIF manifest). Each referent keeps its
+    // own values grouped; only the named one is keyed.
+    const mediaObject = defineSearchType({
+      name: 'MediaObject',
+      fields: [
+        {
+          name: 'encodingFormat',
+          kind: 'keyword',
+          output: true,
+          path: 'https://schema.org/encodingFormat',
+        },
+        {
+          name: 'thumbnailUrl',
+          kind: 'reference',
+          output: true,
+          path: 'https://schema.org/thumbnailUrl',
+          ref: { typeName: 'MediaObject', strategy: 'idOnly' },
+        },
+      ],
+    });
+    const creativeWork = defineSearchType({
+      name: 'CreativeWork',
+      class: 'https://schema.org/CreativeWork',
+      fields: [
+        {
+          name: 'media',
+          kind: 'reference',
+          array: true,
+          output: true,
+          path: 'https://schema.org/associatedMedia',
+          ref: { typeName: 'MediaObject', strategy: 'inline' },
+        },
+      ],
+    });
+    const nestedSchema = searchSchema(creativeWork, mediaObject);
+    const mediaAlias = alias('CreativeWork', 'media');
+    const quads = new Parser({ format: 'N-Triples' }).parse(`
+      <https://ex/w/1> <${mediaAlias}> _:b0 .
+      _:b0 <${alias('MediaObject', 'encodingFormat')}> "image/jpeg" .
+      _:b0 <${alias('MediaObject', 'thumbnailUrl')}> <https://ex/thumb.jpg> .
+      <https://ex/w/1> <${mediaAlias}> <https://ex/iiif/manifest> .
+      <https://ex/iiif/manifest> <${alias('MediaObject', 'encodingFormat')}> "application/ld+json" .
+    `);
+
+    const documents: SearchDocument[] = [];
+    for await (const document of projectRoots(
+      quads,
+      ['https://ex/w/1'],
+      nestedSchema,
+      creativeWork,
+    )) {
+      documents.push(document);
+    }
+
+    expect(documents[0].media).toEqual(
+      expect.arrayContaining([
+        {
+          encodingFormat: ['image/jpeg'],
+          thumbnailUrl: ['https://ex/thumb.jpg'],
+        },
+        {
+          id: 'https://ex/iiif/manifest',
+          encodingFormat: ['application/ld+json'],
+        },
+      ]),
+    );
+    expect(documents[0].media).toHaveLength(2);
   });
 
   it('rejects a searchType not in the schema (no forged schema)', async () => {

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -630,6 +630,64 @@ describe('projectDocument', () => {
     expect(document).toEqual({ id: 'https://ex/d/noschema' });
   });
 
+  it('nests nothing for a value an inline reference cannot read as a referent', () => {
+    // A referent needs no identity, but it does need fields: a literal under the
+    // reference’s alias (dirty source data), or a node the reference type reads
+    // nothing from, projects no field at all. Nesting an empty document would
+    // hand the writer a content-free referent – and, for a single-valued
+    // reference, let it win the slot over a real referent behind it.
+    const creator = defineSearchType({
+      name: 'Creator',
+      fields: [
+        {
+          name: 'label',
+          kind: 'text',
+          path: 'https://schema.org/name',
+          locales: ['nl'],
+          output: true,
+        },
+      ],
+    });
+    const dataset = defineSearchType({
+      name: 'Dataset',
+      class: DATASET,
+      fields: [
+        {
+          name: 'creator',
+          kind: 'reference',
+          output: true,
+          path: `${DR}creator`,
+          ref: { typeName: 'Creator', strategy: 'inline' },
+        },
+      ],
+    });
+    const withReference = searchSchema(dataset, creator);
+
+    const document = projectDocument(
+      {
+        '@id': 'https://ex/d/literal',
+        [dsKey('creator')]: [
+          { '@value': 'Jan Jansen' },
+          {
+            '@id': 'https://ex/c/3',
+            [alias('Creator', 'label')]: {
+              '@language': 'nl',
+              '@value': 'Naam',
+            },
+          },
+        ],
+      },
+      dataset,
+      withReference,
+    );
+
+    // The literal contributed no referent, so the real one takes the slot.
+    expect(document.creator).toEqual({
+      id: 'https://ex/c/3',
+      label_nl: 'Naam',
+    });
+  });
+
   it('skips an inline reference the given schema does not declare', () => {
     // projectDocument does not check type membership (projectRoots does); framed
     // against a schema that omits the referent, an inline reference contributes

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 98.95,
+          branches: 98.97,
           statements: 100,
         },
       },


### PR DESCRIPTION
An inline reference silently dropped every blank-node referent, so it could only
ever carry named nodes: JSON-LD 1.1 framing prunes a blank node identifier that
occurs once in the results, and the projection then filtered referents on
`typeof referent['@id'] === 'string'`.

This takes option 1 from the issue – do not require an identifier for an inline
referent. A nested document is not a document key; nesting needs the referent’s
fields. Framing behaviour stays spec-default, so no non-standard `jsonld.js`
escape hatch and no minted identity the data does not carry.

## Changes

- `applyInlineReference` no longer filters referents on `@id`, and a projected
  node carries `id` only when the node has one.
- A projected node is keyed by an IRI only. A blank node label (`_:b0`) – which
  framing keeps when the label occurs more than once – is minted per framing
  call, so it recurs across documents and churns any skip-unchanged hash: it
  never becomes an `id`. A root bearing one is now rejected like a node carrying
  no `@id` at all.
- Fields, not identity, are what make a referent: a value that projects none – a
  literal under the reference’s alias in dirty source data – nests nothing.
  Without this, the dropped `@id` filter would let a literal through as an empty
  nested document, and that document could win the slot of a single-valued
  reference over a real referent behind it.
- New `ProjectedNode` type (`SearchDocument` is it plus a guaranteed `id`), and
  `derive` now receives it: a Reference Type’s derive may run on a referent that
  has no identity.
- The constraint is documented next to the Inline Reference definition in
  `packages/search/CONTEXT.md` and in `docs/reference/search.md`.

Tests cover the projection end to end through real framing – the issue’s own
reproduction (a blank-node image and a named IIIF manifest under one alias, each
referent keeping its values grouped) plus the blank-label, keyless-root and
fieldless-referent rules.

## Breaking change

`SearchFieldBase.derive` receives a `ProjectedNode` rather than a
`SearchDocument`. A derive whose parameter is explicitly typed `SearchDocument`
no longer type-checks – type it `ProjectedNode`, or drop the annotation and let
it be inferred. Reading `document.id` inside a Reference Type’s derive is no
longer sound: a blank-node referent has none.

## Follow-up (not in this PR)

`buildReferenceType` in `@lde/search-api-graphql` declares `id` as
`GraphQLNonNull`, so an id-less nested referent would null the response once
inline references round-trip through an engine. Unreachable today – the Typesense
adapter maps a `reference` to `string`/`string[]` and has no nested-object
support – and it belongs to the surface work in #674.

Fix #677
