### PR TITLE
feat(search-api-graphql)!: type boolean facets with a BooleanBucket

### DIFF
--- a/docs/decisions/0004-search-api-graphql-surface.md
+++ b/docs/decisions/0004-search-api-graphql-surface.md
@@ -83,7 +83,7 @@ the optional `printGraphQLSchema()` SDL snapshot (the real artifact).
 ### Construction rules (field model → schema)
 
 Type names derive from each `SearchType`’s logical `name`; shared types (`LanguageString`,
-`ValueBucket`, `RangeBucket`, `SortDirection`, `StringFilter`, `IntRange`, `FloatRange`,
+`ValueBucket`, `RangeBucket`, `BooleanBucket`, `SortDirection`, `StringFilter`, `IntRange`, `FloatRange`,
 `DateRange`, and the reference types) are emitted once across all root types, and the
 per-type keyed facets object is named `<name>Facets`. A type with no `filterable` fields gets
 no `where` arg, and one
@@ -125,14 +125,15 @@ GraphQL field names are the field model `name` verbatim (declare camelCase).
   coercion) – **variable-based clients break** (`$o: DatasetOrderBy` where `[DatasetOrderBy!]`
   is expected) – so a future array is a deliberate, potentially breaking change.
 - **Facets** – a **keyed object** (`<Type>Facets`), one field per `facetable` field, typed by
-  the field’s kind: a numeric range-facet field is `[RangeBucket!]!`, every other facet is
+  the field’s kind: a numeric range-facet field is `[RangeBucket!]!`, a `boolean` field is
+  `[BooleanBucket!]!`, every other facet is
   `[ValueBucket!]!`. The facet set and each bucket shape are thus encoded **statically in the
   schema**, not discovered at runtime through an enum + polymorphic bucket (no `__typename`, no
   fragments). **Selection is the request**: only the facet keys a query selects are computed
   (the resolver inspects the selection), each with its **own where-filter removed**
   (skip-own-filter – a multi-select facet still lists its other options; dropping a `status`
   filter also drops the valid-only default, so the status facet counts across every status).
-  Two bucket types:
+  Three bucket types:
   - `ValueBucket { value, count, label }` – `value` is the selection key (filter via
     `field.in`); `label` (nullable) is the engine-resolved canonical **data** label, present
     only for **reference** (IRI-keyed) facets, `null` for token/free-string facets whose
@@ -140,6 +141,14 @@ GraphQL field names are the field model `name` verbatim (declare camelCase).
     or the `value` itself). The null is load-bearing.
   - `RangeBucket { min, max, count }` – a half-open `[min, max)` numeric bin (`max` null on an
     open-ended top bin), filtered via `field.range`.
+  - `BooleanBucket { value, count }` – `value` is a real `Boolean!`, filtered via `field.is`
+    with no reparsing of a stringified `"true"`. Carries **no `label` field** – not a nullable
+    one: a boolean has no data label to resolve and no language to negotiate one from, and its
+    absence is a fact of the kind rather than a null a consumer must read as either “missing”
+    or “not applicable”. Because at most two buckets exist and no third value can arrive, a
+    consumer can safely render the idiomatic single checkbox carrying the facet’s own label
+    (“Met afbeelding (1071)”) instead of a two-option value list, without matching on field
+    names.
   - A grouped facet (a coarse category alongside granular values, e.g. `group:rdf` next to media
     types) needs **no special bucket**: its tokens are denormalized into the field at index time,
     so they are ordinary `ValueBucket` values – faceted, filtered (`field.in: ["group:rdf"]`) and,
@@ -208,6 +217,11 @@ type RangeBucket {
   max: Float
   count: Int!
 }
