### PR TITLE
feat(search)!: serve a surfaced inline reference as a nested document

### DIFF
--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -150,7 +150,11 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
   (`[0].language` is the language actually served); references → named per-shape
   types (`Organization`, `Term`) with a `name` – a reference whose `typeName`
   names a root type (`creator` → `Person`) is served under a derived name
-  (`PersonReference`), since GraphQL type names must be unique; scalars/booleans
+  (`PersonReference`), since GraphQL type names must be unique; a **surfaced
+  inline reference** instead gets a type built from its Reference Type’s own
+  `output` fields – the same per-kind rules as a root type, with a nullable
+  `id`, since a referent needs no identity – so a client selects a nested
+  object’s fields directly and renders one referent at a time; scalars/booleans
   per kind; `date` → ISO 8601 string; nullability from `required` / `array` /
   `kind`.
 - **`where`** one input per `filterable` field (`StringFilter`, `IntRange` /

--- a/docs/reference/search-pipeline.md
+++ b/docs/reference/search-pipeline.md
@@ -71,7 +71,8 @@ const pipeline = searchIndexerPipeline({
     ...createQlever({ mode: 'docker', image: 'adfreiburg/qlever:latest' }),
     strategy: 'import',
   }),
-  writerFor: (searchType) => new InPlaceRebuild(typesenseClient, searchType),
+  writerFor: (searchType, schema) =>
+    new InPlaceRebuild(typesenseClient, searchType, { schema }),
   // Optional: skip datasets whose source and pipeline version are unchanged.
   provenanceStore: new FileProvenanceStore({ path: 'data/provenance.json' }),
   pipelineVersion: '1',
@@ -176,8 +177,8 @@ const pipeline = new Pipeline<TypedSearchDocument>({
   // engine reading these collections cannot disagree about where they are.
   writers: searchIndexWriter({
     schema,
-    writerFor: (searchType) =>
-      new BlueGreenRebuild(typesenseClient, searchType),
+    writerFor: (searchType, schema) =>
+      new BlueGreenRebuild(typesenseClient, searchType, { schema }),
   }),
 });
 
@@ -193,8 +194,9 @@ derivation:
 ```ts
 import { BlueGreenRebuild, deriveCollectionName } from '@lde/search-typesense';
 
-writerFor: (searchType) =>
+writerFor: (searchType, schema) =>
   new BlueGreenRebuild(typesenseClient, searchType, {
+    schema,
     name: `${process.env.INDEX_PREFIX}_${deriveCollectionName(searchType)}`,
   });
 ```

--- a/docs/reference/search-typesense.md
+++ b/docs/reference/search-typesense.md
@@ -74,12 +74,22 @@ engine is constructed rather than on the first rebuild or search:
 
 ## Collection schema and engine
 
-`buildCollectionDefinition(searchType, { name?, defaultSortingField, … })` derives a
-Typesense collection from the unified `SearchField` model – the Typesense field
-type comes from each field’s `kind`, and the physical fanout (per-locale
-search/sort keys, plus one regex display field per output text field) matches
-what the projection writes, via `@lde/search`’s `physicalFields` and its display
-helpers, so the index and the documents cannot drift.
+`buildCollectionDefinition(searchType, { name?, schema?, defaultSortingField, … })`
+derives a Typesense collection from the unified `SearchField` model – the
+Typesense field type comes from each field’s `kind`, and the physical fanout
+(per-locale search/sort keys, plus one regex display field per output text
+field) matches what the projection writes, via `@lde/search`’s `physicalFields`
+and its display helpers, so the index and the documents cannot drift.
+
+A **surfaced inline reference** (`output` + `strategy: 'inline'`) is stored as a
+nested object – `object` or `object[]`, which turns on the collection’s
+`enable_nested_fields` – with one nested Physical Field per output field of its
+Reference Type (`media.contentUrl`, `media.caption_<lang>`, via
+`nestedFieldName`). Everything nested is declared `index: false`: a nested field
+carries `output` only, so it is display weight on disk, like the language
+labels. Pass the `schema` option for a type that surfaces one – it is what
+resolves the Reference Type; a type declaring one without it throws here, rather
+than building a collection whose documents would all fail to import.
 
 **Memory lever.** Typesense keeps the index in RAM (with a raw copy of each
 document on disk), so RAM tracks the _indexed_ surface – roughly 2–3× the size
@@ -105,7 +115,11 @@ down.
   stays id-only. With `labelCacheTtlMs` set, each label-source collection is
   instead loaded once into an in-memory cache;
 - reconstructs the logical `SearchResult` (`parseSearchResponse`) – language
-  maps, labelled references, labelled facet buckets.
+  maps, labelled references, labelled facet buckets, and one nested Search
+  Document per referent of a surfaced inline reference (each referent’s values
+  grouped, `id` only where the referent had one). Nesting is rebuilt here,
+  below every API surface, so a second surface inherits it rather than
+  reimplementing it.
 
 A label source is just another `SearchType` in the schema (with an `output`,
 `searchable` text field called `label`), so its collection is named by the same

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -199,7 +199,12 @@ const DATASET = defineSearchType({
     { name: 'size', path: 'urn:dr:size', kind: 'integer', sortable: true },
     // internal field (no role): projected as a reading device for the derive
     // below, then pruned before the writer – absent from the collection too
-    { name: 'classes', path: 'urn:dr:class', kind: 'reference' },
+    {
+      name: 'classes',
+      path: 'urn:dr:class',
+      kind: 'reference',
+      array: true,
+    },
     // derived field (no path): computed from the document in declaration order,
     // never from the graph – so `path` stays the whole statement of what is read
     {
@@ -278,6 +283,13 @@ directly.
 | `integer` / `number` | `range { min, max }` | yes   | yes              | number                                                                                |
 | `date`               | `range` (inclusive)  | yes   | yes              | ISO 8601 string (surface)                                                             |
 | `boolean`            | `is`                 | yes   | –                | boolean (absent = false)                                                              |
+
+**`array` decides a field’s shape**, whatever the graph carries: a declared
+`array` field stores a list, and a single-valued one stores the first value –
+for every kind alike, so the projection, the engine collection definition
+(`string` vs `string[]`) and the API output type never describe one declaration
+differently. Declare `array: true` wherever the source may carry several values
+you want to keep, including on an internal field a `derive` counts.
 
 A `reference` carries one of two strategies today: `labelOnly` (id + display
 label, resolved at query time from a label source) and `inline` (the referent’s

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -28,7 +28,8 @@ It provides four things:
   semantics: every API surface compiles into it, every engine adapter compiles
   out of it, so the two cannot drift;
 - **engine port** – `SearchEngine` and the logical result types
-  (`SearchResult` / `SearchHit` / `ResultDocument` / `Reference` / …);
+  (`SearchResult` / `SearchHit` / `ResultDocument` / `Reference` /
+  `NestedDocument` / …);
 - **streaming projection** – `projectRoots`, RDF `CONSTRUCT` quads → flat
   search documents, one root type at a time.
 
@@ -84,6 +85,11 @@ Exports are stratified by audience:
     predicates;
   - `referenceTypeNamed` – resolve an inline `ref.typeName` to its declared
     Reference Type;
+  - `nestedReferenceType` – the Reference Type a **surfaced** (`output`) inline
+    reference nests, the one predicate the collection definition, result
+    reconstruction and the API surfaces share;
+  - `nestedFieldName` – the nested Physical Field naming convention
+    (`media.contentUrl`), the nested counterpart of `physicalFields`;
   - `inlineFramingDepth` – the framing depth a Root Type’s inline reference
     graph needs;
   - `labelFieldOf` – the `label` text field a label source serves labels
@@ -264,14 +270,14 @@ than per document at index time. `validateSearchType` /
 `assertValidSearchType` are exported for validating a single declaration
 directly.
 
-| kind                 | `where`              | facet | sort             | output                          |
-| -------------------- | -------------------- | ----- | ---------------- | ------------------------------- |
-| `text`               | – (feeds free text)  | –     | yes (per-locale) | best-first language list        |
-| `keyword`            | `in` (membership)    | yes   | –                | string / `string[]`             |
-| `reference`          | `in` (membership)    | yes   | –                | labelled reference (id + label) |
-| `integer` / `number` | `range { min, max }` | yes   | yes              | number                          |
-| `date`               | `range` (inclusive)  | yes   | yes              | ISO 8601 string (surface)       |
-| `boolean`            | `is`                 | yes   | –                | boolean (absent = false)        |
+| kind                 | `where`              | facet | sort             | output                                                                                |
+| -------------------- | -------------------- | ----- | ---------------- | ------------------------------------------------------------------------------------- |
+| `text`               | – (feeds free text)  | –     | yes (per-locale) | best-first language list                                                              |
+| `keyword`            | `in` (membership)    | yes   | –                | string / `string[]`                                                                   |
+| `reference`          | `in` (membership)    | yes   | –                | labelled reference (id + label), or a nested document for a surfaced inline reference |
+| `integer` / `number` | `range { min, max }` | yes   | yes              | number                                                                                |
+| `date`               | `range` (inclusive)  | yes   | yes              | ISO 8601 string (surface)                                                             |
+| `boolean`            | `is`                 | yes   | –                | boolean (absent = false)                                                              |
 
 A `reference` carries one of two strategies today: `labelOnly` (id + display
 label, resolved at query time from a label source) and `inline` (the referent’s
@@ -291,8 +297,19 @@ construct serves two jobs (see
   so a later `derive` can select and flatten a value a `path` cannot address (a
   qualified hop), then pruned before the writer – nothing nested reaches the
   engine or the API;
-- an **API device** declares `output`, deliberately surfacing the nested
-  Reference Type.
+- an **API device** declares `output`, surfacing the nested Reference Type all
+  the way to the API: the engine stores the referent as a nested document, the
+  engine adapter reconstructs it as one, and every surface serves the referent’s
+  own fields. A multi-valued reference keeps each referent’s values grouped, so
+  a consumer never pairs parallel arrays by index.
+
+Those are its only two shapes, and a nested field carries **`output` only**.
+`searchable`, `filterable`, `facetable`, `sortable` and `labelSource` – on the
+inline reference itself or on any field of its Reference Type – are rejected by
+`searchSchema`, naming the field: a nested value is stored with its referent and
+read back with it, never as an addressable field of its own, so declaring one of
+those would be silently ignored per query. Filtering, faceting and sorting on
+nested fields is future work.
 
 A referent needs no identity of its own: the nesting carries its fields, not a
 document key. A blank-node referent – whose `@id` JSON-LD 1.1 framing prunes –

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -32,6 +32,7 @@ import {
   filterOperatorFor,
   ID_FIELD,
   isRangeFacet,
+  nestedReferenceType,
   outputFields,
   pageForOffset,
   sortableFields,
@@ -217,37 +218,76 @@ export function buildGraphQLSchema(
   // and rejects duplicate names schema-wide.
   const referenceTypes = new Map<string, GraphQLObjectType>();
   const takenTypeNames = new Set(rootTypeNames);
+
+  /**
+   * Register the GraphQL type one reference field is served as, once per
+   * referenced shape. A **surfaced inline** reference is served as the nested
+   * object its Reference Type declares – its own `output` fields, configured by
+   * exactly the same per-kind rules a root type’s fields are – so the response
+   * shape matches the data’s shape. Its `id` is nullable: a referent needs no
+   * identity, and a blank-node one nests without one. Every other reference
+   * stays the id-plus-label pair its strategy carries.
+   */
+  function registerReferenceType(field: SearchField, owner: SearchType): void {
+    if (
+      field.kind !== 'reference' ||
+      field.ref === undefined ||
+      referenceTypes.has(field.ref.typeName)
+    ) {
+      return;
+    }
+    const { typeName } = field.ref;
+    const graphQLName = rootTypeNames.has(typeName)
+      ? `${typeName}Reference`
+      : typeName;
+    if (takenTypeNames.has(graphQLName)) {
+      throw new Error(
+        `Reference type “${typeName}” (field “${field.name}” of “${owner.name}”) would be served as “${graphQLName}”, which collides with another type name; rename one.`,
+      );
+    }
+    takenTypeNames.add(graphQLName);
+    const nested = nestedReferenceType(schema, field);
+    referenceTypes.set(
+      typeName,
+      new GraphQLObjectType({
+        name: graphQLName,
+        // A thunk, so a Reference Type nesting another one resolves whatever
+        // the registration order is (the graph is acyclic by searchSchema).
+        fields: (): Record<
+          string,
+          GraphQLFieldConfig<Source, SearchContext>
+        > =>
+          nested === undefined
+            ? {
+                id: { type: new GraphQLNonNull(GraphQLString) },
+                name: labelList(
+                  (source) => source.label as LocalizedValue | undefined,
+                ),
+              }
+            : {
+                id: { type: GraphQLString },
+                ...Object.fromEntries(
+                  outputFields(nested).map((nestedField) => [
+                    nestedField.name,
+                    outputFieldConfig(nestedField),
+                  ]),
+                ),
+              },
+      }),
+    );
+    if (nested === undefined) {
+      return;
+    }
+    // A nested reference type’s own surfaced references are types too; register
+    // them now, so every type exists before the thunks above are called.
+    for (const nestedField of outputFields(nested)) {
+      registerReferenceType(nestedField, nested);
+    }
+  }
+
   for (const searchType of schema.values()) {
     for (const field of outputFields(searchType)) {
-      if (
-        field.kind !== 'reference' ||
-        field.ref === undefined ||
-        referenceTypes.has(field.ref.typeName)
-      ) {
-        continue;
-      }
-      const { typeName } = field.ref;
-      const graphQLName = rootTypeNames.has(typeName)
-        ? `${typeName}Reference`
-        : typeName;
-      if (takenTypeNames.has(graphQLName)) {
-        throw new Error(
-          `Reference type “${typeName}” (field “${field.name}” of “${searchType.name}”) would be served as “${graphQLName}”, which collides with another type name; rename one.`,
-        );
-      }
-      takenTypeNames.add(graphQLName);
-      referenceTypes.set(
-        typeName,
-        new GraphQLObjectType({
-          name: graphQLName,
-          fields: {
-            id: { type: new GraphQLNonNull(GraphQLString) },
-            name: labelList(
-              (source) => source.label as LocalizedValue | undefined,
-            ),
-          },
-        }),
-      );
+      registerReferenceType(field, searchType);
     }
   }
 

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -853,3 +853,161 @@ describe('und-locale text output', () => {
     ]);
   });
 });
+
+describe('nested inline references', () => {
+  const MEDIA_OBJECT: SearchType = {
+    name: 'MediaObject',
+    fields: [
+      {
+        name: 'contentUrl',
+        kind: 'keyword',
+        array: true,
+        output: true,
+        path: 'https://schema.org/contentUrl',
+      },
+      {
+        name: 'width',
+        kind: 'integer',
+        output: true,
+        path: 'https://schema.org/width',
+      },
+      {
+        name: 'caption',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        path: 'https://schema.org/caption',
+      },
+      // No Role: pruned before the writer, so it is no part of the API either.
+      { name: 'rawWidth', kind: 'keyword', path: 'https://schema.org/width' },
+    ],
+  };
+  const CREATIVE_WORK_WITH_MEDIA: SearchType = {
+    name: 'CreativeWork',
+    class: 'https://schema.org/CreativeWork',
+    fields: [
+      {
+        name: 'media',
+        kind: 'reference',
+        array: true,
+        output: true,
+        path: 'https://schema.org/associatedMedia',
+        ref: { typeName: 'MediaObject', strategy: 'inline' },
+      },
+    ],
+  };
+  const nestedSchema = searchSchema(CREATIVE_WORK_WITH_MEDIA, MEDIA_OBJECT);
+
+  it('builds the reference type from the Reference Type’s output fields', () => {
+    const sdl = printSchema(buildGraphQLSchema(nestedSchema));
+    expect(sdl).toMatch(/media: \[MediaObject!\]!/);
+    // Each field is typed by exactly the per-kind rules a root type’s fields
+    // get. `id` is nullable: a referent needs no identity, so a blank-node one
+    // nests without one.
+    expect(sdl).toMatch(
+      /type MediaObject \{\s+id: String\s+contentUrl: \[String!\]!\s+width: Int\s+caption: \[LanguageString!\]!\s+\}/,
+    );
+    // An Internal Field inside a Reference Type stays out of the API.
+    expect(sdl).not.toMatch(/rawWidth/);
+  });
+
+  it('serves a nested object’s fields directly, one referent at a time', async () => {
+    const { engine } = fakeEngine({
+      total: 1,
+      hits: [
+        {
+          id: 'https://ex/w/1',
+          document: {
+            media: [
+              {
+                id: 'https://ex/m/1',
+                contentUrl: ['https://ex/1.jpg'],
+                width: 4096,
+                caption: { nl: ['Voorkant'] },
+              },
+              // A blank-node referent: no id, and no width.
+              { contentUrl: ['https://ex/2.jpg'] },
+            ],
+          },
+        },
+      ],
+      facets: {},
+    });
+    const result = await graphql({
+      schema: buildGraphQLSchema(nestedSchema),
+      source: `{
+        creativeWorks {
+          items {
+            id
+            media { id contentUrl width caption { language value } }
+          }
+        }
+      }`,
+      contextValue: { engine, acceptLanguage: ['nl'] },
+    });
+
+    expect(result.errors).toBeUndefined();
+    // The response shape matches the data's shape: each referent's values stay
+    // together instead of arriving as parallel arrays to pair by index.
+    expect(result.data).toEqual({
+      creativeWorks: {
+        items: [
+          {
+            id: 'https://ex/w/1',
+            media: [
+              {
+                id: 'https://ex/m/1',
+                contentUrl: ['https://ex/1.jpg'],
+                width: 4096,
+                caption: [{ language: 'nl', value: 'Voorkant' }],
+              },
+              {
+                id: null,
+                contentUrl: ['https://ex/2.jpg'],
+                width: null,
+                caption: [],
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('serves a reference type that itself nests one', () => {
+    const thumbnail: SearchType = {
+      name: 'Thumbnail',
+      fields: [
+        {
+          name: 'contentUrl',
+          kind: 'keyword',
+          output: true,
+          path: 'https://schema.org/contentUrl',
+        },
+      ],
+    };
+    const media: SearchType = {
+      name: 'MediaObject',
+      fields: [
+        {
+          name: 'thumbnail',
+          kind: 'reference',
+          output: true,
+          path: 'https://schema.org/thumbnail',
+          ref: { typeName: 'Thumbnail', strategy: 'inline' },
+        },
+      ],
+    };
+    const sdl = printSchema(
+      buildGraphQLSchema(
+        searchSchema(CREATIVE_WORK_WITH_MEDIA, media, thumbnail),
+      ),
+    );
+    expect(sdl).toMatch(
+      /type MediaObject \{\s+id: String\s+thumbnail: Thumbnail\s+\}/,
+    );
+    expect(sdl).toMatch(
+      /type Thumbnail \{\s+id: String\s+contentUrl: String\s+\}/,
+    );
+  });
+});

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -981,6 +981,7 @@ describe('nested inline references', () => {
         {
           name: 'contentUrl',
           kind: 'keyword',
+          array: true,
           output: true,
           path: 'https://schema.org/contentUrl',
         },
@@ -1007,7 +1008,7 @@ describe('nested inline references', () => {
       /type MediaObject \{\s+id: String\s+thumbnail: Thumbnail\s+\}/,
     );
     expect(sdl).toMatch(
-      /type Thumbnail \{\s+id: String\s+contentUrl: String\s+\}/,
+      /type Thumbnail \{\s+id: String\s+contentUrl: \[String!\]!\s+\}/,
     );
   });
 });

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -22,7 +22,7 @@ export default mergeConfig(
           lines: 100,
           // Full-suite baseline, re-anchored when covered branches are
           // deleted (autoUpdate only ever raises; see AGENTS.md).
-          branches: 94.16,
+          branches: 95.03,
           statements: 100,
         },
       },

--- a/packages/search-indexer/src/composition.ts
+++ b/packages/search-indexer/src/composition.ts
@@ -9,7 +9,7 @@ import {
   type DistributionResolver,
   type Writer,
 } from '@lde/pipeline';
-import type { RootType, SearchDocument } from '@lde/search';
+import type { RootType, SearchDocument, SearchSchema } from '@lde/search';
 import {
   BlueGreenRebuild,
   deriveCollectionName,
@@ -32,17 +32,25 @@ export function datasetSelectorFrom(config: IndexerConfig): DatasetSelector {
  * {@link InPlaceRebuild} or {@link BlueGreenRebuild} per root type, its
  * collection name derived from the type – prefixed when the deployment says
  * so, so the read side must be configured with the same prefix.
+ *
+ * The mounted schema the pipeline hands each call travels into the writer: a
+ * type that surfaces an inline reference builds its collection from the
+ * Reference Type the schema resolves, so the nested fields are declared rather
+ * than silently dropped.
  */
 export function writerFactoryFrom(
   client: Client,
   config: IndexerConfig,
-): (searchType: RootType) => Writer<SearchDocument> {
-  return (searchType) => {
-    const options = config.collectionPrefix
-      ? {
-          name: `${config.collectionPrefix}${deriveCollectionName(searchType)}`,
-        }
-      : {};
+): (searchType: RootType, schema: SearchSchema) => Writer<SearchDocument> {
+  return (searchType, schema) => {
+    const options = {
+      schema,
+      ...(config.collectionPrefix
+        ? {
+            name: `${config.collectionPrefix}${deriveCollectionName(searchType)}`,
+          }
+        : {}),
+    };
     return config.rebuildMode === 'blue-green'
       ? new BlueGreenRebuild(client, searchType, options)
       : new InPlaceRebuild(client, searchType, options);

--- a/packages/search-indexer/test/composition.test.ts
+++ b/packages/search-indexer/test/composition.test.ts
@@ -38,7 +38,7 @@ describe('datasetSelectorFrom', () => {
 describe('writerFactoryFrom', () => {
   it('builds an in-place rebuild writer by default', () => {
     const writerFor = writerFactoryFrom(client, configFromEnvironment(minimal));
-    const writer = writerFor(datasetType);
+    const writer = writerFor(datasetType, schema);
     expect(writer).toBeInstanceOf(InPlaceRebuild);
     expect((writer as InPlaceRebuild<never>).collectionName).toBe('datasets');
   });
@@ -48,7 +48,7 @@ describe('writerFactoryFrom', () => {
       client,
       configFromEnvironment({ ...minimal, REBUILD_MODE: 'blue-green' }),
     );
-    const writer = writerFor(datasetType);
+    const writer = writerFor(datasetType, schema);
     expect(writer).toBeInstanceOf(BlueGreenRebuild);
     expect((writer as BlueGreenRebuild<never>).collectionName).toBe('datasets');
   });
@@ -58,7 +58,7 @@ describe('writerFactoryFrom', () => {
       client,
       configFromEnvironment({ ...minimal, COLLECTION_PREFIX: 'staging_' }),
     );
-    const writer = writerFor(datasetType);
+    const writer = writerFor(datasetType, schema);
     expect((writer as InPlaceRebuild<never>).collectionName).toBe(
       'staging_datasets',
     );

--- a/packages/search-pipeline/src/search-index-writer.ts
+++ b/packages/search-pipeline/src/search-index-writer.ts
@@ -31,7 +31,10 @@ export interface SearchIndexWriterOptions {
    * own collection, alias and cross-pod lock. The per-collection fan-out is this
    * writer’s job.
    */
-  writerFor: (searchType: RootType) => Writer<SearchDocument>;
+  writerFor: (
+    searchType: RootType,
+    schema: SearchSchema,
+  ) => Writer<SearchDocument>;
 }
 
 /**
@@ -74,7 +77,7 @@ export function searchIndexWriter(
   const writers = new Map<string, Writer<SearchDocument>>(
     [...schema.values()].map((searchType) => [
       searchType.class,
-      writerFor(searchType),
+      writerFor(searchType, schema),
     ]),
   );
 

--- a/packages/search-pipeline/src/search-indexer-pipeline.ts
+++ b/packages/search-pipeline/src/search-indexer-pipeline.ts
@@ -40,9 +40,15 @@ export interface SearchIndexerPipelineOptions {
   /**
    * The engine writer that owns a given root type’s collection – e.g. a
    * `@lde/search-typesense` `InPlaceRebuild` or `BlueGreenRebuild` bound to
-   * that type. Called once per {@link RootType} in the schema.
+   * that type. Called once per {@link RootType} in the schema, with the schema
+   * itself: an engine that stores a surfaced inline reference as a nested
+   * document needs it to declare the nesting, and it is the pipeline that holds
+   * it.
    */
-  writerFor: (searchType: RootType) => Writer<SearchDocument>;
+  writerFor: (
+    searchType: RootType,
+    schema: SearchSchema,
+  ) => Writer<SearchDocument>;
   /**
    * Optional per-dataset processing memory: skip a dataset whose source
    * fingerprint and {@link pipelineVersion} both match the stored record.
@@ -83,7 +89,8 @@ export interface SearchIndexerPipelineOptions {
  *     ...createQlever({ mode: 'docker', image: 'adfreiburg/qlever:latest' }),
  *     strategy: 'import',
  *   }),
- *   writerFor: (searchType) => new InPlaceRebuild(typesenseClient, searchType),
+ *   writerFor: (searchType, schema) =>
+ *     new InPlaceRebuild(typesenseClient, searchType, { schema }),
  * });
  * await pipeline.run();
  * ```

--- a/packages/search-pipeline/test/extraction-roundtrip.integration.test.ts
+++ b/packages/search-pipeline/test/extraction-roundtrip.integration.test.ts
@@ -138,7 +138,7 @@ describe('extraction round-trip: generate → read → frame → project', () =>
     expect(first.description_nl).toBe('Een schilderij van Johannes Vermeer.');
     // …and the labelOnly creator carried as its bare IRI (label resolved at
     // query time from the Person collection, not here).
-    expect(first.creator).toEqual(['https://ex/p/1']);
+    expect(first.creator).toBe('https://ex/p/1');
 
     // A root with only a name still projects, with the optional fields absent.
     const second = byId['https://ex/cw/2'];

--- a/packages/search-pipeline/test/search-stages.test.ts
+++ b/packages/search-pipeline/test/search-stages.test.ts
@@ -95,8 +95,8 @@ describe('searchStages', () => {
 
     expect(received.map((item) => item.searchType)).toEqual([person, person]);
     expect(received.map((item) => item.document)).toEqual([
-      { id: 'https://ex/p/1', name: ['Name https://ex/p/1'] },
-      { id: 'https://ex/p/2', name: ['Name https://ex/p/2'] },
+      { id: 'https://ex/p/1', name: 'Name https://ex/p/1' },
+      { id: 'https://ex/p/2', name: 'Name https://ex/p/2' },
     ]);
   });
 

--- a/packages/search-typesense/src/collection-definition.ts
+++ b/packages/search-typesense/src/collection-definition.ts
@@ -1,9 +1,17 @@
 import type { CollectionCreateSchema } from 'typesense';
 import type { CollectionFieldSchema } from 'typesense/lib/Typesense/Collection.js';
-import { type SearchField, type SearchType } from '@lde/search';
+import {
+  type ReferenceType,
+  type SearchField,
+  type SearchSchema,
+  type SearchType,
+} from '@lde/search';
 import {
   displayFieldPattern,
+  isInlineReference,
   isInternalField,
+  nestedFieldName,
+  nestedReferenceType,
   physicalFields,
 } from '@lde/search/adapter';
 import { deriveCollectionName } from './collection-name.js';
@@ -14,6 +22,15 @@ export interface CollectionDefinitionOptions {
    *  type’s `name` ({@link deriveCollectionName}); supply one to override that
    *  (an env prefix, a multi-tenant name, an existing collection). */
   readonly name?: string;
+  /**
+   * The Search Schema the type belongs to – required only when the type
+   * surfaces an inline reference, whose nested fields are declared from the
+   * {@link ReferenceType} the schema resolves. A type without one needs no
+   * schema, so a caller that declares no nesting passes none; a type that does
+   * fails here rather than building a collection that silently omits the
+   * nesting.
+   */
+  readonly schema?: SearchSchema;
   /** Snowball stemming locale for non-localized searchable fields (e.g. `en`).
    *  Unset, those fields are not stemmed – folding still applies – so no
    *  language is ever assumed. Localized text search fields always stem in
@@ -54,6 +71,14 @@ export interface CollectionDefinitionOptions {
  * {@link isInternalField Internal fields} (those declaring no role) are omitted
  * entirely: they exist only as a projection-time reading device for the
  * derives, so the collection stores nothing for them.
+ *
+ * A surfaced (`output`) inline reference is stored as a **nested object** –
+ * `object` or `object[]` – with one nested Physical Field per output field of
+ * its {@link ReferenceType} ({@link nestedFieldName}), which turns on
+ * `enable_nested_fields` for the collection. Nested fields carry `output` only
+ * (enforced by `searchSchema`), so they are declared `index: false`: each
+ * referent’s values stay grouped on disk and cost no RAM, exactly like the
+ * display labels.
  */
 export function buildCollectionDefinition(
   searchType: SearchType,
@@ -63,9 +88,20 @@ export function buildCollectionDefinition(
   const collection: CollectionCreateSchema = {
     name: options.name ?? deriveCollectionName(searchType),
     fields: searchType.fields.flatMap((field) =>
-      typesenseFields(field, defaultLocale, options.defaultSortingField),
+      typesenseFields(
+        searchType,
+        field,
+        defaultLocale,
+        options.defaultSortingField,
+        options.schema,
+      ),
     ),
   };
+  // Typesense rejects an `object`/`object[]` field unless nesting is enabled,
+  // so the flag is a consequence of the declaration – never a knob.
+  if (collection.fields?.some((field) => field.type.startsWith('object'))) {
+    collection.enable_nested_fields = true;
+  }
   if (options.defaultSortingField !== undefined) {
     collection.default_sorting_field = options.defaultSortingField;
   }
@@ -75,11 +111,37 @@ export function buildCollectionDefinition(
   return collection;
 }
 
+/**
+ * The {@link ReferenceType} a field nests, or `undefined` when it nests
+ * nothing. Throws when the type surfaces an inline reference the caller gave no
+ * schema to resolve: the collection would silently store the reference as a
+ * string the projection never writes, so every document would fail to import.
+ */
+function nestedTypeOf(
+  searchType: SearchType,
+  field: SearchField,
+  schema: SearchSchema | undefined,
+): ReferenceType | undefined {
+  const nested =
+    schema === undefined ? undefined : nestedReferenceType(schema, field);
+  // Reached only for a field carrying a Role, so an inline reference here is a
+  // surfaced one: `searchSchema` allows an inline reference no Role but
+  // `output`.
+  if (nested === undefined && isInlineReference(field)) {
+    throw new Error(
+      `Building the collection for “${searchType.name}” needs the search schema its surfaced inline reference “${field.name}” resolves against; pass it as the collection-definition option “schema”.`,
+    );
+  }
+  return nested;
+}
+
 /** The physical Typesense fields one declaration produces. */
 function typesenseFields(
+  searchType: SearchType,
   field: SearchField,
   defaultLocale: string | undefined,
   defaultSortingField: string | undefined,
+  schema: SearchSchema | undefined,
 ): CollectionFieldSchema[] {
   // An internal field (no role) is projected as a reading device for the
   // derives and pruned before the writer, so the collection stores nothing for
@@ -87,6 +149,10 @@ function typesenseFields(
   // by, so the index and the document cannot disagree.
   if (isInternalField(field)) {
     return [];
+  }
+  const nested = nestedTypeOf(searchType, field, schema);
+  if (nested !== undefined) {
+    return nestedFields(field.name, field, nested, schema as SearchSchema);
   }
   const names = physicalFields(field);
   if (field.kind === 'text') {
@@ -122,14 +188,12 @@ function typesenseFields(
           ...(locale !== undefined && { stem: true, locale }),
         };
       }),
-      ...names.sort.map(
-        (name): CollectionFieldSchema => ({
-          name,
-          type: 'string',
-          sort: true,
-          optional: true,
-        }),
-      ),
+      ...names.sort.map((name): CollectionFieldSchema => ({
+        name,
+        type: 'string',
+        sort: true,
+        optional: true,
+      })),
     ];
   }
 
@@ -156,6 +220,73 @@ function typesenseFields(
         stem: true,
         locale: defaultLocale,
       }),
+    });
+  }
+  return fields;
+}
+
+/**
+ * The nested object one surfaced inline reference stores, plus one nested
+ * Physical Field per output field of its {@link ReferenceType} – recursing for
+ * a reference type that itself surfaces an inline reference, to the depth the
+ * schema declares (`searchSchema` rejects inline cycles, so the recursion
+ * terminates).
+ *
+ * Everything nested is `index: false`: a nested field carries `output` only, so
+ * it is stored with its referent and read back with it, never searched, faceted
+ * or sorted on. That keeps the RAM lever intact – a nested document is display
+ * weight, like the per-language labels – and lets the declared child types be
+ * exactly what the projection writes without an indexing contract to satisfy.
+ * Declaring the children rather than only the object is what makes the nesting
+ * legible in the collection, and what keeps an {@link isInternalField Internal
+ * Field} inside a Reference Type visibly contributing nothing.
+ */
+function nestedFields(
+  prefix: string,
+  reference: SearchField,
+  referenceType: ReferenceType,
+  schema: SearchSchema,
+): CollectionFieldSchema[] {
+  const array = reference.array === true;
+  const fields: CollectionFieldSchema[] = [
+    {
+      name: prefix,
+      type: array ? 'object[]' : 'object',
+      index: false,
+      optional: reference.required !== true,
+    },
+  ];
+  for (const field of referenceType.fields) {
+    if (isInternalField(field)) {
+      continue;
+    }
+    const nested = nestedReferenceType(schema, field);
+    if (nested !== undefined) {
+      fields.push(
+        ...nestedFields(
+          nestedFieldName(prefix, field.name),
+          field,
+          nested,
+          schema,
+        ),
+      );
+      continue;
+    }
+    // A nested text field stores its display values exactly as a root one does
+    // – one `${name}_<lang>` per present language, matched by one pattern
+    // field – only under the referent’s prefix. It has no search or sort
+    // companions: those are Roles a nested field cannot declare.
+    const pattern =
+      field.kind === 'text' ? displayFieldPattern(field) : undefined;
+    fields.push({
+      name: nestedFieldName(prefix, pattern ?? field.name),
+      type: field.kind === 'text' ? 'string' : typesenseValueType(field),
+      index: false,
+      // Always optional: `required` is a promise about the *referent* (this
+      // value is on every referent), while Typesense’s flag is about the
+      // document. Under a multi-valued reference those are different claims,
+      // and only the referent-level one is the declaration’s.
+      optional: true,
     });
   }
   return fields;

--- a/packages/search-typesense/src/rebuild-support.ts
+++ b/packages/search-typesense/src/rebuild-support.ts
@@ -1,6 +1,9 @@
 import type { Client } from 'typesense';
 import type { SearchType } from '@lde/search';
-import type { CollectionDefinitionOptions } from './collection-definition.js';
+import {
+  buildCollectionDefinition,
+  type CollectionDefinitionOptions,
+} from './collection-definition.js';
 import { deriveCollectionName } from './collection-name.js';
 import { DEFAULT_LOCK_TTL_MS } from './lock.js';
 import { DEFAULT_BATCH_SIZE } from './import.js';
@@ -35,7 +38,12 @@ export interface ResolvedRebuildOptions {
  * when the deployment supplies none.
  *
  * Writers resolve at construction rather than per run, so an underivable name
- * throws when the writer is built, not on the first rebuild.
+ * throws when the writer is built, not on the first rebuild. The collection
+ * definition is built here and discarded for the same reason: every way a
+ * declaration can fail to describe a collection – an unresolvable surfaced
+ * inline reference, whose nesting needs the schema – then fails at construction
+ * rather than inside the first run, after a lock is held and a whole extraction
+ * has been paid for.
  */
 export function resolveRebuildOptions(
   searchType: SearchType,
@@ -46,7 +54,7 @@ export function resolveRebuildOptions(
     lockTtlMs = DEFAULT_LOCK_TTL_MS,
     ...definitionOptions
   } = options;
-  return {
+  const resolved = {
     batchSize,
     lockTtlMs,
     definitionOptions: {
@@ -54,6 +62,8 @@ export function resolveRebuildOptions(
       name: definitionOptions.name ?? deriveCollectionName(searchType),
     },
   };
+  buildCollectionDefinition(searchType, resolved.definitionOptions);
+  return resolved;
 }
 
 /**

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -4,8 +4,10 @@ import {
   type FacetBucket,
   type FacetsOutcome,
   type LocalizedValue,
+  type NestedDocument,
   type Reference,
   type ReferenceField,
+  type ReferenceType,
   type ResultDocument,
   type RootType,
   type RootTypeOf,
@@ -24,9 +26,11 @@ import {
   assertValidQuery,
   displayLangOf,
   fieldNamed,
+  isInlineReference,
   isRangeFacet,
   isUnsatisfiable,
   labelFieldOf,
+  nestedReferenceType,
   outputFields,
   physicalFields,
   referenceFields,
@@ -367,7 +371,7 @@ export function createTypesenseSearchEngine<
           outputReferenceSources.get(searchType.class) ?? [],
         ),
       );
-      return parseSearchResponse(response, searchType, labels);
+      return parseSearchResponse(response, searchType, labels, schema);
     },
     async searchFacets(
       searchType: RootType,
@@ -439,7 +443,8 @@ export function createTypesenseSearchEngine<
                 ),
               }
             : {
-                facets: parseSearchResponse(result, searchType, labels).facets,
+                facets: parseSearchResponse(result, searchType, labels, schema)
+                  .facets,
               };
       });
       return outcomes;
@@ -727,17 +732,21 @@ export interface TypesenseSearchResponse {
  * Reconstruct a Typesense response into the engine-neutral {@link SearchResult}:
  * the flat, fanned-out document is turned back into a logical one (per-locale
  * display fields → a language map, reference IRIs → labelled references via the
- * label-source lookup, scalars passed through). `labels` maps a reference IRI
- * to its resolved label; an IRI absent from it yields an id-only reference.
+ * label-source lookup, nested objects → nested Search Documents, scalars passed
+ * through). `labels` maps a reference IRI to its resolved label; an IRI absent
+ * from it yields an id-only reference. `schema` resolves the Reference Type a
+ * surfaced inline reference nests; without one such a field reconstructs as
+ * nothing rather than as the wrong shape.
  */
 export function parseSearchResponse(
   response: TypesenseSearchResponse,
   searchType: SearchType,
   labels: ReadonlyMap<string, LocalizedValue>,
+  schema?: SearchSchema,
 ): SearchResult {
   const hits: SearchHit[] = (response.hits ?? []).map((hit) => ({
     id: String(hit.document.id),
-    document: reconstructDocument(hit.document, searchType, labels),
+    document: reconstructDocument(hit.document, searchType, labels, schema),
   }));
   // Reference facets are IRI-keyed; their buckets carry a resolved data label.
   // Plain facets (tokens, free strings) carry no label – the consumer owns display.
@@ -779,10 +788,11 @@ function reconstructDocument(
   flat: Record<string, unknown>,
   searchType: SearchType,
   labels: ReadonlyMap<string, LocalizedValue>,
+  schema: SearchSchema | undefined,
 ): ResultDocument {
   const document: Record<string, SearchValue> = {};
   for (const field of outputFields(searchType)) {
-    const value = logicalValue(flat, field, labels);
+    const value = logicalValue(flat, field, labels, schema);
     if (value !== undefined) {
       document[field.name] = value;
     }
@@ -794,12 +804,32 @@ function logicalValue(
   flat: Record<string, unknown>,
   field: SearchField,
   labels: ReadonlyMap<string, LocalizedValue>,
+  schema: SearchSchema | undefined,
 ): SearchValue | undefined {
   switch (field.kind) {
     case 'text':
       return localizedValue(flat, field);
-    case 'reference':
-      return referenceValue(flat, field, labels);
+    case 'reference': {
+      // A surfaced inline reference carries its referent’s own fields, so it
+      // reconstructs as a nested Search Document rather than as an IRI plus a
+      // label. Nesting is rebuilt HERE, below every surface, so a second
+      // surface inherits it instead of reimplementing it (ADR 11).
+      const nested =
+        schema === undefined ? undefined : nestedReferenceType(schema, field);
+      if (nested !== undefined) {
+        return nestedValue(flat[field.name], field, nested, labels, schema!);
+      }
+      // A surfaced inline reference stores nested documents, not IRIs. Without
+      // the schema that declares its reference type there is nothing to
+      // reconstruct them by, so reconstruct nothing rather than hand back the
+      // wrong shape – the same call the projection makes when it is handed no
+      // schema. (Only output fields are reconstructed, and `searchSchema`
+      // allows an inline reference no Role but `output`, so every inline
+      // reference reaching this point is a surfaced one.)
+      return isInlineReference(field)
+        ? undefined
+        : referenceValue(flat, field, labels);
+    }
     case 'keyword': {
       const value = flat[field.name];
       return Array.isArray(value) || typeof value === 'string'
@@ -840,6 +870,43 @@ function localizedValue(
     }
   }
   return Object.keys(map).length > 0 ? map : undefined;
+}
+
+/**
+ * Rebuild a surfaced inline reference from the nested object(s) the engine
+ * stored: one {@link NestedDocument} per referent, each carrying its Reference
+ * Type’s own output fields – so a multi-valued reference keeps every referent’s
+ * values grouped rather than smeared across parallel arrays. `id` is carried
+ * only when the referent had one; a blank-node referent nests without it, since
+ * a nested document is read, not addressed. A nested reference type may itself
+ * surface an inline reference, which recurses through {@link reconstructDocument}.
+ */
+function nestedValue(
+  raw: unknown,
+  field: ReferenceField,
+  referenceType: ReferenceType,
+  labels: ReadonlyMap<string, LocalizedValue>,
+  schema: SearchSchema,
+): SearchValue | undefined {
+  const referents = (Array.isArray(raw) ? raw : [raw]).filter(
+    (referent): referent is Record<string, unknown> =>
+      typeof referent === 'object' && referent !== null,
+  );
+  const documents: NestedDocument[] = referents.map((referent) => {
+    const document = reconstructDocument(
+      referent,
+      referenceType,
+      labels,
+      schema,
+    );
+    return typeof referent.id === 'string'
+      ? { id: referent.id, ...document }
+      : document;
+  });
+  if (documents.length === 0) {
+    return undefined;
+  }
+  return field.array === true ? documents : documents[0];
 }
 
 /** Map stored reference IRIs to labelled references; id-only when no label. */

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -735,14 +735,17 @@ export interface TypesenseSearchResponse {
  * label-source lookup, nested objects → nested Search Documents, scalars passed
  * through). `labels` maps a reference IRI to its resolved label; an IRI absent
  * from it yields an id-only reference. `schema` resolves the Reference Type a
- * surfaced inline reference nests; without one such a field reconstructs as
- * nothing rather than as the wrong shape.
+ * surfaced inline reference nests – required, not optional: reconstruction is a
+ * function of the whole schema exactly as the engine is, and a caller that
+ * omitted it would silently serve nothing for every nested field. A schema that
+ * does not declare a field’s reference type reconstructs nothing for it rather
+ * than the wrong shape, the same call the projection makes.
  */
 export function parseSearchResponse(
   response: TypesenseSearchResponse,
   searchType: SearchType,
   labels: ReadonlyMap<string, LocalizedValue>,
-  schema?: SearchSchema,
+  schema: SearchSchema,
 ): SearchResult {
   const hits: SearchHit[] = (response.hits ?? []).map((hit) => ({
     id: String(hit.document.id),
@@ -788,7 +791,7 @@ function reconstructDocument(
   flat: Record<string, unknown>,
   searchType: SearchType,
   labels: ReadonlyMap<string, LocalizedValue>,
-  schema: SearchSchema | undefined,
+  schema: SearchSchema,
 ): ResultDocument {
   const document: Record<string, SearchValue> = {};
   for (const field of outputFields(searchType)) {
@@ -804,7 +807,7 @@ function logicalValue(
   flat: Record<string, unknown>,
   field: SearchField,
   labels: ReadonlyMap<string, LocalizedValue>,
-  schema: SearchSchema | undefined,
+  schema: SearchSchema,
 ): SearchValue | undefined {
   switch (field.kind) {
     case 'text':
@@ -814,18 +817,17 @@ function logicalValue(
       // reconstructs as a nested Search Document rather than as an IRI plus a
       // label. Nesting is rebuilt HERE, below every surface, so a second
       // surface inherits it instead of reimplementing it (ADR 11).
-      const nested =
-        schema === undefined ? undefined : nestedReferenceType(schema, field);
+      const nested = nestedReferenceType(schema, field);
       if (nested !== undefined) {
-        return nestedValue(flat[field.name], field, nested, labels, schema!);
+        return nestedValue(flat[field.name], field, nested, labels, schema);
       }
-      // A surfaced inline reference stores nested documents, not IRIs. Without
-      // the schema that declares its reference type there is nothing to
-      // reconstruct them by, so reconstruct nothing rather than hand back the
-      // wrong shape – the same call the projection makes when it is handed no
-      // schema. (Only output fields are reconstructed, and `searchSchema`
-      // allows an inline reference no Role but `output`, so every inline
-      // reference reaching this point is a surfaced one.)
+      // A surfaced inline reference stores nested documents, not IRIs, so a
+      // schema that does not declare its reference type (a type parsed against
+      // a foreign schema) reconstructs nothing rather than the wrong shape –
+      // the same call the projection makes. Only output fields are
+      // reconstructed, and `searchSchema` allows an inline reference no Role
+      // but `output`, so every inline reference reaching this point is a
+      // surfaced one.
       return isInlineReference(field)
         ? undefined
         : referenceValue(flat, field, labels);

--- a/packages/search-typesense/test/collection-definition.test.ts
+++ b/packages/search-typesense/test/collection-definition.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { SearchType } from '@lde/search';
+import { defineSearchType, searchSchema, type SearchType } from '@lde/search';
 import { buildCollectionDefinition } from '../src/collection-definition.js';
 
 const schema: SearchType = {
@@ -317,5 +317,189 @@ describe('internal fields', () => {
         optional: true,
       },
     ]);
+  });
+});
+
+describe('surfaced inline references', () => {
+  const mediaObject = defineSearchType({
+    name: 'MediaObject',
+    fields: [
+      {
+        name: 'contentUrl',
+        kind: 'keyword',
+        array: true,
+        output: true,
+        path: 'https://schema.org/contentUrl',
+      },
+      {
+        name: 'width',
+        kind: 'integer',
+        output: true,
+        path: 'https://schema.org/width',
+      },
+      {
+        name: 'caption',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        path: 'https://schema.org/caption',
+      },
+      // No role: the reading device an inline reference is the other half of.
+      { name: 'rawWidth', kind: 'keyword', path: 'https://schema.org/width' },
+    ],
+  });
+
+  const creativeWorkWith = (media: Record<string, unknown>) =>
+    defineSearchType({
+      name: 'CreativeWork',
+      class: 'https://schema.org/CreativeWork',
+      fields: [
+        {
+          name: 'media',
+          kind: 'reference',
+          output: true,
+          path: 'https://schema.org/associatedMedia',
+          ref: { typeName: 'MediaObject', strategy: 'inline' },
+          ...media,
+        },
+      ],
+    });
+
+  const definitionFor = (media: Record<string, unknown>) => {
+    const creativeWork = creativeWorkWith(media);
+    return buildCollectionDefinition(creativeWork, {
+      name: 'works',
+      schema: searchSchema(creativeWork, mediaObject),
+    });
+  };
+
+  it('stores a multi-valued inline reference as one nested object per referent', () => {
+    const collection = definitionFor({ array: true });
+    // `object[]` – each referent keeps its own values grouped, so a consumer
+    // never pairs parallel arrays by index. Everything nested is un-indexed:
+    // a nested field carries `output` only, so it is display weight on disk.
+    expect(collection.fields).toEqual([
+      { name: 'media', type: 'object[]', index: false, optional: true },
+      {
+        name: 'media.contentUrl',
+        type: 'string[]',
+        index: false,
+        optional: true,
+      },
+      { name: 'media.width', type: 'int64', index: false, optional: true },
+      // A nested text field stores its display values exactly as a root one
+      // does – one field per present language, matched by one pattern.
+      {
+        name: 'media.caption_[^_]+',
+        type: 'string',
+        index: false,
+        optional: true,
+      },
+    ]);
+    // The nested object types are what turn nesting on; Typesense rejects them
+    // otherwise.
+    expect(collection.enable_nested_fields).toBe(true);
+  });
+
+  it('stores a single-valued inline reference as one nested object', () => {
+    expect(definitionFor({}).fields?.[0]).toEqual({
+      name: 'media',
+      type: 'object',
+      index: false,
+      optional: true,
+    });
+    expect(definitionFor({ required: true }).fields?.[0]).toEqual({
+      name: 'media',
+      type: 'object',
+      index: false,
+      optional: false,
+    });
+  });
+
+  it('contributes nothing for an internal field inside a reference type', () => {
+    // `rawWidth` declares no role, so the invariant *a field without a role
+    // reaches neither the engine nor the API* holds at nesting depth too.
+    expect(definitionFor({}).fields).not.toContainEqual(
+      expect.objectContaining({ name: 'media.rawWidth' }),
+    );
+  });
+
+  it('nests a reference type that itself surfaces an inline reference', () => {
+    const thumbnail = defineSearchType({
+      name: 'Thumbnail',
+      fields: [
+        {
+          name: 'contentUrl',
+          kind: 'keyword',
+          output: true,
+          path: 'https://schema.org/contentUrl',
+        },
+      ],
+    });
+    const media = defineSearchType({
+      name: 'MediaObject',
+      fields: [
+        {
+          name: 'thumbnail',
+          kind: 'reference',
+          array: true,
+          output: true,
+          path: 'https://schema.org/thumbnail',
+          ref: { typeName: 'Thumbnail', strategy: 'inline' },
+        },
+      ],
+    });
+    const creativeWork = creativeWorkWith({});
+    const collection = buildCollectionDefinition(creativeWork, {
+      name: 'works',
+      schema: searchSchema(creativeWork, media, thumbnail),
+    });
+    expect(collection.fields).toEqual([
+      { name: 'media', type: 'object', index: false, optional: true },
+      {
+        name: 'media.thumbnail',
+        type: 'object[]',
+        index: false,
+        optional: true,
+      },
+      {
+        name: 'media.thumbnail.contentUrl',
+        type: 'string',
+        index: false,
+        optional: true,
+      },
+    ]);
+  });
+
+  it('rejects building a collection for a nesting type without its schema', () => {
+    // Without the schema the nesting is invisible: the collection would declare
+    // the reference as a string the projection never writes, and every document
+    // would fail to import. Fail where the collection is built instead.
+    expect(() =>
+      buildCollectionDefinition(creativeWorkWith({}), { name: 'works' }),
+    ).toThrow(/needs the search schema.*“media”/);
+  });
+
+  it('leaves a reading-device inline reference out of the collection', () => {
+    // No role: pruned before the writer, so nothing is stored – no nested
+    // object, and no nesting flag on the collection.
+    const creativeWork = defineSearchType({
+      name: 'CreativeWork',
+      class: 'https://schema.org/CreativeWork',
+      fields: [
+        {
+          name: 'media',
+          kind: 'reference',
+          path: 'https://schema.org/associatedMedia',
+          ref: { typeName: 'MediaObject', strategy: 'inline' },
+        },
+      ],
+    });
+    const collection = buildCollectionDefinition(creativeWork, {
+      name: 'works',
+      schema: searchSchema(creativeWork, mediaObject),
+    });
+    expect(collection.fields).toEqual([]);
+    expect(collection.enable_nested_fields).toBeUndefined();
   });
 });

--- a/packages/search-typesense/test/collection-definition.test.ts
+++ b/packages/search-typesense/test/collection-definition.test.ts
@@ -431,6 +431,7 @@ describe('surfaced inline references', () => {
         {
           name: 'contentUrl',
           kind: 'keyword',
+          array: true,
           output: true,
           path: 'https://schema.org/contentUrl',
         },
@@ -464,7 +465,7 @@ describe('surfaced inline references', () => {
       },
       {
         name: 'media.thumbnail.contentUrl',
-        type: 'string',
+        type: 'string[]',
         index: false,
         optional: true,
       },

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -133,7 +133,12 @@ const response = {
 };
 
 describe('parseSearchResponse', () => {
-  const result = parseSearchResponse(response, schema, labels);
+  const result = parseSearchResponse(
+    response,
+    schema,
+    labels,
+    searchSchema(organization, schema),
+  );
 
   it('carries the total and the facet buckets keyed by field name', () => {
     expect(result.total).toBe(2);
@@ -307,14 +312,16 @@ describe('parseSearchResponse nested inline references', () => {
     expect(hits[0].document.primaryMedia).toBeUndefined();
   });
 
-  it('reconstructs nothing for a nested reference without the schema declaring it', () => {
-    // No schema means no reference type to rebuild the referents by. Serving
-    // nothing is the same call the projection makes when it is handed no
-    // schema; the alternative is handing a consumer the wrong shape.
+  it('reconstructs nothing for a nested reference the schema does not declare', () => {
+    // A schema without the reference type – a type parsed against a foreign
+    // schema – has nothing to rebuild the referents by. Serving nothing is the
+    // same call the projection makes; the alternative is handing a consumer the
+    // wrong shape.
     const { hits } = parseSearchResponse(
       nestedResponse,
       creativeWork,
       new Map(),
+      searchSchema({ name: 'Other', class: 'urn:other', fields: [] }),
     );
     expect(hits[0].document.media).toBeUndefined();
     expect(hits[0].document.primaryMedia).toBeUndefined();
@@ -357,7 +364,12 @@ describe('parseSearchResponse range facets', () => {
   };
 
   it('echoes each range bin’s half-open bounds onto its bucket, open ends omitted', () => {
-    const result = parseSearchResponse(rangeResponse, rangeSchema, new Map());
+    const result = parseSearchResponse(
+      rangeResponse,
+      rangeSchema,
+      new Map(),
+      searchSchema(rangeSchema),
+    );
     expect(result.facets.size).toEqual([
       { value: '0', count: 2, min: 1, max: 10 },
       { value: '1', count: 1, min: 10, max: 100 },
@@ -942,6 +954,23 @@ describe('fetchLabels', () => {
 });
 
 describe('und-locale text reconstruction', () => {
+  const undDoc = defineSearchType({
+    name: 'Doc',
+    class: 'urn:example:Doc',
+    fields: [
+      { name: 'summary', kind: 'text', locales: ['und'], output: true },
+      // A non-string stored value for a text field is dropped.
+      { name: 'bad', kind: 'text', locales: ['und'], output: true },
+      // A single (non-array) stored reference IRI.
+      {
+        name: 'publisher',
+        kind: 'reference',
+        output: true,
+        ref: { typeName: 'Organization', strategy: 'labelOnly' },
+      },
+    ],
+  });
+
   it('gathers the und display field into the language map', () => {
     const result = parseSearchResponse(
       {
@@ -957,23 +986,9 @@ describe('und-locale text reconstruction', () => {
           },
         ],
       },
-      {
-        name: 'Doc',
-        class: 'urn:example:Doc',
-        fields: [
-          { name: 'summary', kind: 'text', locales: ['und'], output: true },
-          // A non-string stored value for a text field is dropped.
-          { name: 'bad', kind: 'text', locales: ['und'], output: true },
-          // A single (non-array) stored reference IRI.
-          {
-            name: 'publisher',
-            kind: 'reference',
-            output: true,
-            ref: { typeName: 'Organization', strategy: 'labelOnly' },
-          },
-        ],
-      },
+      undDoc,
       new Map(),
+      searchSchema(undDoc),
     );
     expect(result.hits[0].document.summary).toEqual({ und: ['Plain prose'] });
     expect(result.hits[0].document).not.toHaveProperty('bad');

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  defineSearchType,
   searchSchema,
   type LocalizedValue,
   type SearchQuery,
@@ -188,6 +189,135 @@ describe('parseSearchResponse', () => {
     expect(result.hits[0].document.iiif).toBe(true);
     expect(result.hits[1].document.iiif).toBe(false);
     expect(result.hits[0].document.status).toBeUndefined();
+  });
+});
+
+describe('parseSearchResponse nested inline references', () => {
+  const mediaObject = defineSearchType({
+    name: 'MediaObject',
+    fields: [
+      {
+        name: 'contentUrl',
+        kind: 'keyword',
+        array: true,
+        output: true,
+        path: 'https://schema.org/contentUrl',
+      },
+      {
+        name: 'width',
+        kind: 'integer',
+        output: true,
+        path: 'https://schema.org/width',
+      },
+      {
+        name: 'caption',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        path: 'https://schema.org/caption',
+      },
+    ],
+  });
+  const creativeWork = defineSearchType({
+    name: 'CreativeWork',
+    class: 'https://schema.org/CreativeWork',
+    fields: [
+      {
+        name: 'media',
+        kind: 'reference',
+        array: true,
+        output: true,
+        path: 'https://schema.org/associatedMedia',
+        ref: { typeName: 'MediaObject', strategy: 'inline' },
+      },
+      {
+        name: 'primaryMedia',
+        kind: 'reference',
+        output: true,
+        path: 'https://schema.org/primaryImageOfPage',
+        ref: { typeName: 'MediaObject', strategy: 'inline' },
+      },
+    ],
+  });
+  const nestedSchema = searchSchema(creativeWork, mediaObject);
+  const nestedResponse = {
+    found: 1,
+    hits: [
+      {
+        document: {
+          id: 'https://ex/w/1',
+          media: [
+            {
+              id: 'https://ex/m/1',
+              contentUrl: ['https://ex/1.jpg'],
+              width: 4096,
+              caption_nl: 'Voorkant',
+            },
+            // A blank-node referent (no id) missing the optional width.
+            { contentUrl: ['https://ex/2.jpg'] },
+          ],
+          primaryMedia: { contentUrl: ['https://ex/1.jpg'], width: 4096 },
+        },
+      },
+    ],
+  };
+
+  it('reconstructs each referent as a nested document, values grouped per referent', () => {
+    const { hits } = parseSearchResponse(
+      nestedResponse,
+      creativeWork,
+      new Map(),
+      nestedSchema,
+    );
+    // One document per referent – never two parallel arrays a consumer has to
+    // pair by index. `id` is carried only by the referent that had one: a
+    // nested document is read, not addressed.
+    expect(hits[0].document.media).toEqual([
+      {
+        id: 'https://ex/m/1',
+        contentUrl: ['https://ex/1.jpg'],
+        width: 4096,
+        caption: { nl: ['Voorkant'] },
+      },
+      { contentUrl: ['https://ex/2.jpg'] },
+    ]);
+  });
+
+  it('reconstructs a single-valued inline reference as one nested document', () => {
+    const { hits } = parseSearchResponse(
+      nestedResponse,
+      creativeWork,
+      new Map(),
+      nestedSchema,
+    );
+    expect(hits[0].document.primaryMedia).toEqual({
+      contentUrl: ['https://ex/1.jpg'],
+      width: 4096,
+    });
+  });
+
+  it('omits an inline reference the document carries no referent for', () => {
+    const { hits } = parseSearchResponse(
+      { found: 1, hits: [{ document: { id: 'https://ex/w/2', media: [] } }] },
+      creativeWork,
+      new Map(),
+      nestedSchema,
+    );
+    expect(hits[0].document.media).toBeUndefined();
+    expect(hits[0].document.primaryMedia).toBeUndefined();
+  });
+
+  it('reconstructs nothing for a nested reference without the schema declaring it', () => {
+    // No schema means no reference type to rebuild the referents by. Serving
+    // nothing is the same call the projection makes when it is handed no
+    // schema; the alternative is handing a consumer the wrong shape.
+    const { hits } = parseSearchResponse(
+      nestedResponse,
+      creativeWork,
+      new Map(),
+    );
+    expect(hits[0].document.media).toBeUndefined();
+    expect(hits[0].document.primaryMedia).toBeUndefined();
   });
 });
 

--- a/packages/search-typesense/test/search-engine.test.ts
+++ b/packages/search-typesense/test/search-engine.test.ts
@@ -27,6 +27,27 @@ const organizationSchema: SearchType = {
   ],
 };
 
+// The shape a surfaced inline reference carries: a Reference Type, declaring
+// no class, reached only through `Dataset.media`.
+const mediaObjectSchema: SearchType = {
+  name: 'MediaObject',
+  fields: [
+    {
+      name: 'contentUrl',
+      kind: 'keyword',
+      array: true,
+      output: true,
+      path: 'https://schema.org/contentUrl',
+    },
+    {
+      name: 'width',
+      kind: 'integer',
+      output: true,
+      path: 'https://schema.org/width',
+    },
+  ],
+};
+
 const datasetSchema: SearchType = {
   name: 'Dataset',
   class: 'http://www.w3.org/ns/dcat#Dataset',
@@ -57,6 +78,14 @@ const datasetSchema: SearchType = {
       ref: { typeName: 'Agent', strategy: 'labelOnly' },
       labelSource: 'Organization',
     },
+    {
+      name: 'media',
+      kind: 'reference',
+      array: true,
+      output: true,
+      path: 'https://schema.org/associatedMedia',
+      ref: { typeName: 'MediaObject', strategy: 'inline' },
+    },
     { name: 'status', kind: 'keyword', facetable: true, filterable: true },
     { name: 'statusRank', kind: 'integer', sortable: true },
   ],
@@ -75,6 +104,17 @@ const documents = [
     keyword: ['kaarten'],
     keyword_search: ['kaarten'],
     publisher: ['https://org/1'],
+    // A surfaced inline reference: one nested document per referent, exactly as
+    // the projection nests them. The second referent is a blank node in the
+    // source, so it carries no `id`, and it has no width.
+    media: [
+      {
+        id: 'https://ex/m/1',
+        contentUrl: ['https://ex/1/full/max/0/default.jpg'],
+        width: 4096,
+      },
+      { contentUrl: ['https://ex/2/full/max/0/default.jpg'] },
+    ],
     status: 'valid',
     statusRank: 0,
   },
@@ -132,6 +172,12 @@ const baseQuery: SearchQuery = {
   locale: 'nl',
 };
 
+const fullSchema = searchSchema(
+  organizationSchema,
+  mediaObjectSchema,
+  datasetSchema,
+);
+
 describe('createTypesenseSearchEngine (integration)', () => {
   const container = new TypesenseContainer();
   let client: Client;
@@ -145,6 +191,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
         name: 'datasets',
         defaultSortingField: 'statusRank',
         defaultLocale: 'nl',
+        schema: fullSchema,
       }),
     );
     // The label source's collection comes from the same declarative source.
@@ -162,13 +209,9 @@ describe('createTypesenseSearchEngine (integration)', () => {
       .documents()
       .import(labelDocuments, { action: 'create' });
 
-    engine = createTypesenseSearchEngine(
-      client,
-      searchSchema(organizationSchema, datasetSchema),
-      {
-        collections: { Dataset: 'datasets', Organization: 'labels' },
-      },
-    );
+    engine = createTypesenseSearchEngine(client, fullSchema, {
+      collections: { Dataset: 'datasets', Organization: 'labels' },
+    });
   }, 120_000);
 
   afterAll(async () => {
@@ -205,6 +248,32 @@ describe('createTypesenseSearchEngine (integration)', () => {
     expect(result.hits[1].document.publisher).toEqual([
       { id: 'https://org/1', label: { nl: ['Het Utrechts Archief'] } },
     ]);
+  });
+
+  it('serves a surfaced inline reference as nested documents, values grouped per referent', async () => {
+    // End to end through a real Typesense: the collection declares the nested
+    // object and its nested Physical Fields, the referents survive the
+    // round-trip grouped, and reconstruction hands back one nested Search
+    // Document per referent – `id` only on the referent that had one.
+    const result = await engine.search(datasetSchema, {
+      ...baseQuery,
+      where: [{ field: 'id', in: ['d1'] }],
+    });
+
+    expect(result.hits[0].document.media).toEqual([
+      {
+        id: 'https://ex/m/1',
+        contentUrl: ['https://ex/1/full/max/0/default.jpg'],
+        width: 4096,
+      },
+      { contentUrl: ['https://ex/2/full/max/0/default.jpg'] },
+    ]);
+    // A document without referents nests nothing rather than an empty list.
+    const others = await engine.search(datasetSchema, {
+      ...baseQuery,
+      where: [{ field: 'id', in: ['d2'] }],
+    });
+    expect(others.hits[0].document.media).toBeUndefined();
   });
 
   it('looks documents up by `id`, the field no type declares', async () => {
@@ -385,7 +454,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
     const ignored: unknown[] = [];
     const reporting = createTypesenseSearchEngine(
       client,
-      searchSchema(organizationSchema, datasetSchema),
+      searchSchema(organizationSchema, mediaObjectSchema, datasetSchema),
       {
         collections: { Dataset: 'datasets', Organization: 'labels' },
         onIgnoredFilter: (filter) => ignored.push(filter),

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these – see AGENTS.md.
-          functions: 98.72,
-          lines: 99.07,
-          branches: 94.07,
-          statements: 99.09,
+          functions: 98.77,
+          lines: 99.12,
+          branches: 94.73,
+          statements: 99.14,
         },
       },
     },

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -20,7 +20,7 @@ export default mergeConfig(
           // partial vitest run must never rewrite these – see AGENTS.md.
           functions: 98.77,
           lines: 99.12,
-          branches: 94.73,
+          branches: 94.7,
           statements: 99.14,
         },
       },

--- a/packages/search/CONTEXT.md
+++ b/packages/search/CONTEXT.md
@@ -113,7 +113,15 @@ apart only by Roles:
   _qualified_ hop by inlining the intermediate node with its discriminator, then
   let a **Derive** select and flatten it. Pruned before the writer – nothing
   nested reaches the engine or the API.
-- _API device_ (`output`): deliberately surface a nested Reference Type.
+- _API device_ (`output`): surface a **Nested Search Document** – the referent’s
+  own Search Fields, stored, reconstructed and served as one object per referent,
+  so a multi-valued reference never becomes parallel arrays to pair by index.
+
+Those are its only two shapes. A Nested Search Document carries the Role
+`output` and nothing else: it is stored with its referent and read back with it,
+never as an addressable field of its own, so `searchable`, `filterable`,
+`facetable`, `sortable` and a Label Source are rejected by `searchSchema` –
+inside the Reference Type and on the Inline Reference itself.
 
 A referent needs **no identity**: nesting carries the referent’s fields, not a
 document key. A blank-node referent nests exactly like a named one, minus the
@@ -155,11 +163,19 @@ only for searching: retrieval (`output`) is as much its job. Bare `Document`
 would also shadow the DOM global, and the browser query path reads this package.
 _Avoid_: document (unqualified), record, row, hit
 
+**Search Document**, nested:
+The referent of a surfaced Inline Reference, carried inside its Search Document.
+Keyed by the referent’s own field names, and carrying an `Id` only when the
+referent is a named node – a nested document is read, not addressed.
+_Avoid_: sub-document, embedded record
+
 **Physical Field**:
 A field the engine actually stores – `title_search_nl`, `title_sort_nl`,
 `title_nl`. One Search Field fans out into several; `physicalFields()` owns the
 convention, so the projection, the collection definition and the query compiler
-cannot disagree.
+cannot disagree. A nested one qualifies the referent’s own physical name with
+the reference carrying it (`media.contentUrl`), owned by `nestedFieldName()` for
+the same reason.
 _Avoid_: column, engine field
 
 ## Flagged ambiguities

--- a/packages/search/src/adapter.ts
+++ b/packages/search/src/adapter.ts
@@ -20,6 +20,8 @@ export {
   outputFields,
   isInternalField,
   isInlineReference,
+  nestedReferenceType,
+  nestedFieldName,
   referenceFields,
   referenceTypeNamed,
   inlineFramingDepth,

--- a/packages/search/src/engine.ts
+++ b/packages/search/src/engine.ts
@@ -77,8 +77,7 @@ export interface SearchEngine<
  * the failed query. Discriminate with `'error' in outcome`.
  */
 export type FacetsOutcome<FacetField extends string = string> =
-  | { readonly facets: FacetMap<FacetField> }
-  | { readonly error: unknown };
+  { readonly facets: FacetMap<FacetField> } | { readonly error: unknown };
 
 /** What an engine returns: logical hits, a total, and the requested facets. */
 export interface SearchResult<
@@ -150,7 +149,24 @@ export type SearchValue =
   | readonly string[]
   | LocalizedValue
   | Reference
-  | readonly Reference[];
+  | readonly Reference[]
+  | NestedDocument
+  | readonly NestedDocument[];
+
+/**
+ * A **nested Search Document**: the referent of a surfaced (`output`) inline
+ * reference, carrying its Reference Type’s own output fields – each referent’s
+ * values grouped together, so a multi-valued reference never degrades into
+ * parallel arrays a consumer has to pair by index.
+ *
+ * `id` is present only when the referent is a named node: nesting carries the
+ * referent’s fields, not a document key, so a blank-node referent nests exactly
+ * like a named one, minus the `id`. Distinct from {@link Reference}, which is
+ * what an `idOnly`/`labelOnly` reference carries – there the IRI *is* the value.
+ */
+export interface NestedDocument {
+  readonly [field: string]: SearchValue | undefined;
+}
 
 /**
  * A JSON-LD-style language map (`@container: @language`, `@set` arrays); the key

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -53,6 +53,7 @@ export type {
   SearchValue,
   LocalizedValue,
   Reference,
+  NestedDocument,
   FacetBucket,
   FacetMap,
   FacetsOutcome,

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -298,10 +298,20 @@ function foldedSearchValue(values: readonly string[]): string {
 }
 
 /**
- * Project a faceted multi-value field: dedupe (after the optional transform),
- * write the value field, and – when `searchable` – a folded `${name}_search`
- * array. `keyword` reads literals; `reference` reads IRIs (the caller passes the
+ * Project a faceted field: dedupe (after the optional transform), write the
+ * value field, and – when `searchable` – its folded `${name}_search` companion.
+ * `keyword` reads literals; `reference` reads IRIs (the caller passes the
  * already-read raw values).
+ *
+ * **`array` decides the shape**, as it does for every other kind: a declared
+ * `array` field stores a list, and a single-valued one stores the first value –
+ * the graph may still carry several, exactly as it may carry several literals
+ * for a single-valued `integer` or `date` (which take the first too). Honouring
+ * it here is what keeps the projection, the engine collection definition
+ * (`string` vs `string[]`) and the API output type saying the same thing about
+ * one declaration; a list written into a single-valued field is a document the
+ * engine rejects, or – where it does not type-check, as inside a nested
+ * document – a value the API cannot serialize.
  */
 function applyFacet(
   document: ProjectedNode,
@@ -309,13 +319,18 @@ function applyFacet(
   field: KeywordField | ReferenceField,
 ): void {
   const values = dedupe(field.transform ? raw.map(field.transform) : raw);
-  setArray(document, field.name, values);
+  const folded = dedupe(values.map((value) => fold(value)));
+  const searchField = physicalFields(field).search[0];
+  if (field.array === true) {
+    setArray(document, field.name, values);
+    if (field.searchable) {
+      setArray(document, searchField, folded);
+    }
+    return;
+  }
+  setString(document, field.name, values[0]);
   if (field.searchable) {
-    setArray(
-      document,
-      physicalFields(field).search[0],
-      dedupe(values.map((value) => fold(value))),
-    );
+    setString(document, searchField, folded[0]);
   }
 }
 

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -79,7 +79,10 @@ export interface SearchFieldBase {
   /** Framed-IR predicate IRI to project from. Omit for a field populated by
    *  {@link SearchFieldBase.derive} (or outside the projection entirely). */
   readonly path?: string;
-  /** Multi-valued. */
+  /** Multi-valued: the field stores a list. Single-valued (the default) stores
+   *  the FIRST value the graph carries, whatever their number – for every kind
+   *  alike – so one declaration cannot mean a list to the projection and a
+   *  scalar to the collection definition and the API. */
   readonly array?: boolean;
   /** Always present: a non-null scalar in the API output and
    *  a non-optional field in the engine index. Moot for arrays/booleans/`id`,

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -391,6 +391,7 @@ export function searchSchema<const Types extends readonly SearchType[]>(
       .map((searchType) => [searchType.name, searchType]),
   );
   assertResolvableInlineReferences(types, referenceTypes);
+  assertServiceableNestedFields(referenceTypes);
   assertResolvableLabelSources(types);
   // The one blessed cast: only this validated constructor mints the brand.
   const schema = new Map(
@@ -423,6 +424,45 @@ export function isInlineReference(
   readonly ref: { readonly typeName: string; readonly strategy: 'inline' };
 } {
   return field.kind === 'reference' && field.ref?.strategy === 'inline';
+}
+
+/**
+ * The {@link ReferenceType} a **surfaced** inline reference nests – an
+ * `output` inline reference’s referent shape – or `undefined` for every other
+ * field. The one predicate the collection definition, result reconstruction and
+ * the API surfaces share, so they cannot disagree about which fields carry a
+ * nested Search Document and which carry a bare IRI: an inline reference
+ * declaring no Role is a reading device, pruned before the writer
+ * ({@link isInternalField}), and a `labelOnly`/`idOnly` reference stays an id
+ * (plus a resolved label).
+ *
+ * A schema built by {@link searchSchema} always resolves the reference type of
+ * its own types; `undefined` for a type declared against another schema.
+ */
+export function nestedReferenceType(
+  schema: SearchSchema,
+  field: SearchField,
+): ReferenceType | undefined {
+  return isInlineReference(field) && field.output === true
+    ? referenceTypeNamed(schema, field.ref.typeName)
+    : undefined;
+}
+
+/**
+ * The Physical Field name a nested field carries in the engine: the surfaced
+ * inline reference’s own name, then the referent’s physical name –
+ * `media.contentUrl`, `media.label_nl`, and `media.thumbnail.contentUrl` one
+ * hop deeper. The nested counterpart of {@link physicalFields}, and equally the
+ * single home of its convention: the collection definition declares these
+ * names, so a second consumer (a nested filter compiler) reads them from here
+ * rather than restating the separator.
+ *
+ * The nested Search Document itself is keyed by the referent’s own field names
+ * ({@link ProjectedNode}) – the qualification is how an engine that stores
+ * nested documents flat addresses them, never what the projection writes.
+ */
+export function nestedFieldName(parent: string, name: string): string {
+  return `${parent}.${name}`;
 }
 
 /**
@@ -484,6 +524,21 @@ function assertResolvableInlineReferences(
           `Inline reference “${searchType.name}.${field.name}” names “${field.ref.typeName}”, which is not a declared reference type; declare a reference type (a SearchType with no class) with that name.`,
         );
       }
+      // The two jobs of an inline reference, told apart only by Roles: a
+      // reading device (no Role, pruned before the writer) or a surfaced nested
+      // object (`output`). Anything else asks an engine to search, filter,
+      // facet or sort on a value that is stored as a nested document – which no
+      // query compiler serves, so it would be ignored per query.
+      const extraRoles = unserviceableNestedRoles(field);
+      if (extraRoles.length > 0) {
+        throw new Error(
+          `Inline reference “${searchType.name}.${field.name}” declares ${extraRoles
+            .map((role) => `“${role}”`)
+            .join(
+              ', ',
+            )}, which it cannot serve: an inline reference is either a reading device (no Role) or surfaced (“output”).`,
+        );
+      }
     }
   }
   for (const referenceType of referenceTypes.values()) {
@@ -512,6 +567,66 @@ function assertNoInlineCycle(
     assertNoInlineCycle(referent, referenceTypes, extended);
   }
 }
+
+/**
+ * Every field of a {@link ReferenceType} must be one the nesting can actually
+ * serve. A nested field carries **`output` only**: it is stored as part of its
+ * referent and read back with it, so it never becomes an indexed, addressable
+ * field of its own. `searchable`, `filterable`, `facetable` and `sortable` on a
+ * nested field would need query-compiler and engine support that no engine port
+ * declares, and a `labelSource` would need a label lookup no reconstruction
+ * runs – each would be silently ignored per query. A Role-less field stays an
+ * {@link isInternalField Internal Field}, the reading device that is the other
+ * half of an inline reference’s job.
+ *
+ * Checked schema-wide, like the label sources and for the same reason: a single
+ * declaration cannot see whether it is a Reference Type at all.
+ */
+function assertServiceableNestedFields(
+  referenceTypes: ReadonlyMap<string, ReferenceType>,
+): void {
+  for (const referenceType of referenceTypes.values()) {
+    for (const field of referenceType.fields) {
+      const unserviceable = unserviceableNestedRoles(field);
+      if (unserviceable.length > 0) {
+        throw new Error(
+          `Nested field “${referenceType.name}.${field.name}” declares ${unserviceable
+            .map((role) => `“${role}”`)
+            .join(
+              ', ',
+            )}, which an inline reference cannot serve; a nested field carries “output” only.`,
+        );
+      }
+      if (
+        (field as { readonly labelSource?: string }).labelSource !== undefined
+      ) {
+        throw new Error(
+          `Nested field “${referenceType.name}.${field.name}” declares a label source, which an inline reference cannot serve; nest the referent through an inline reference instead of resolving a label for it.`,
+        );
+      }
+    }
+  }
+}
+
+/** The Roles a field declares that nesting cannot serve – every Role but
+ *  `output`, in declaration order, so a message names them all at once. */
+function unserviceableNestedRoles(
+  field: SearchField,
+): readonly (typeof UNSERVICEABLE_NESTED_ROLES)[number][] {
+  return UNSERVICEABLE_NESTED_ROLES.filter((role) =>
+    role === 'searchable'
+      ? field.searchable !== undefined
+      : field[role] === true,
+  );
+}
+
+/** The Roles a nested field cannot carry – everything but `output`. */
+const UNSERVICEABLE_NESTED_ROLES = [
+  'searchable',
+  'filterable',
+  'facetable',
+  'sortable',
+] as const;
 
 /**
  * The text field a label source serves labels from – the ‘label’ convention

--- a/packages/search/src/testing.ts
+++ b/packages/search/src/testing.ts
@@ -10,7 +10,11 @@ import {
   facetableFields,
   filterableFields,
   ID_FIELD,
+  nestedReferenceType,
+  outputFields,
   type RootType,
+  type SearchField,
+  type SearchType,
 } from './schema.js';
 
 /**
@@ -184,6 +188,57 @@ export function describeSearchEngineContract(
         await expect(engine().searchFacets(searchType, [])).resolves.toEqual(
           [],
         );
+      }
+    });
+
+    it('serves a surfaced inline reference as nested documents, never a bare IRI', async () => {
+      // The API device of an Inline Reference (ADR 11): a reference declared
+      // `inline` with `output` reaches the caller as its referent’s own fields,
+      // grouped per referent. Every engine owes that shape – reconstruction
+      // lives below the surfaces, so a surface never has to rebuild it – and an
+      // adapter that stores the reference as an IRI fails here rather than in
+      // one deployment’s UI.
+      for (const searchType of types()) {
+        const nested: { field: SearchField; referenceType: SearchType }[] = [];
+        for (const field of searchType.fields) {
+          const referenceType = nestedReferenceType(engine().schema, field);
+          if (referenceType !== undefined) {
+            nested.push({ field, referenceType });
+          }
+        }
+        if (nested.length === 0) {
+          continue;
+        }
+        const result = await engine().search(searchType, {
+          ...browse(searchType),
+          limit: 20,
+        });
+        for (const hit of result.hits) {
+          for (const { field, referenceType } of nested) {
+            const value = hit.document[field.name];
+            if (value === undefined) {
+              continue; // A referent-less document nests nothing.
+            }
+            // A multi-valued reference keeps one document per referent, so a
+            // consumer never pairs parallel arrays by index.
+            expect(Array.isArray(value)).toBe(field.array === true);
+            const referents = (
+              Array.isArray(value) ? value : [value]
+            ) as Record<string, unknown>[];
+            const declared = new Set([
+              ID_FIELD,
+              ...outputFields(referenceType).map(
+                (nestedField) => nestedField.name,
+              ),
+            ]);
+            for (const referent of referents) {
+              expect(referent).toBeTypeOf('object');
+              expect(
+                Object.keys(referent).every((key) => declared.has(key)),
+              ).toBe(true);
+            }
+          }
+        }
       }
     });
 

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -67,16 +67,24 @@ const fields: SearchField[] = [
     name: 'keyword',
     path: dcat.keyword.value,
     kind: 'keyword',
+    array: true,
     searchable: { weight: 1 },
   },
   {
     name: 'format',
     path: `${DR}format`,
     kind: 'keyword',
+    array: true,
     facetable: true,
     transform: (value) => value.replace(IANA, ''),
   },
-  { name: 'class', path: `${DR}class`, kind: 'reference', facetable: true },
+  {
+    name: 'class',
+    path: `${DR}class`,
+    kind: 'reference',
+    array: true,
+    facetable: true,
+  },
   {
     name: 'date_posted',
     path: `${DR}datePosted`,
@@ -117,7 +125,8 @@ describe('projectDocument', () => {
     expect(document.publisherName_nl).toBe('Erfgoed');
     expect(document.publisherName_search_nl).toBe('erfgoed');
     expect(document.publisherName_en).toBeUndefined();
-    expect(document.publisher).toEqual(['https://ex/o/1']);
+    // Single-valued by declaration → the value itself, like every other kind.
+    expect(document.publisher).toBe('https://ex/o/1');
     expect(document.keyword).toEqual(['Erfgoed']);
     expect(document.keyword_search).toEqual(['erfgoed']);
     expect(document.format).toEqual(['text/turtle']);
@@ -170,9 +179,9 @@ describe('projectDocument', () => {
       },
     );
     expect(document.size).toBe(42);
-    expect(document.language).toEqual(['true']);
-    expect(document.keyword).toEqual(['bareString']);
-    expect(document.class).toEqual(['http://example.org/BareClass']);
+    expect(document.language).toBe('true');
+    expect(document.keyword).toBe('bareString');
+    expect(document.class).toBe('http://example.org/BareClass');
   });
 
   it('projects a number field as a float (not truncated like integer)', () => {
@@ -212,6 +221,52 @@ describe('projectDocument', () => {
     ).toBeUndefined();
   });
 
+  it('stores a single-valued keyword or reference as the value, a declared array as a list', () => {
+    // `array` decides the shape for these kinds exactly as it does for the
+    // others: the graph may carry several values either way, and a
+    // single-valued declaration takes the first – so the projection, the
+    // engine collection definition (`string` vs `string[]`) and the API output
+    // type all describe one declaration the same way.
+    const document = projectDocument(
+      {
+        '@id': 'https://ex/d/shape',
+        [dsKey('format')]: [`${IANA}text/turtle`, `${IANA}application/ld+json`],
+        [dsKey('class')]: [
+          { '@id': 'http://schema.org/Person' },
+          { '@id': 'http://schema.org/Place' },
+        ],
+      },
+      {
+        name: 'Dataset',
+        class: DATASET,
+        fields: [
+          {
+            name: 'format',
+            path: `${DR}format`,
+            kind: 'keyword',
+            facetable: true,
+            searchable: { weight: 1 },
+            transform: (value) => value.replace(IANA, ''),
+          },
+          {
+            name: 'class',
+            path: `${DR}class`,
+            kind: 'reference',
+            array: true,
+            facetable: true,
+          },
+        ],
+      },
+    );
+
+    expect(document.format).toBe('text/turtle');
+    expect(document.format_search).toBe('text/turtle');
+    expect(document.class).toEqual([
+      'http://schema.org/Person',
+      'http://schema.org/Place',
+    ]);
+  });
+
   it('folds the transformed values (not the raw ones) for a facet search field', () => {
     const document = projectDocument(
       { '@id': 'https://ex/d/4', [dsKey('format')]: [`${IANA}text/turtle`] },
@@ -223,6 +278,7 @@ describe('projectDocument', () => {
             name: 'format',
             path: `${DR}format`,
             kind: 'keyword',
+            array: true,
             searchable: { weight: 1 },
             transform: (value) => value.replace(IANA, ''),
           },
@@ -473,7 +529,12 @@ describe('projectDocument', () => {
         fields: [
           // An internal reading device: a reference with no role, projected so
           // the derive below can read it, pruned before the writer sees it.
-          { name: 'classes', path: `${DR}class`, kind: 'reference' },
+          {
+            name: 'classes',
+            path: `${DR}class`,
+            kind: 'reference',
+            array: true,
+          },
           {
             name: 'classCount',
             kind: 'integer',
@@ -796,8 +857,7 @@ describe('projectDocument', () => {
           name: 'sortLabel',
           kind: 'keyword',
           output: true,
-          derive: (referent) =>
-            (referent.rawSort as readonly string[] | undefined)?.[0],
+          derive: (referent) => referent.rawSort as string | undefined,
         },
       ],
     });
@@ -990,8 +1050,8 @@ describe('projectDocument', () => {
       },
     );
     expect(document.title_nl).toBe('Titel');
-    expect(document.keyword).toEqual(['kaart']);
-    expect(document.publisher).toEqual(['https://o/1']);
+    expect(document.keyword).toBe('kaart');
+    expect(document.publisher).toBe('https://o/1');
   });
 
   it('throws when the framed node has no @id', () => {
@@ -1147,6 +1207,7 @@ describe('projectRoots', () => {
         {
           name: 'encodingFormat',
           kind: 'keyword',
+          array: true,
           output: true,
           path: 'https://schema.org/encodingFormat',
         },
@@ -1195,6 +1256,7 @@ describe('projectRoots', () => {
         {
           name: 'encodingFormat',
           kind: 'keyword',
+          array: true,
           output: true,
           path: 'https://schema.org/encodingFormat',
         },
@@ -1245,7 +1307,8 @@ describe('projectRoots', () => {
       expect.arrayContaining([
         {
           encodingFormat: ['image/jpeg'],
-          thumbnailUrl: ['https://ex/thumb.jpg'],
+          // Single-valued by declaration → the IRI itself.
+          thumbnailUrl: 'https://ex/thumb.jpg',
         },
         {
           id: 'https://ex/iiif/manifest',

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -731,7 +731,6 @@ describe('projectDocument', () => {
           path: 'https://schema.org/name',
           locales: ['nl'],
           output: true,
-          searchable: { weight: 1 },
         },
       ],
     });
@@ -764,10 +763,9 @@ describe('projectDocument', () => {
 
     // An output inline reference surfaces its referent as a nested Search
     // Document (its Reference Type’s projected fields), not a bare IRI.
-    expect(document.creator).toMatchObject({
+    expect(document.creator).toEqual({
       id: 'https://ex/c/1',
       label_nl: 'Naam',
-      label_search_nl: 'naam',
     });
   });
 
@@ -786,7 +784,6 @@ describe('projectDocument', () => {
           path: 'https://schema.org/name',
           locales: ['nl'],
           output: true,
-          searchable: { weight: 1 },
         },
         // Internal helper: no role, read by the derive below, pruned from the
         // surfaced referent.

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -12,6 +12,8 @@ import {
   irAlias,
   isoToUnixSeconds,
   isRangeFacet,
+  nestedFieldName,
+  nestedReferenceType,
   outputFields,
   physicalFields,
   referenceFields,
@@ -701,6 +703,161 @@ describe('searchSchema validation', () => {
       // Against a schema that does not declare the referent, an inline reference
       // contributes no depth (the type is being framed through a foreign schema).
       expect(inlineFramingDepth(searchSchema(flatDataset), dataset)).toBe(1);
+    });
+  });
+
+  describe('nested fields', () => {
+    const datasetNesting = (strategy: 'inline' | 'labelOnly') =>
+      ({
+        name: 'Dataset',
+        class: DATASET,
+        fields: [
+          {
+            name: 'media',
+            kind: 'reference',
+            array: true,
+            output: true,
+            path: 'https://schema.org/associatedMedia',
+            ref: { typeName: 'MediaObject', strategy },
+          },
+        ],
+      }) as const;
+
+    // The declaration under test is deliberately malformed in some cases, so
+    // the overriding members are applied untyped and the whole cast back.
+    const mediaObjectWith = (field: Record<string, unknown>): SearchType =>
+      ({
+        name: 'MediaObject',
+        fields: [
+          {
+            name: 'contentUrl',
+            kind: 'keyword',
+            array: true,
+            output: true,
+            path: 'https://schema.org/contentUrl',
+            ...field,
+          },
+        ],
+      }) as SearchType;
+
+    it('resolves the reference type a surfaced inline reference nests', () => {
+      const dataset = datasetNesting('inline');
+      const mediaObject = mediaObjectWith({});
+      const schema = searchSchema(dataset, mediaObject);
+      expect(nestedReferenceType(schema, dataset.fields[0])).toEqual(
+        mediaObject,
+      );
+    });
+
+    it('nests nothing for a reading device or a non-inline reference', () => {
+      // No Role: the reading device an inline reference is the other half of,
+      // pruned before the writer rather than surfaced.
+      const readingDevice = {
+        name: 'Dataset',
+        class: DATASET,
+        fields: [
+          {
+            name: 'media',
+            kind: 'reference',
+            path: 'https://schema.org/associatedMedia',
+            ref: { typeName: 'MediaObject', strategy: 'inline' },
+          },
+        ],
+      } as const;
+      const schema = searchSchema(readingDevice, mediaObjectWith({}));
+      expect(
+        nestedReferenceType(schema, readingDevice.fields[0]),
+      ).toBeUndefined();
+      // A labelOnly reference carries an IRI plus a resolved label, not fields.
+      const labelOnly = datasetNesting('labelOnly');
+      expect(
+        nestedReferenceType(
+          searchSchema(labelOnly, mediaObjectWith({})),
+          labelOnly.fields[0],
+        ),
+      ).toBeUndefined();
+    });
+
+    it.each([
+      ['searchable', { searchable: { weight: 1 } }],
+      ['filterable', { filterable: true }],
+      ['facetable', { facetable: true }],
+      ['sortable', { sortable: true }],
+    ])(
+      'rejects a nested field declaring %s, naming the field',
+      (role, declaration) => {
+        // A nested field is stored with its referent and read back with it; it
+        // never becomes an addressable field of its own, so any Role but
+        // `output` would be silently ignored per query. Startup is where a
+        // schema invariant fails.
+        expect(() =>
+          searchSchema(datasetNesting('inline'), mediaObjectWith(declaration)),
+        ).toThrow(
+          new RegExp(
+            `Nested field “MediaObject.contentUrl” declares “${role}”`,
+          ),
+        );
+      },
+    );
+
+    it.each([
+      ['searchable', { searchable: { weight: 1 } }],
+      ['facetable', { facetable: true }],
+    ])(
+      'rejects an inline reference declaring %s alongside its nesting',
+      (role, declaration) => {
+        // An inline reference has exactly two jobs: a reading device (no Role)
+        // or a surfaced nested object (`output`). Anything else would have an
+        // engine search, facet, filter or sort on a nested document.
+        expect(() =>
+          searchSchema(
+            {
+              ...datasetNesting('inline'),
+              fields: [
+                { ...datasetNesting('inline').fields[0], ...declaration },
+              ],
+            },
+            mediaObjectWith({}),
+          ),
+        ).toThrow(
+          new RegExp(`Inline reference “Dataset.media” declares “${role}”`),
+        );
+      },
+    );
+
+    it('names every unserviceable role a nested field declares', () => {
+      expect(() =>
+        searchSchema(
+          datasetNesting('inline'),
+          mediaObjectWith({ filterable: true, facetable: true }),
+        ),
+      ).toThrow(/“filterable”, “facetable”/);
+    });
+
+    it('rejects a label source on a nested field', () => {
+      // Reconstruction runs no label lookup for a nested field, so a label
+      // source there resolves nothing.
+      expect(() =>
+        searchSchema(
+          datasetNesting('inline'),
+          mediaObjectWith({
+            kind: 'reference',
+            labelSource: 'Organization',
+            ref: { typeName: 'Organization', strategy: 'labelOnly' },
+          }),
+        ),
+      ).toThrow(
+        /Nested field “MediaObject.contentUrl” declares a label source/,
+      );
+    });
+
+    it('names the nested Physical Field of a referent’s field', () => {
+      // The engine addresses a stored nested document by qualifying the
+      // referent’s own field name with the reference that carries it.
+      expect(nestedFieldName('media', 'contentUrl')).toBe('media.contentUrl');
+      expect(nestedFieldName('media.thumbnail', 'label_nl')).toBe(
+        'media.thumbnail.label_nl',
+      );
     });
   });
 

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 98.97,
+          branches: 99.01,
           statements: 100,
         },
       },

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 99.01,
+          branches: 99.35,
           statements: 100,
         },
       },


### PR DESCRIPTION
Makes the API device of an Inline Reference real end to end: a Reference Type declared `inline` with `output` is now stored, reconstructed and served as a nested object carrying its own Search Fields. A multi-valued reference keeps each referent’s values grouped, so a consumer never pairs parallel arrays by index, and a Deployment no longer flattens referents onto the root.

Fix #674

## What changed

**`@lde/search`**

- `SearchValue` gains `NestedDocument` – the referent of a surfaced inline reference, carrying an `id` only when the referent is a named node (a nested document is read, not addressed).
- `nestedReferenceType(schema, field)` – the one predicate the collection definition, result reconstruction and the API surfaces share for “does this field carry a nested document?”.
- `nestedFieldName(parent, name)` – the nested Physical Field convention (`media.contentUrl`), the nested counterpart of `physicalFields`.
- `searchSchema` gains the invariants the nested shape needs, so an unserviceable nesting fails at startup, naming the field: an inline reference is either a reading device (no Role) or surfaced (`output`), and every field of a Reference Type carries `output` only – `searchable`/`filterable`/`facetable`/`sortable`/`labelSource` are rejected, because no query compiler serves them and they would be silently ignored per query.
- The projection now honours `array` for `keyword` and `reference` as it already did for every other kind: a declared array stores a list, a single-valued field the first value the graph carries. It previously wrote a list either way, so one declaration meant a list to the projection and a scalar to the collection definition and the API output type – at root the engine rejected the document, and inside a nested document (which the engine does not type-check) it survived to fail per query at the surface.
- The port contract (`@lde/search/testing`) gains the nesting rule, so every engine implementation is held to it.

**`@lde/search-typesense`**

- The collection definition stores a surfaced inline reference as `object`/`object[]` (turning on `enable_nested_fields`), with one nested Physical Field per output field of its Reference Type, all `index: false` – nested content is display weight on disk, so the RAM lever is unchanged. It takes the schema as an option, and a rebuild writer builds its definition at construction, so a nesting type without its schema throws when the writer is built rather than inside the first run under a held lock.
- Reconstruction rebuilds one nested Search Document per referent, at the engine-adapter level rather than in a surface, so a second surface inherits it (the placement decision from ADR 11). `parseSearchResponse` now requires the schema, so a caller cannot silently reconstruct nothing for every nested field.

**`@lde/search-api-graphql`**

- A surfaced inline reference’s GraphQL type is built from its Reference Type’s `output` fields (same per-kind rules as a root type, nullable `id`), so a client selects a nested object’s fields directly. Other references keep the id-plus-label pair.

**Wiring**

- `searchIndexerPipeline`’s `writerFor` is called with the schema as well as the type, so a writer can declare the nesting; `@lde/search-indexer` passes it through.

## Breaking changes

- A `keyword`/`reference` field that does not declare `array: true` now projects a value rather than a one-element list. A Deployment whose source is multi-valued must declare `array: true` – including on an internal field a `derive` counts.
- `SearchValue` widens: a consumer switching on a reference value must handle a nested document.
- `parseSearchResponse` takes the schema as a required fourth argument.
- `buildCollectionDefinition` throws for a type surfacing an inline reference unless the new `schema` option is passed.
- Declarations that previously carried an ignored Role on an inline reference or inside a Reference Type now fail at `searchSchema()`.

Verified end to end against a real Typesense container (collection creation, import, search, reconstruction), including a mixed named/blank-node multi-valued reference and a referent missing an optional field.