+type BooleanBucket {
+  value: Boolean! # a real boolean: send it straight back as `where: { iiif: true }`
+  count: Int!
+  # no label: nothing to resolve, no language to negotiate – the consumer names it
+}
 type DatasetFacets {
   # one field per facetable field, typed by kind; selection = request, skip-own-filter applied
   publisher: [ValueBucket!]!
@@ -218,6 +232,7 @@ type DatasetFacets {
   terminologySource: [ValueBucket!]!
   status: [ValueBucket!]!
   size: [RangeBucket!]!
+  iiif: [BooleanBucket!]!
 }
 
 type Pagination {

--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -174,7 +174,18 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
   - a numeric field with [`facetRanges`](./search#range-facets) returns
     `[RangeBucket!]!` instead – one bucket per declared half-open
     `[min, max)` bin, carrying `min`/`max` (null on an open end) and
-    `count`, with no `value` or `label`.
+    `count`, with no `value` or `label`;
+  - a `boolean` field returns `[BooleanBucket!]!` – `value: Boolean!` +
+    `count`, and **no `label` field at all**. The value is a real boolean, so
+    the bucket a client selects is exactly the term the `where` filter takes
+    (`where: { iiif: true }`) rather than a string to parse back. There is no
+    label because a boolean has no data label to resolve and no language to
+    negotiate one from: the sensible rendering (“Met afbeelding” / “Zonder
+    afbeelding”) is knowable only by the consumer. Because no third value can
+    arrive, one checkbox labelled with the facet’s own label is a safe
+    rendering – no field-name matching needed. A bucket is present only if
+    the engine counted documents for it, so a uniform result set yields one
+    bucket, not two.
 
   Selecting facet fields IS
   the request: each selected facet is computed with its own `where`-filter

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -347,6 +347,26 @@ type must declare an `output`, `searchable` text field called `label` –
 `searchSchema` validates this schema-wide, so a dangling or unsuitable label
 source fails at startup. A reference without a `labelSource` stays id-only.
 
+### Facet buckets
+
+A `FacetBucket` always carries its `value` and `count`; what else it carries is
+decided by the facet’s kind, and a surface types the bucket accordingly (see
+[bucket types](./search-api-graphql#what-it-builds-per-root-type)).
+
+**`label`** is the engine-resolved canonical **data** label, and appears only
+for a **reference** facet with a [label source](#field-model) – the bucket is
+IRI-keyed, so without it a consumer has nothing to display. Every other kind
+carries none, and this is a rule about the data, not an omission to fill in
+later:
+
+- a `keyword` facet’s value is a token or free string whose display the
+  consumer owns – its own i18n, or the value itself;
+- a `boolean` facet has no data label at all, and no language to negotiate one
+  from. Only the consumer knows that `true` means “Met afbeelding”. Its bucket
+  additionally carries **`is`**, the value as a real boolean, so it round-trips
+  straight into the `is` filter that selects it;
+- a range-facet bin carries `min`/`max` instead – see below.
+
 ### Range facets
 
 A facetable numeric field (`integer`/`number`/`date`) may declare

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -434,7 +434,8 @@ export function buildGraphQLSchema(
     });
 
     // Keyed facets object: one field per facetable field, typed by its kind
-    // (range fields → [RangeBucket!], else [ValueBucket!]). Only the selected
+    // (range fields → [RangeBucket!], boolean fields → [BooleanBucket!], else
+    // [ValueBucket!]). Only the selected
     // fields are resolved (GraphQL prunes the rest), so the selection IS the
     // request; how they are computed – skip-own-filter, batched into one
     // engine dispatch – lives in facet-batch.ts.

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -169,6 +169,20 @@ export function buildGraphQLSchema(
       count: { type: new GraphQLNonNull(GraphQLInt) },
     },
   });
+  // A boolean-facet bucket: the value as a real boolean, so the bucket a client
+  // selects round-trips straight into the `is` filter that selects it. No label
+  // – a boolean has no data label to resolve, and the sensible rendering (“with
+  // an image” / “without one”) is knowable only by the consumer.
+  const booleanBucket = new GraphQLObjectType({
+    name: 'BooleanBucket',
+    fields: {
+      value: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: (bucket: Source) => bucket.is,
+      },
+      count: { type: new GraphQLNonNull(GraphQLInt) },
+    },
+  });
   // The pagination actually applied (after queryDefaults), shared across every
   // ‹Type›SearchResult so one client pager fragment serves all root types.
   const paginationType = new GraphQLObjectType({
@@ -489,6 +503,13 @@ export function buildGraphQLSchema(
     };
   }
 
+  /** The bucket type a facet’s kind earns: bins for a range facet, a real
+   *  boolean for a boolean one, a keyed value otherwise. */
+  function bucketTypeFor(field: SearchField): GraphQLObjectType {
+    if (isRangeFacet(field)) return rangeBucket;
+    return field.kind === 'boolean' ? booleanBucket : valueBucket;
+  }
+
   /** The keyed facets object for one type (only called with ≥ 1 facetable field). */
   function facetsTypeFor(
     typeName: string,
@@ -503,9 +524,7 @@ export function buildGraphQLSchema(
         > = {};
         for (const field of facetable) {
           fields[field.name] = {
-            type: nonNullListOf(
-              isRangeFacet(field) ? rangeBucket : valueBucket,
-            ),
+            type: nonNullListOf(bucketTypeFor(field)),
             // The skip-own-filter query building, the batching into one
             // engine dispatch and the degrade-to-[] error handling all live
             // in the loader (facet-batch.ts).

--- a/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
+++ b/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
@@ -46,13 +46,18 @@ type ThingFacets {
   creator: [ValueBucket!]!
   publisher: [ValueBucket!]!
   status: [ValueBucket!]!
-  open: [ValueBucket!]!
+  open: [BooleanBucket!]!
 }
 
 type ValueBucket {
   value: String!
   count: Int!
   label: [LanguageString!]
+}
+
+type BooleanBucket {
+  value: Boolean!
+  count: Int!
 }
 
 input ThingWhere {

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -347,6 +347,36 @@ describe('buildGraphQLSchema', () => {
     expect(facets.keyword).toEqual([{ value: 'kaarten', count: 3 }]);
   });
 
+  it('serves boolean-facet buckets as real booleans, ready to send straight back as a filter', async () => {
+    const { engine, received } = fakeEngine({
+      total: 0,
+      hits: [],
+      facets: {
+        iiif: [
+          { value: 'true', is: true, count: 1071 },
+          { value: 'false', is: false, count: 342 },
+        ],
+      },
+    });
+    const result = await run(
+      `{ datasets { facets { iiif { value count } } } }`,
+      { engine, acceptLanguage: ['nl'] },
+    );
+    const facets = (result.data?.datasets as Record<string, unknown>)
+      .facets as { iiif: { value: boolean; count: number }[] };
+    expect(facets.iiif).toEqual([
+      { value: true, count: 1071 },
+      { value: false, count: 342 },
+    ]);
+    // The bucket a client picked is exactly what its filter takes: no reparsing.
+    await run(
+      `query ($iiif: Boolean) { datasets(where: { iiif: $iiif }) { pagination { total } } }`,
+      { engine, acceptLanguage: ['nl'] },
+      { iiif: facets.iiif[0].value },
+    );
+    expect(received().where).toEqual([{ field: 'iiif', is: true }]);
+  });
+
   it('resolves every selected facet key through ONE batched engine dispatch, returning [] where the engine has none', async () => {
     const { engine, facetBatches } = fakeEngine({
       total: 0,
@@ -616,9 +646,21 @@ describe('buildGraphQLSchema', () => {
     expect(sdl).toMatch(/type DatasetFacets/);
     expect(sdl).toMatch(/keyword: \[ValueBucket!\]!/);
     expect(sdl).toMatch(/size: \[RangeBucket!\]!/);
+    expect(sdl).toMatch(/iiif: \[BooleanBucket!\]!/);
     expect(sdl).toMatch(/input DatasetWhere/);
     expect(sdl).toMatch(/status: StringFilter/);
     expect(sdl).toMatch(/size: IntRange/);
+  });
+
+  it('gives a boolean facet a real boolean value and no label to interpret', () => {
+    const sdl = printSchema(
+      buildGraphQLSchema(searchSchema(schema), datasetOptions),
+    );
+    expect(sdl).toContain(
+      ['type BooleanBucket {', '  value: Boolean!', '  count: Int!', '}'].join(
+        '\n',
+      ),
+    );
   });
 
   describe('multiple root types in one schema', () => {

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -22,7 +22,7 @@ export default mergeConfig(
           lines: 100,
           // Full-suite baseline, re-anchored when covered branches are
           // deleted (autoUpdate only ever raises; see AGENTS.md).
-          branches: 95.03,
+          branches: 95.1,
           statements: 100,
         },
       },

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -771,6 +771,9 @@ export function parseSearchResponse(
       field !== undefined && isRangeFacet(field)
         ? new Map(field.facetRanges.map((range) => [range.key, range]))
         : undefined;
+    // A boolean facet is reported with the values stringified; recover the
+    // boolean so the bucket carries the term the `is` filter expects.
+    const booleanFacet = field?.kind === 'boolean';
     facets[facet.field_name] = facet.counts.map((bucket) => {
       const label = labelled ? labels.get(bucket.value) : undefined;
       const range = rangesByKey?.get(bucket.value);
@@ -780,6 +783,7 @@ export function parseSearchResponse(
         ...(label !== undefined ? { label } : {}),
         ...(range?.min !== undefined ? { min: range.min } : {}),
         ...(range?.max !== undefined ? { max: range.max } : {}),
+        ...(booleanFacet ? { is: bucket.value === 'true' } : {}),
       };
     });
   }

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -129,6 +129,14 @@ const response = {
         { value: 'https://org/3', count: 1 },
       ],
     },
+    {
+      // A boolean facet: Typesense reports the two values as strings.
+      field_name: 'iiif',
+      counts: [
+        { value: 'true', count: 2 },
+        { value: 'false', count: 1 },
+      ],
+    },
   ],
 };
 
@@ -157,6 +165,13 @@ describe('parseSearchResponse', () => {
         label: { nl: ['Het Utrechts Archief'] },
       },
       { value: 'https://org/3', count: 1 },
+    ]);
+  });
+
+  it('gives boolean-facet buckets a real boolean alongside the engine’s string value', () => {
+    expect(result.facets.iiif).toEqual([
+      { value: 'true', is: true, count: 2 },
+      { value: 'false', is: false, count: 1 },
     ]);
   });
 

--- a/packages/search-typesense/test/search-engine.test.ts
+++ b/packages/search-typesense/test/search-engine.test.ts
@@ -88,6 +88,7 @@ const datasetSchema: SearchType = {
     },
     { name: 'status', kind: 'keyword', facetable: true, filterable: true },
     { name: 'statusRank', kind: 'integer', sortable: true },
+    { name: 'iiif', kind: 'boolean', facetable: true, filterable: true },
   ],
 };
 
@@ -117,6 +118,7 @@ const documents = [
     ],
     status: 'valid',
     statusRank: 0,
+    iiif: true,
   },
   {
     id: 'd2',
@@ -128,6 +130,8 @@ const documents = [
     publisher: ['https://org/2'],
     status: 'valid',
     statusRank: 0,
+    // The negative case, so the facet reports both buckets.
+    iiif: false,
   },
   {
     id: 'd3',
@@ -139,6 +143,7 @@ const documents = [
     publisher: ['https://org/1'],
     status: 'invalid',
     statusRank: 3,
+    iiif: true,
   },
 ];
 

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -20,7 +20,7 @@ export default mergeConfig(
           // partial vitest run must never rewrite these – see AGENTS.md.
           functions: 98.78,
           lines: 99.15,
-          branches: 95.02,
+          branches: 95.05,
           statements: 99.17,
         },
       },

--- a/packages/search/src/engine.ts
+++ b/packages/search/src/engine.ts
@@ -203,4 +203,10 @@ export interface FacetBucket {
    */
   readonly min?: number;
   readonly max?: number;
+  /**
+   * For a boolean-facet bucket: the value as a real boolean, so it round-trips
+   * straight into the `is` filter that selects it rather than leaving a
+   * consumer to parse `value` back. Absent on every other kind of facet.
+   */
+  readonly is?: boolean;
 }

--- a/packages/search/src/engine.ts
+++ b/packages/search/src/engine.ts
@@ -207,6 +207,11 @@ export interface FacetBucket {
    * For a boolean-facet bucket: the value as a real boolean, so it round-trips
    * straight into the `is` filter that selects it rather than leaving a
    * consumer to parse `value` back. Absent on every other kind of facet.
+   *
+   * Optional only because one bucket type serves every kind: an adapter MUST
+   * set it on every bucket of a `boolean` facet, and the engine conformance
+   * suite checks that it does. A surface types it non-null, so omitting it
+   * fails the whole response rather than degrading the one facet.
    */
   readonly is?: boolean;
 }

--- a/packages/search/src/testing.ts
+++ b/packages/search/src/testing.ts
@@ -173,10 +173,21 @@ export function describeSearchEngineContract(
             continue;
           }
           expect(outcome.facets).toBeTypeOf('object');
-          for (const buckets of Object.values(outcome.facets)) {
+          const booleanFacets = new Set(
+            facetableFields(searchType)
+              .filter((field) => field.kind === 'boolean')
+              .map((field) => field.name),
+          );
+          for (const [name, buckets] of Object.entries(outcome.facets)) {
             for (const bucket of buckets ?? []) {
               expect(typeof bucket.value).toBe('string');
               expect(typeof bucket.count).toBe('number');
+              // A boolean facet MUST carry `is`: a surface types it non-null
+              // (GraphQL `Boolean!`), so an adapter that omits it nulls the
+              // whole response rather than degrading one facet.
+              if (booleanFacets.has(name)) {
+                expect(typeof bucket.is).toBe('boolean');
+              }
             }
           }
         }


### PR DESCRIPTION
A boolean facet was surfaced as an untyped two-bucket value list – `[ValueBucket!]!` with `value: "true"` / `"false"` and a null `label` – so the bucket a client selected did not round-trip into the boolean filter that selects it.

Booleans now get their own bucket type, parallel to the `ValueBucket` / `RangeBucket` split that numeric range facets already established:

```graphql
type BooleanBucket {
  value: Boolean!
  count: Int!
}
```

No `label` field, and not a nullable one: a boolean has no data label to resolve and no language to negotiate one from, so its absence is a fact of the kind rather than a null a consumer has to read as either “missing” or “not applicable”. Because at most two buckets exist and no third value can arrive, a consumer can render the idiomatic single checkbox carrying the facet’s own label (“Met afbeelding (1071)”) without matching on field names.

## Shape

It follows how range facets were built rather than parsing strings at the surface: the **adapter** enriches the port bucket, and the GraphQL type is a plain projection of it.

- `FacetBucket` gains an optional `is?: boolean`, set for boolean facets exactly as `min`/`max` are set for range bins. `value` keeps its string type and meaning.
- `search-typesense` recovers the boolean from Typesense’s stringified facet values.
- `search-api-graphql` types a boolean facetable field `[BooleanBucket!]!` and projects `is`.

The `where` input for a boolean is already a bare `Boolean`, so a selected bucket’s `value` is exactly what the filter takes – `where: { iiif: true }`, same scalar in both directions.

## Deviation from the issue

The issue asks that both `true` and `false` buckets always be present, padding the absent one to `count: 0`. That is deliberately **not** implemented: a zero-count bucket carries no information, so buckets are emitted only where the engine actually counted documents. A uniform result set therefore yields one bucket, not two. The claim the clause was protecting – no third value can arrive, so a single checkbox is safe – holds regardless.

## Port contract

`FacetBucket.is` is optional on the port only because one bucket type serves every kind – but a surface types it non-null, so an adapter that omitted it would null the entire response (items and pagination included) rather than degrade the one facet. The engine conformance suite now asserts `is` on every boolean-facet bucket, and the contract fixture gains a boolean facetable field carrying both values – boolean facets had no adapter-contract coverage at all before.

## Breaking change

The generated surface changes for any boolean facetable field: `value` goes from `String!` to `Boolean!`, and `label` is gone. Pre-1.0, so no compatibility shim.

## Docs

Closes both gaps the issue names: `/reference/search-api-graphql` now states the boolean case explicitly instead of leaving it to implication, and `/reference/search` – the page you land on after writing `facetable: true` – gains a **Facet buckets** section stating the label rule per kind. ADR 4 records the third bucket type.

Fix #704
