### PR TITLE
feat(search): declare a field over the indexed dataset

### DIFF
--- a/docs/reference/search-typesense.md
+++ b/docs/reference/search-typesense.md
@@ -269,6 +269,16 @@ the index. Declaring the dataset as an _internal_ field (no role at all, purely
 so a `derive` can read it) is fine: the projection prunes it before the writer,
 which falls back to `source`.
 
+**Adopting the field needs a fresh collection.** `InPlaceRebuild` creates a
+collection on demand and leaves an existing one alone, so a type that gains a
+`from: 'dataset'` field against a collection built without it keeps the old
+`source` column and has no field for the new one. Typesense stores the
+unindexed value happily, so the run imports; `commit` then fails when the
+membership sweep tries to facet a field the collection does not declare, and
+the documents already stamped with `source` are no longer reachable by any
+sweep. Drop and rebuild the collection when a type adopts the field.
+(Blue/green builds a fresh collection every run, so it needs nothing.)
+
 Both writers take a `Client` the caller owns (and reuses for queries), so this
 package adds no connection or document type of its own – any object with an `id`
 is a valid document, including the `SearchDocument`s `@lde/search` produces.

--- a/docs/reference/search-typesense.md
+++ b/docs/reference/search-typesense.md
@@ -247,6 +247,28 @@ and `last_seen` (the run id); deletion is a sweep, never special-cased:
 
 Document ids must be unique per (source, entity) – the caller keys them.
 
+### Provenance
+
+`source` above is the **private** bookkeeping field a writer adds when the
+`SearchType` declares nothing over the dataset itself; a schema cannot declare a
+field of that name.
+
+A type that _does_ declare one – a `keyword`/`reference` field with
+[`from: 'dataset'`](./search.md#projection-values) – makes that field the
+collection’s provenance instead: the writer stamps it, the sweeps filter on it,
+and no private `source` column is added beside it. One column then feeds the
+facet, the query-time label resolution, any `derive` and the membership sweep,
+so they cannot drift the way two copies of one IRI can.
+
+Because the sweep deletes by it, a declared dataset field must be single-valued
+and carry no `transform` (the sweep matches the stored value against the run’s
+raw dataset IRIs), and – for `InPlaceRebuild`, which enumerates the indexed
+datasets by faceting it – must be `facetable`. Each is checked when the writer
+is constructed, so a declaration that cannot be swept fails before a run touches
+the index. Declaring the dataset as an _internal_ field (no role at all, purely
+so a `derive` can read it) is fine: the projection prunes it before the writer,
+which falls back to `source`.
+
 Both writers take a `Client` the caller owns (and reuses for queries), so this
 package adds no connection or document type of its own – any object with an `id`
 is a valid document, including the `SearchDocument`s `@lde/search` produces.

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -157,11 +157,14 @@ Two conventions hold across the whole family:
 
 ## Field model
 
-The mapping is data, not code. Each field declares its `kind`, the IR `path` to
-read (or a `derive` function for a **derived** field, computed from the document
-in declaration order – so it may read fields declared before it, never the
-graph), and the capabilities (**roles**) it opts into. `path` is therefore the
-complete statement of what the projection reads from the graph. A field that
+The mapping is data, not code. Each field declares its `kind`, its value source,
+and the capabilities (**roles**) it opts into. There are three mutually
+exclusive value sources: the IR `path` to read; a `derive` function for a
+**derived** field, computed from the document in declaration order – so it may
+read fields declared before it, never the graph; or `from`, naming a
+[projection value](#projection-values) the run knows and the graph does not.
+`path` is therefore the complete statement of what the projection reads from the
+graph. A field that
 declares **no** role is an **internal field**: projected so a later `derive` can
 read it, then pruned before the writer and absent from the collection definition
 – not stored, not indexed, no RAM. The physical field names a declaration fans
@@ -403,6 +406,79 @@ projectRoots(
   DATASET,
 );
 ```
+
+### Projection values
+
+Some things a document should carry are true of the **indexing**, not of the
+graph. The dataset an entity was indexed from is the case that matters: every
+indexed document comes from exactly one, and for the entity types that carry no
+containing-collection property – `Person`, `Organization`, `Place`, `Term` – it
+is the only available answer to _which dataset does this come from_, because
+nothing in the data says it.
+
+A `keyword`/`reference` field declares itself over such a value with `from`
+instead of a `path` or a `derive`. The logical name is the deployment’s to
+choose, and the field behaves like any other: `output`, `filterable`,
+`facetable`, and – as a `reference` – a `labelSource` that resolves the IRI to a
+readable label at query time, so a dataset facet arrives with names rather than
+URIs.
+
+```ts
+const PERSON = defineSearchType({
+  name: 'Person',
+  class: 'http://schema.org/Person',
+  fields: [
+    {
+      name: 'label',
+      path: 'http://schema.org/name',
+      kind: 'text',
+      locales: ['nl'],
+      output: true,
+      searchable: { weight: 5 },
+    },
+    {
+      name: 'dataset',
+      kind: 'reference',
+      from: 'dataset',
+      output: true,
+      filterable: true,
+      facetable: true,
+      labelSource: 'Dataset',
+      ref: { typeName: 'Dataset', strategy: 'labelOnly' },
+    },
+  ],
+});
+```
+
+The value reaches the projection through `projectRoots`’ **projection context**;
+`@lde/search-pipeline`’s `searchStages` supplies it from the batch’s dataset, so
+a deployment declares the field and nothing else. Every `derive` receives the
+same context as its second argument, which is what lets a derive relate a
+projected value to its provenance – dropping a polymorphic `isPartOf` value that
+merely points back at the containing dataset, say:
+
+```ts
+{
+  name: 'isPartOf',
+  kind: 'reference',
+  array: true,
+  output: true,
+  ref: { typeName: 'CreativeWork', strategy: 'labelOnly' },
+  // `partOfRaw` is an internal field over schema:isPartOf
+  derive: (document, context) =>
+    (document.partOfRaw as string[] | undefined)?.filter(
+      (value) => value !== context.dataset,
+    ),
+}
+```
+
+Projecting without a context is legitimate (a test, a one-off): the field is
+simply left unpopulated, exactly as a `path` that matched nothing would be.
+
+A declared dataset field is also what the engine writer keeps its **provenance
+bookkeeping** on – see [`@lde/search-typesense`](./search-typesense.md#provenance)
+– so the facet, the label, any derive and the membership sweep read one column
+rather than two copies of one IRI.
 
 ## Locales
 

--- a/packages/search-pipeline/src/search-stages.ts
+++ b/packages/search-pipeline/src/search-stages.ts
@@ -140,11 +140,19 @@ export function searchStages(
           }
           return term.value;
         });
+        // The dataset the batch came from is what a `from: 'dataset'` field is
+        // declared over, and what a `derive` reads to relate a projected value
+        // to its provenance. The stage is where it is known: the writer sees it
+        // only after projection, which is too late for either.
         for await (const document of projectRoots(
           quads,
           roots,
           schema,
           searchType,
+          // The same `iri.toString()` the writer’s provenance bookkeeping and
+          // `selectedSources()` use, so a declared field, the membership sweep
+          // and the selection all compare one spelling of the IRI.
+          { dataset: context.dataset.iri.toString() },
         )) {
           yield { searchType, document };
         }

--- a/packages/search-pipeline/test/search-stages.test.ts
+++ b/packages/search-pipeline/test/search-stages.test.ts
@@ -104,6 +104,58 @@ describe('searchStages', () => {
     ]);
   });
 
+  it('projects the batch’s dataset, so a declared field and a derive can see it', async () => {
+    // The stage is where the dataset is known: the writer sees it only after
+    // projection, which is too late for either.
+    const withDataset = searchSchema({
+      name: 'Person',
+      class: PERSON,
+      fields: [
+        { name: 'name', kind: 'keyword', path: NAME, output: true },
+        {
+          name: 'dataset',
+          kind: 'reference',
+          from: 'dataset',
+          output: true,
+          facetable: true,
+          ref: { typeName: 'Dataset', strategy: 'labelOnly' },
+        },
+        {
+          name: 'fromDataset',
+          kind: 'keyword',
+          filterable: true,
+          derive: (_document, context) =>
+            context.dataset === undefined ? undefined : 'yes',
+        },
+      ],
+    });
+    const [stage] = searchStages({
+      schema: withDataset,
+      types: [
+        {
+          searchType: withDataset.get(PERSON) as RootType,
+          rootVariable: 'root',
+          itemSelector: rootsSelector(['https://ex/p/1']),
+          readers: nameReader,
+        },
+      ],
+    });
+
+    const received: TypedSearchDocument[] = [];
+    const writer: DatasetWriter<TypedSearchDocument> = {
+      write: async (_dataset, items) => {
+        for await (const item of items) {
+          received.push(item);
+        }
+      },
+    };
+
+    await stage.run(dataset, distribution, writer);
+
+    expect(received[0].document.dataset).toBe('http://example.org/dataset/1');
+    expect(received[0].document.fromDataset).toBe('yes');
+  });
+
   it('names each stage after its type and yields one stage per type', () => {
     const stages = searchStages({
       schema,

--- a/packages/search-typesense/src/blue-green-rebuild.ts
+++ b/packages/search-typesense/src/blue-green-rebuild.ts
@@ -10,9 +10,14 @@ import type { Dataset } from '@lde/dataset';
 import { buildCollectionDefinition } from './collection-definition.js';
 import { BatchImporter } from './import.js';
 import { httpStatus, openLockedRun, releaseLock } from './lock.js';
-import { SOURCE_FIELD, sourceDocumentsFilter } from './sweep.js';
+import {
+  SOURCE_FIELD,
+  provenanceField,
+  sourceDocumentsFilter,
+} from './sweep.js';
 import {
   assertNoReservedFields,
+  assertSweepableProvenanceField,
   deleteByFilter,
   resolveRebuildOptions,
   stampDocuments,
@@ -67,6 +72,10 @@ export class BlueGreenRebuild<
    */
   public readonly collectionName: string;
   private readonly resolved: ResolvedRebuildOptions;
+  /** The column this collection carries its documents’ dataset IRI in: the
+   *  type’s declared dataset field, or the private `source` when it declares
+   *  none. Both the stamp and the per-dataset rollback filter read it. */
+  private readonly sourceField: string;
 
   constructor(
     private readonly client: Client,
@@ -75,6 +84,10 @@ export class BlueGreenRebuild<
   ) {
     // `source` is stamped on every document for per-dataset rollback.
     assertNoReservedFields(searchType, [SOURCE_FIELD]);
+    // Rollback filters by a known dataset IRI rather than enumerating the
+    // indexed ones, so a declared field need not be facetable here.
+    assertSweepableProvenanceField(searchType, { requireFacetable: false });
+    this.sourceField = provenanceField(searchType);
     this.resolved = resolveRebuildOptions(searchType, options);
     this.collectionName = this.resolved.definitionOptions.name;
   }
@@ -82,6 +95,7 @@ export class BlueGreenRebuild<
   async openRun(context: RunContext): Promise<RunWriter<TDocument>> {
     const { batchSize, lockTtlMs, definitionOptions } = this.resolved;
     const name = this.collectionName;
+    const sourceField = this.sourceField;
 
     return openLockedRun(this.client, name, lockTtlMs, async () => {
       // Create the fresh (blue) collection up front, so a failure surfaces
@@ -96,9 +110,14 @@ export class BlueGreenRebuild<
       await this.client.collections().create({
         ...definition,
         name: collection,
+        // The private `source` only when the type declares no dataset field of
+        // its own; a declared one is already in the definition and carries the
+        // same IRI.
         fields: [
           ...(definition.fields ?? []),
-          { name: SOURCE_FIELD, type: 'string' },
+          ...(sourceField === SOURCE_FIELD
+            ? [{ name: SOURCE_FIELD, type: 'string' } as const]
+            : []),
         ],
       });
 
@@ -116,7 +135,7 @@ export class BlueGreenRebuild<
         await deleteByFilter(
           this.client,
           collection,
-          sourceDocumentsFilter(dataset.iri.toString()),
+          sourceDocumentsFilter(sourceField, dataset.iri.toString()),
         );
       };
 
@@ -124,7 +143,7 @@ export class BlueGreenRebuild<
         write: async (dataset: Dataset, documents: AsyncIterable<TDocument>) =>
           importer.add(
             stampDocuments(documents, {
-              [SOURCE_FIELD]: dataset.iri.toString(),
+              [sourceField]: dataset.iri.toString(),
             }),
           ),
 

--- a/packages/search-typesense/src/in-place-rebuild.ts
+++ b/packages/search-typesense/src/in-place-rebuild.ts
@@ -16,11 +16,13 @@ import {
   SOURCE_FIELD,
   departedSources,
   membershipSweepFilters,
+  provenanceField,
   staleDocumentsFilter,
   thisRunDocumentsFilter,
 } from './sweep.js';
 import {
   assertNoReservedFields,
+  assertSweepableProvenanceField,
   deleteByFilter,
   resolveRebuildOptions,
   stampDocuments,
@@ -92,6 +94,11 @@ export class InPlaceRebuild<
   public readonly collectionName: string;
   private readonly maxSweepableSources: number;
   private readonly resolved: ResolvedRebuildOptions;
+  /** The column this collection carries its documents’ dataset IRI in: the
+   *  type’s declared dataset field, or the private `source` when it declares
+   *  none. Everything below – the stamp, every sweep filter, the source
+   *  enumeration – reads this one name. */
+  private readonly sourceField: string;
 
   constructor(
     private readonly client: Client,
@@ -99,6 +106,8 @@ export class InPlaceRebuild<
     options: InPlaceRebuildOptions = {},
   ) {
     assertNoReservedFields(searchType, [SOURCE_FIELD, LAST_SEEN_FIELD]);
+    assertSweepableProvenanceField(searchType, { requireFacetable: true });
+    this.sourceField = provenanceField(searchType);
     const {
       maxSweepableSources = DEFAULT_MAX_SWEEPABLE_SOURCES,
       ...rebuildOptions
@@ -111,18 +120,24 @@ export class InPlaceRebuild<
   async openRun(context: RunContext): Promise<RunWriter<TDocument>> {
     const { batchSize, lockTtlMs, definitionOptions } = this.resolved;
     const name = this.collectionName;
+    const sourceField = this.sourceField;
 
     return openLockedRun(this.client, name, lockTtlMs, async () => {
       // Create the collection on demand: SearchType schema + the bookkeeping
-      // fields, `source` faceted so the membership sweep can enumerate the
-      // distinct sources.
+      // fields. The private `source` – faceted so the membership sweep can
+      // enumerate the distinct sources – only when the type declares no dataset
+      // field of its own; when it does, that declared field already carries the
+      // IRI (and its own `facet: true`), and a second column would be the same
+      // value twice, free to drift.
       await ensureCollectionExists(this.client, name, () => {
         const definition = buildCollectionDefinition(
           this.searchType,
           definitionOptions,
         );
         const bookkeeping: CollectionFieldSchema[] = [
-          { name: SOURCE_FIELD, type: 'string', facet: true },
+          ...(sourceField === SOURCE_FIELD
+            ? [{ name: SOURCE_FIELD, type: 'string', facet: true } as const]
+            : []),
           { name: LAST_SEEN_FIELD, type: 'string' },
         ];
         return {
@@ -138,10 +153,16 @@ export class InPlaceRebuild<
       );
 
       return {
+        // Stamping the provenance field – rather than trusting the projection
+        // to have filled a declared one – is what keeps the sweep total: a
+        // caller projecting without a dataset context, or a document reaching
+        // the writer any other way, still lands in a swept collection. Where
+        // the projection did fill it, the value is the same dataset IRI, so the
+        // stamp only ever reasserts it.
         write: async (dataset: Dataset, documents: AsyncIterable<TDocument>) =>
           importer.add(
             stampDocuments(documents, {
-              [SOURCE_FIELD]: dataset.iri.toString(),
+              [sourceField]: dataset.iri.toString(),
               [LAST_SEEN_FIELD]: context.runId,
             }),
           ),
@@ -159,7 +180,11 @@ export class InPlaceRebuild<
           await deleteByFilter(
             this.client,
             name,
-            staleDocumentsFilter(dataset.iri.toString(), context.runId),
+            staleDocumentsFilter(
+              sourceField,
+              dataset.iri.toString(),
+              context.runId,
+            ),
           );
         },
 
@@ -171,7 +196,11 @@ export class InPlaceRebuild<
           await deleteByFilter(
             this.client,
             name,
-            thisRunDocumentsFilter(dataset.iri.toString(), context.runId),
+            thisRunDocumentsFilter(
+              sourceField,
+              dataset.iri.toString(),
+              context.runId,
+            ),
           );
         },
 
@@ -181,7 +210,7 @@ export class InPlaceRebuild<
             await this.indexedSources(name, this.maxSweepableSources),
             context.selectedSources(),
           );
-          for (const filter of membershipSweepFilters(departed)) {
+          for (const filter of membershipSweepFilters(sourceField, departed)) {
             await deleteByFilter(this.client, name, filter);
           }
           await releaseLock(this.client, name);
@@ -195,8 +224,8 @@ export class InPlaceRebuild<
   }
 
   /**
-   * The distinct sources present in the collection, via a single `source`
-   * facet. Requests one bucket beyond `maxSources` so genuine truncation is
+   * The distinct sources present in the collection, via a single facet over its
+   * {@link provenanceField}. Requests one bucket beyond `maxSources` so genuine truncation is
    * distinguishable from an exactly-full result: `maxSources` buckets are
    * returned intact, `maxSources + 1` proves more exist and the sweep would
    * miss some, so it throws rather than delete blind.
@@ -210,9 +239,9 @@ export class InPlaceRebuild<
       .documents()
       .search({
         q: '*',
-        query_by: SOURCE_FIELD,
+        query_by: this.sourceField,
         per_page: 0,
-        facet_by: SOURCE_FIELD,
+        facet_by: this.sourceField,
         max_facet_values: maxSources + 1,
       });
     const counts = response.facet_counts?.[0]?.counts ?? [];

--- a/packages/search-typesense/src/in-place-rebuild.ts
+++ b/packages/search-typesense/src/in-place-rebuild.ts
@@ -159,6 +159,13 @@ export class InPlaceRebuild<
         // the writer any other way, still lands in a swept collection. Where
         // the projection did fill it, the value is the same dataset IRI, so the
         // stamp only ever reasserts it.
+        //
+        // It reasserts the sweep’s column only, never the physical fanout a
+        // declared field also produces (the folded `${name}_search` companion
+        // of a `searchable` one). Folding is the projection’s convention, and
+        // restating it here would put it in two places – the split this change
+        // exists to close. So a document that reached the writer unprojected is
+        // sweepable but not full-text findable by dataset: absent, never wrong.
         write: async (dataset: Dataset, documents: AsyncIterable<TDocument>) =>
           importer.add(
             stampDocuments(documents, {

--- a/packages/search-typesense/src/rebuild-support.ts
+++ b/packages/search-typesense/src/rebuild-support.ts
@@ -1,5 +1,6 @@
 import type { Client } from 'typesense';
 import type { SearchType } from '@lde/search';
+import { datasetField, isInternalField } from '@lde/search/adapter';
 import {
   buildCollectionDefinition,
   type CollectionDefinitionOptions,
@@ -83,6 +84,57 @@ export function assertNoReservedFields(
       `SearchType “${searchType.name}” declares reserved bookkeeping field(s) ${clashing
         .map((field) => `“${field.name}”`)
         .join(', ')}`,
+    );
+  }
+}
+
+/**
+ * Reject a declared dataset field the provenance bookkeeping cannot be kept on.
+ * A type declaring one makes it the collection’s provenance field – the column
+ * the membership sweep enumerates and deletes by – so the declaration has to answer
+ * *which single dataset is this document’s* the way the private `source` field
+ * did:
+ *
+ * - **not `array`**: Typesense reads `field:=[a,b]` over a `string[]` as
+ *   *contains any*, so a departed source would take every document that merely
+ *   mentions it – including entities another selected dataset still
+ *   contributes;
+ * - **no `transform`**: the sweep compares the stored value against the run’s
+ *   selection, which carries raw dataset IRIs, so a transformed value would
+ *   match nothing and the sweep would silently stop deleting;
+ * - **`facetable`** where the writer enumerates the indexed sources by faceting
+ *   it (the In-place writer does; Blue/green only ever filters by a known IRI).
+ *
+ * Thrown at writer construction, so a declaration that cannot be swept fails
+ * before a run touches the index rather than at the sweep, after the writes.
+ */
+export function assertSweepableProvenanceField(
+  searchType: SearchType,
+  options: { readonly requireFacetable: boolean },
+): void {
+  const field = datasetField(searchType);
+  if (field === undefined || isInternalField(field)) {
+    return;
+  }
+  const problems: string[] = [];
+  if (field.array === true) {
+    problems.push(
+      'it is an array, and a membership sweep over one would delete every document merely mentioning a departed dataset',
+    );
+  }
+  if (field.transform !== undefined) {
+    problems.push(
+      'it declares a transform, and the sweep matches the stored value against the run’s raw dataset IRIs',
+    );
+  }
+  if (options.requireFacetable && field.facetable !== true) {
+    problems.push(
+      'it is not facetable, and the membership sweep enumerates the indexed datasets by faceting it',
+    );
+  }
+  if (problems.length > 0) {
+    throw new Error(
+      `SearchType “${searchType.name}” declares “${field.name}” over the indexed dataset, which this writer keeps its provenance bookkeeping on, but ${problems.join('; and ')}.`,
     );
   }
 }

--- a/packages/search-typesense/src/sweep.ts
+++ b/packages/search-typesense/src/sweep.ts
@@ -1,16 +1,40 @@
 // Pure deletion planning shared by the rebuild writers: which documents leave
 // a collection, expressed as source sets and Typesense filter strings. Kept
 // free of the Typesense client so the logic is unit-testable. This module owns
-// the bookkeeping field names, so stamping and every filter that reads them
-// can never disagree.
+// the private bookkeeping field names and resolves which field a collection
+// carries its provenance in, so stamping and every filter that reads it can
+// never disagree.
 
+import { datasetField, isInternalField } from '@lde/search/adapter';
+import type { SearchType } from '@lde/search';
 import { escapeFilterValue } from './query-compiler.js';
 
-/** The document field carrying the dataset IRI a document came from. */
+/** The private field carrying the dataset IRI a document came from, for a type
+ *  that declares none of its own – see {@link provenanceField}. */
 export const SOURCE_FIELD = 'source';
 
 /** The document field carrying the id of the run that last wrote a document. */
 export const LAST_SEEN_FIELD = 'last_seen';
+
+/**
+ * The field a collection carries its documents’ dataset IRI in – the one the
+ * membership sweep enumerates, filters and deletes by.
+ *
+ * A type that declares a field over the dataset
+ * ({@link datasetField `from: 'dataset'`}) *is* its provenance: the writer keeps
+ * its bookkeeping on that field rather than stamping a private one beside it,
+ * so the facet, the label resolution, any `derive` and the sweep all read one
+ * column that cannot drift. A type declaring nothing – or declaring the dataset
+ * only as an *internal* field, which the projection prunes before the writer
+ * ever sees it – falls back to the private {@link SOURCE_FIELD}, and behaves
+ * exactly as it always has.
+ */
+export function provenanceField(searchType: SearchType): string {
+  const declared = datasetField(searchType);
+  return declared === undefined || isInternalField(declared)
+    ? SOURCE_FIELD
+    : declared.name;
+}
 
 /**
  * Sources whose documents must leave the index: indexed, but no longer part
@@ -32,11 +56,16 @@ export function departedSources(
  * Typesense filter matching a source’s documents that this run did not touch:
  * everything the source no longer contains, ready for a per-source sweep.
  *
- * @param sourceIri The dataset IRI stamped on the documents as `source`
+ * @param sourceField The collection’s {@link provenanceField}
+ * @param sourceIri The dataset IRI the documents carry in that field
  * @param runId The current run; documents it wrote carry it as `last_seen`
  */
-export function staleDocumentsFilter(sourceIri: string, runId: string): string {
-  return `${sourceDocumentsFilter(sourceIri)} && ${LAST_SEEN_FIELD}:!=${escapeFilterValue(runId)}`;
+export function staleDocumentsFilter(
+  sourceField: string,
+  sourceIri: string,
+  runId: string,
+): string {
+  return `${sourceDocumentsFilter(sourceField, sourceIri)} && ${LAST_SEEN_FIELD}:!=${escapeFilterValue(runId)}`;
 }
 
 /**
@@ -44,10 +73,14 @@ export function staleDocumentsFilter(sourceIri: string, runId: string): string {
  * source (a departed source’s membership sweep, or a Blue/green writer rolling
  * a failed dataset out of its not-yet-live collection).
  *
- * @param sourceIri The dataset IRI stamped on the documents as `source`
+ * @param sourceField The collection’s {@link provenanceField}
+ * @param sourceIri The dataset IRI the documents carry in that field
  */
-export function sourceDocumentsFilter(sourceIri: string): string {
-  return `${SOURCE_FIELD}:=${escapeFilterValue(sourceIri)}`;
+export function sourceDocumentsFilter(
+  sourceField: string,
+  sourceIri: string,
+): string {
+  return `${sourceField}:=${escapeFilterValue(sourceIri)}`;
 }
 
 /**
@@ -57,14 +90,16 @@ export function sourceDocumentsFilter(sourceIri: string): string {
  * touching its prior-run documents, which the success sweep or a failed run
  * still owns.
  *
- * @param sourceIri The dataset IRI stamped on the documents as `source`
+ * @param sourceField The collection’s {@link provenanceField}
+ * @param sourceIri The dataset IRI the documents carry in that field
  * @param runId The current run, stamped on its documents as `last_seen`
  */
 export function thisRunDocumentsFilter(
+  sourceField: string,
   sourceIri: string,
   runId: string,
 ): string {
-  return `${sourceDocumentsFilter(sourceIri)} && ${LAST_SEEN_FIELD}:=${escapeFilterValue(runId)}`;
+  return `${sourceDocumentsFilter(sourceField, sourceIri)} && ${LAST_SEEN_FIELD}:=${escapeFilterValue(runId)}`;
 }
 
 /**
@@ -73,15 +108,19 @@ export function thisRunDocumentsFilter(
  * filter stays under a conservative length budget rather than listing every
  * source in one string.
  *
+ * @param sourceField The collection’s {@link provenanceField}
  * @param departed The departed source IRIs ({@link departedSources})
  */
-export function membershipSweepFilters(departed: readonly string[]): string[] {
+export function membershipSweepFilters(
+  sourceField: string,
+  departed: readonly string[],
+): string[] {
   const filters: string[] = [];
   let chunk: string[] = [];
   let chunkLength = 0;
   const flush = () => {
     if (chunk.length > 0) {
-      filters.push(`${SOURCE_FIELD}:=[${chunk.join(',')}]`);
+      filters.push(`${sourceField}:=[${chunk.join(',')}]`);
       chunk = [];
       chunkLength = 0;
     }

--- a/packages/search-typesense/test/blue-green-rebuild.test.ts
+++ b/packages/search-typesense/test/blue-green-rebuild.test.ts
@@ -288,4 +288,50 @@ describe('BlueGreenRebuild', () => {
         ),
     ).toThrow(/source/);
   });
+
+  it('stamps and rolls back on a declared dataset field, without a private source', async () => {
+    const withDataset = {
+      name: 'Dataset',
+      class: 'https://example.org/Dataset',
+      fields: [
+        { name: 'title', kind: 'keyword', output: true },
+        // Not facetable: Blue/green rolls back by a known IRI rather than
+        // enumerating the indexed datasets, so it needs no facet.
+        {
+          name: 'dataset',
+          kind: 'reference',
+          from: 'dataset',
+          output: true,
+          ref: { typeName: 'Dataset', strategy: 'labelOnly' },
+        },
+      ],
+    } satisfies SearchType;
+    const writer = new BlueGreenRebuild<{ id: string; title: string }>(
+      client,
+      withDataset,
+      { name: NAME },
+    );
+
+    const failing = new Dataset({
+      iri: new URL('http://example.org/dataset/2'),
+      distributions: [],
+    });
+    const run = await writer.openRun(makeRunContext([dataset.iri.toString()]));
+    await run.write(dataset, stream([{ id: 'a1', title: 'One' }]));
+    await run.flush?.(dataset, 'success');
+    await run.write(failing, stream([{ id: 'b1', title: 'Bee' }]));
+    // A failed dataset is rolled back by its dataset IRI.
+    await run.flush?.(failing, 'failed');
+    await run.commit();
+
+    const stored = (await client
+      .collections(NAME)
+      .documents('a1')
+      .retrieve()) as Record<string, unknown>;
+    expect(stored.dataset).toBe(dataset.iri.toString());
+    expect(stored).not.toHaveProperty('source');
+    await expect(
+      client.collections(NAME).documents('b1').retrieve(),
+    ).rejects.toThrow();
+  });
 });

--- a/packages/search-typesense/test/in-place-rebuild.test.ts
+++ b/packages/search-typesense/test/in-place-rebuild.test.ts
@@ -316,4 +316,96 @@ describe('InPlaceRebuild', () => {
       /source/,
     );
   });
+
+  describe('a type declaring the indexed dataset', () => {
+    const withDataset: SearchType = {
+      name: 'Object',
+      class: 'https://example.org/Object',
+      fields: [
+        { name: 'title', kind: 'keyword', output: true },
+        {
+          name: 'dataset',
+          kind: 'reference',
+          from: 'dataset',
+          output: true,
+          filterable: true,
+          facetable: true,
+          ref: { typeName: 'Dataset', strategy: 'labelOnly' },
+        },
+      ],
+    };
+
+    it('keeps its provenance on the declared field, with no private source beside it', async () => {
+      const writer = new InPlaceRebuild<{ id: string; title: string }>(
+        client,
+        withDataset,
+        { name: NAME },
+      );
+
+      const run = await writer.openRun(
+        makeRunContext([datasetA.iri.toString()]),
+      );
+      await run.write(datasetA, stream([{ id: 'a1', title: 'One' }]));
+      await run.flush?.(datasetA, 'success');
+      await run.commit();
+
+      const stored = (await client
+        .collections(NAME)
+        .documents('a1')
+        .retrieve()) as Record<string, unknown>;
+      expect(stored.dataset).toBe('http://example.org/dataset/a');
+      // One column, not the same IRI twice under two names.
+      expect(stored).not.toHaveProperty('source');
+      const definition = await client.collections(NAME).retrieve();
+      expect(definition.fields?.map((field) => field.name)).not.toContain(
+        'source',
+      );
+    });
+
+    it('sweeps a departed dataset by the declared field', async () => {
+      const writer = new InPlaceRebuild<{ id: string; title: string }>(
+        client,
+        withDataset,
+        { name: NAME },
+      );
+      await seed(
+        writer,
+        new Map([
+          [datasetA, [{ id: 'a1', title: 'One' }]],
+          [datasetB, [{ id: 'b1', title: 'Bee' }]],
+        ]),
+      );
+
+      // B leaves the selection: the membership sweep enumerates and deletes by
+      // `dataset`, the column the facet and the label resolution also read.
+      const run = await writer.openRun(
+        makeRunContext([datasetA.iri.toString()]),
+      );
+      await run.write(datasetA, stream([{ id: 'a1', title: 'One' }]));
+      await run.flush?.(datasetA, 'success');
+      await run.commit();
+
+      expect(await documentIds(client)).toEqual(['a1']);
+    });
+
+    it('refuses a declared dataset field the sweep cannot enumerate', () => {
+      const notFacetable: SearchType = {
+        name: 'Object',
+        class: 'https://example.org/Object',
+        fields: [
+          {
+            name: 'dataset',
+            kind: 'reference',
+            from: 'dataset',
+            output: true,
+            ref: { typeName: 'Dataset', strategy: 'labelOnly' },
+          },
+        ],
+      };
+
+      expect(
+        () => new InPlaceRebuild(client, notFacetable, { name: NAME }),
+      ).toThrow(/facetable/);
+    });
+  });
 });

--- a/packages/search-typesense/test/rebuild-support.test.ts
+++ b/packages/search-typesense/test/rebuild-support.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { SearchType } from '@lde/search';
 import {
   assertNoReservedFields,
+  assertSweepableProvenanceField,
   resolveRebuildOptions,
   stampDocuments,
 } from '../src/rebuild-support.js';
@@ -83,6 +84,95 @@ describe('assertNoReservedFields', () => {
         'last_seen',
       ]),
     ).toThrow(/reserved bookkeeping field\(s\) “source”, “last_seen”/);
+  });
+});
+
+describe('assertSweepableProvenanceField', () => {
+  const typeWith = (field: object): SearchType => ({
+    name: 'Object',
+    class: 'https://example.org/Object',
+    fields: [field] as SearchType['fields'],
+  });
+
+  it('accepts a type declaring no dataset field at all', () => {
+    expect(() =>
+      assertSweepableProvenanceField(
+        typeWith({ name: 'title', kind: 'keyword' }),
+        {
+          requireFacetable: true,
+        },
+      ),
+    ).not.toThrow();
+  });
+
+  it('accepts a facetable, single-valued declaration', () => {
+    expect(() =>
+      assertSweepableProvenanceField(
+        typeWith({
+          name: 'dataset',
+          kind: 'reference',
+          from: 'dataset',
+          facetable: true,
+        }),
+        { requireFacetable: true },
+      ),
+    ).not.toThrow();
+  });
+
+  it('ignores an internal dataset field: the projection prunes it before the writer', () => {
+    expect(() =>
+      assertSweepableProvenanceField(
+        typeWith({ name: 'dataset', kind: 'reference', from: 'dataset' }),
+        { requireFacetable: true },
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects an array declaration, which a membership sweep would over-delete by', () => {
+    expect(() =>
+      assertSweepableProvenanceField(
+        typeWith({
+          name: 'dataset',
+          kind: 'reference',
+          from: 'dataset',
+          array: true,
+          facetable: true,
+        }),
+        { requireFacetable: true },
+      ),
+    ).toThrow(/array/);
+  });
+
+  it('rejects a transform, which would stop the stored value matching the selection', () => {
+    expect(() =>
+      assertSweepableProvenanceField(
+        typeWith({
+          name: 'dataset',
+          kind: 'reference',
+          from: 'dataset',
+          facetable: true,
+          transform: (value: string) => value.replace('https://', 'http://'),
+        }),
+        { requireFacetable: true },
+      ),
+    ).toThrow(/transform/);
+  });
+
+  it('requires facetable only where the writer enumerates the indexed datasets', () => {
+    const notFacetable = typeWith({
+      name: 'dataset',
+      kind: 'reference',
+      from: 'dataset',
+      output: true,
+    });
+
+    expect(() =>
+      assertSweepableProvenanceField(notFacetable, { requireFacetable: true }),
+    ).toThrow(/facetable/);
+    // Blue/green only ever filters by a known IRI, so it needs no facet.
+    expect(() =>
+      assertSweepableProvenanceField(notFacetable, { requireFacetable: false }),
+    ).not.toThrow();
   });
 });
 

--- a/packages/search-typesense/test/sweep.test.ts
+++ b/packages/search-typesense/test/sweep.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { defineSearchType } from '@lde/search';
 import {
+  SOURCE_FIELD,
   departedSources,
   membershipSweepFilters,
   sourceDocumentsFilter,
+  provenanceField,
   staleDocumentsFilter,
   thisRunDocumentsFilter,
 } from '../src/sweep.js';
@@ -32,23 +35,69 @@ describe('departedSources', () => {
   });
 });
 
+describe('provenanceField', () => {
+  it('falls back to the private source field for a type declaring no dataset field', () => {
+    const type = defineSearchType({
+      name: 'Person',
+      class: 'http://schema.org/Person',
+      fields: [{ name: 'name', kind: 'keyword', output: true }],
+    });
+
+    expect(provenanceField(type)).toBe(SOURCE_FIELD);
+  });
+
+  it('is the declared dataset field, so the sweep reads the same column the facet does', () => {
+    const type = defineSearchType({
+      name: 'Person',
+      class: 'http://schema.org/Person',
+      fields: [
+        {
+          name: 'dataset',
+          kind: 'reference',
+          from: 'dataset',
+          facetable: true,
+        },
+      ],
+    });
+
+    expect(provenanceField(type)).toBe('dataset');
+  });
+
+  it('falls back for an INTERNAL dataset field: the projection prunes it before the writer', () => {
+    // Declared with no role, purely so a later derive can read it.
+    const type = defineSearchType({
+      name: 'Person',
+      class: 'http://schema.org/Person',
+      fields: [{ name: 'dataset', kind: 'reference', from: 'dataset' }],
+    });
+
+    expect(provenanceField(type)).toBe(SOURCE_FIELD);
+  });
+});
+
 describe('staleDocumentsFilter', () => {
+  it('filters on whichever field carries the provenance', () => {
+    expect(
+      staleDocumentsFilter('dataset', 'http://example.org/a', 'run-1'),
+    ).toBe('dataset:=`http://example.org/a` && last_seen:!=`run-1`');
+  });
+
   it('matches a source’s documents not touched by this run', () => {
-    expect(staleDocumentsFilter('http://example.org/a', 'run-1')).toBe(
-      'source:=`http://example.org/a` && last_seen:!=`run-1`',
-    );
+    expect(
+      staleDocumentsFilter(SOURCE_FIELD, 'http://example.org/a', 'run-1'),
+    ).toBe('source:=`http://example.org/a` && last_seen:!=`run-1`');
   });
 
   it('escapes values that would break out of the filter quoting', () => {
-    expect(staleDocumentsFilter('http://example.org/`', 'run-1')).toBe(
-      'source:=`http://example.org/\\`` && last_seen:!=`run-1`',
-    );
+    expect(
+      staleDocumentsFilter(SOURCE_FIELD, 'http://example.org/`', 'run-1'),
+    ).toBe('source:=`http://example.org/\\`` && last_seen:!=`run-1`');
   });
 });
 
 describe('sourceDocumentsFilter', () => {
   it('matches all of a source’s documents', () => {
-    expect(sourceDocumentsFilter('http://example.org/a')).toBe(
+    expect(sourceDocumentsFilter(SOURCE_FIELD, 'http://example.org/a')).toBe(
       'source:=`http://example.org/a`',
     );
   });
@@ -56,21 +105,24 @@ describe('sourceDocumentsFilter', () => {
 
 describe('thisRunDocumentsFilter', () => {
   it('matches only the documents this run wrote for a source (the inverse of stale)', () => {
-    expect(thisRunDocumentsFilter('http://example.org/a', 'run-1')).toBe(
-      'source:=`http://example.org/a` && last_seen:=`run-1`',
-    );
+    expect(
+      thisRunDocumentsFilter(SOURCE_FIELD, 'http://example.org/a', 'run-1'),
+    ).toBe('source:=`http://example.org/a` && last_seen:=`run-1`');
   });
 });
 
 describe('membershipSweepFilters', () => {
   it('combines departed sources into one membership filter', () => {
     expect(
-      membershipSweepFilters(['http://example.org/a', 'http://example.org/b']),
+      membershipSweepFilters(SOURCE_FIELD, [
+        'http://example.org/a',
+        'http://example.org/b',
+      ]),
     ).toEqual(['source:=[`http://example.org/a`,`http://example.org/b`]']);
   });
 
   it('returns no filters when nothing departed', () => {
-    expect(membershipSweepFilters([])).toEqual([]);
+    expect(membershipSweepFilters(SOURCE_FIELD, [])).toEqual([]);
   });
 
   it('splits very long source lists over several filters', () => {
@@ -81,7 +133,7 @@ describe('membershipSweepFilters', () => {
       (_, index) => `http://example.org/dataset/with/a/long/path/${index}`,
     );
 
-    const filters = membershipSweepFilters(departed);
+    const filters = membershipSweepFilters(SOURCE_FIELD, departed);
 
     expect(filters.length).toBeGreaterThan(1);
     expect(filters.every((filter) => filter.length < 3200)).toBe(true);

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these – see AGENTS.md.
-          functions: 98.77,
-          lines: 99.12,
-          branches: 94.7,
-          statements: 99.14,
+          functions: 98.78,
+          lines: 99.15,
+          branches: 95.02,
+          statements: 99.17,
         },
       },
     },

--- a/packages/search/CONTEXT.md
+++ b/packages/search/CONTEXT.md
@@ -76,19 +76,38 @@ _Avoid_: sh:path, predicate, selector
 
 **Derive**:
 A Search Field’s computation – what to compute from what was already read. Runs
-in declaration order over the Search Document; never touches the graph, and
-never reaches outside it. Pure and synchronous: a Derive cannot fail.
+in declaration order over the Search Document and the Projection Context; never
+touches the graph, and never reaches outside those two. Pure and synchronous: a
+Derive cannot fail.
 _Avoid_: transform, resolver, mapper
 
-A field has a Path or a Derive, never both. **Path says what to read; Derive
-says what to compute from what was read.**
+**Projection Value**:
+Something the run knows and the graph does not say – a fact about the
+_indexing_, not about the data. Today one: the **Dataset** being indexed, which
+for the entity types carrying no containing-collection property is the only
+available answer to which dataset an entity comes from. A `keyword`/`reference`
+field declares itself over one with `from`, and then carries the full range of
+Roles like any other field.
+_Avoid_: bookkeeping field, stamp, system field
+
+**Projection Context**:
+The Projection Values a projection runs with. Supplied by the pipeline stage
+(which is where the Dataset is known – the writer sees it only _after_
+projection) and passed to every Derive as its second argument, so a Derive can
+relate a projected value to its provenance.
+_Avoid_: run context, environment
+
+A field has a Path, a Derive or a `from`, never more than one. **Path says what
+to read; Derive says what to compute from what was read; `from` says which
+Projection Value to take.**
 
 A value obtained from beyond the record – a service, a store, anything the
 projection did not read – is an **enrichment**, which belongs to
 `@lde/search-pipeline` and runs _after_ projection. Used here, never redefined.
 The boundary is what each is a function of: **a Derive is a function of the
-Search Document; an enrichment is a function of the world.** A Derive therefore
-cannot read an enriched value.
+Search Document and the Projection Context; an enrichment is a function of the
+world.** A Derive therefore cannot read an enriched value. A Projection Value is
+not an enrichment either: the run already holds it, so nothing is fetched.
 
 Two absences declare intent, and both are load-bearing: **a field without a Role
 is an Internal Field; a type without a `class` is a Reference Type.**

--- a/packages/search/src/adapter.ts
+++ b/packages/search/src/adapter.ts
@@ -26,6 +26,7 @@ export {
   referenceTypeNamed,
   inlineFramingDepth,
   fieldNamed,
+  datasetField,
   ID_FIELD,
   labelFieldOf,
   isRangeFacet,

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -8,7 +8,11 @@
 // unified SearchField/SearchType model. A `derive` reads the projected document,
 // never the graph, so the IR readers stay internal to projection.
 export { projectRoots } from './project.js';
-export type { ProjectedNode, SearchDocument } from './project.js';
+export type {
+  ProjectedNode,
+  ProjectionContext,
+  SearchDocument,
+} from './project.js';
 
 // Unified field model: one declaration drives projection, engine collection
 // schema, query semantics and the GraphQL surface – a discriminated union by
@@ -37,6 +41,7 @@ export type {
   SearchTypeIssue,
   SearchSchema,
   FacetRange,
+  ProjectionValue,
 } from './schema.js';
 
 // Engine- and protocol-neutral query IR (what a `queryDefaults` policy or an

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -16,6 +16,7 @@ import {
   physicalFields,
   referenceTypeNamed,
   type KeywordField,
+  type ProjectionValue,
   type ReferenceField,
   type RootType,
   type SearchField,
@@ -37,6 +38,27 @@ export type ProjectedNode = Record<string, unknown>;
 export type SearchDocument = { id: string } & ProjectedNode;
 
 /**
+ * What the projection knows that the graph does not say: the values a run
+ * carries about the *indexing* rather than about the data. They reach a
+ * declaration two ways – a field declaring {@link KeywordField.from `from`} is
+ * populated from one, and every `derive` receives the whole context as its
+ * second argument, so a derive can relate a projected value to it.
+ *
+ * Empty when the caller supplies nothing: projecting a graph in isolation (a
+ * test, a one-off) is legitimate, and a field over an absent value is simply
+ * left unpopulated, exactly as a `path` that matched nothing is.
+ */
+export interface ProjectionContext extends Partial<
+  Readonly<Record<ProjectionValue, string>>
+> {
+  /** The IRI of the dataset being indexed. */
+  readonly dataset?: string;
+}
+
+/** The context a projection runs with when its caller supplied none. */
+const NO_PROJECTION_CONTEXT: ProjectionContext = {};
+
+/**
  * Project one framed JSON-LD node into a flat search document: apply each field
  * of the type in declaration order. A field with a `derive` function computes
  * its value from the document as populated so far (so a derived field may read
@@ -54,6 +76,7 @@ export function projectDocument(
   node: FramedNode,
   searchType: SearchType,
   schema?: SearchSchema,
+  context: ProjectionContext = NO_PROJECTION_CONTEXT,
 ): SearchDocument {
   if (documentKey(node) === undefined) {
     throw new Error(
@@ -62,7 +85,12 @@ export function projectDocument(
   }
   // The guard above is what makes this a SearchDocument: projectFields sets `id`
   // for exactly the nodes documentKey resolves.
-  const document = projectFields(node, searchType, schema) as SearchDocument;
+  const document = projectFields(
+    node,
+    searchType,
+    schema,
+    context,
+  ) as SearchDocument;
   pruneInternalFields(document, searchType, schema);
   return document;
 }
@@ -116,11 +144,12 @@ function projectFields(
   node: FramedNode,
   searchType: SearchType,
   schema: SearchSchema | undefined,
+  context: ProjectionContext,
 ): ProjectedNode {
   const id = documentKey(node);
   const document: ProjectedNode = id === undefined ? {} : { id };
   for (const field of searchType.fields) {
-    applyField(document, node, field, searchType, schema);
+    applyField(document, node, field, searchType, schema, context);
   }
   return document;
 }
@@ -155,6 +184,7 @@ export async function* projectRoots(
   roots: readonly string[],
   schema: SearchSchema,
   searchType: RootType,
+  context: ProjectionContext = NO_PROJECTION_CONTEXT,
 ): AsyncIterable<SearchDocument> {
   assertTypeInSchema(schema, searchType);
   const index = buildSubjectIndex(quads);
@@ -164,7 +194,7 @@ export async function* projectRoots(
   // duplicate document under the same `id`.
   const depth = inlineFramingDepth(schema, searchType);
   for await (const node of frameSubjects(index, [...new Set(roots)], depth)) {
-    yield projectDocument(node, searchType, schema);
+    yield projectDocument(node, searchType, schema, context);
   }
 }
 
@@ -174,9 +204,18 @@ function applyField(
   field: SearchField,
   searchType: SearchType,
   schema: SearchSchema | undefined,
+  context: ProjectionContext,
 ): void {
+  // The three value sources, mutually exclusive by declaration
+  // (`validateSearchType`): a projection value, a computed value, a graph path.
+  if (
+    (field.kind === 'keyword' || field.kind === 'reference') &&
+    field.from !== undefined
+  ) {
+    return applyProjectionValue(document, field, field.from, context);
+  }
   if (field.derive !== undefined) {
-    const value = field.derive(document);
+    const value = field.derive(document, context);
     if (value !== undefined) {
       document[field.name] = value;
     }
@@ -199,7 +238,7 @@ function applyField(
     // project nothing rather than fall through and emit the referent IRIs under
     // the field name (the wrong shape).
     if (schema !== undefined) {
-      applyInlineReference(document, node, alias, field, schema);
+      applyInlineReference(document, node, alias, field, schema, context);
     }
     return;
   }
@@ -335,6 +374,31 @@ function applyFacet(
 }
 
 /**
+ * Project a field declared over a {@link ProjectionContext} value: read the
+ * value the run carries and write it exactly as a graph-read one, through
+ * {@link applyFacet} – so `array`, `transform` and the folded `searchable`
+ * companion mean the same thing for a declaration over the dataset as for one
+ * over a path, and the collection definition needs no special case.
+ *
+ * A value the context does not carry writes nothing: a projection run outside a
+ * pipeline (a test, a one-off) leaves the field absent rather than inventing a
+ * placeholder, the same as a `path` that matched nothing.
+ */
+function applyProjectionValue(
+  document: ProjectedNode,
+  field: KeywordField | ReferenceField,
+  from: ProjectionValue,
+  context: ProjectionContext,
+): void {
+  // `ProjectionContext` is keyed by `ProjectionValue`, so the declaration reads
+  // the context directly: a projection value that has no context key, or a
+  // context key no declaration can name, is a compile error rather than a
+  // silently unpopulated field.
+  const value = context[from];
+  applyFacet(document, value === undefined ? [] : [value], field);
+}
+
+/**
  * Project an inline reference: the referent node(s) embedded under the field’s
  * {@link irAlias IR Alias} are each projected through the reference’s
  * {@link ReferenceType} (whose own fields read their own aliases, minted against
@@ -357,6 +421,7 @@ function applyInlineReference(
   alias: string,
   field: ReferenceField & { readonly ref: { readonly typeName: string } },
   schema: SearchSchema,
+  context: ProjectionContext,
 ): void {
   // Resolves for a schema that declares the referent (always so for the schema a
   // type is projected through); a type framed against a foreign schema that
@@ -367,7 +432,7 @@ function applyInlineReference(
   }
   const referents = valuesOf(node, alias)
     .filter(isObject)
-    .map((referent) => projectFields(referent, referenceType, schema))
+    .map((referent) => projectFields(referent, referenceType, schema, context))
     // Fields, not identity, are what makes something a referent: a literal
     // value object under the alias (dirty source data), or a node this
     // reference type reads nothing from, projects nothing and is no referent.

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -1,4 +1,4 @@
-import type { ProjectedNode } from './project.js';
+import type { ProjectedNode, ProjectionContext } from './project.js';
 
 /**
  * The engine-neutral kind of a queryable field. It drives every downstream
@@ -52,9 +52,13 @@ export function filterOperatorFor(kind: FieldKind): FilterOperator | undefined {
  * field with a {@link SearchFieldBase.derive `derive`} function instead of a
  * `path` is a **derived field** – computed from the document projected so far
  * rather than read from the graph – yet it still carries full query/schema/output
- * behavior (e.g. `status`, the compatibility booleans). A field declaring **no**
- * role at all is an {@link isInternalField **internal field**}: projected so a
- * later derive can read it, then pruned before the writer.
+ * behavior (e.g. `status`, the compatibility booleans). A `keyword`/`reference`
+ * field may instead declare {@link KeywordField.from `from`}, populating it from
+ * a {@link ProjectionValue} – something the run knows and the graph does not.
+ * `path`, `derive` and `from` are the three mutually exclusive value sources. A
+ * field declaring **no** role at all is an {@link isInternalField **internal
+ * field**}: projected so a later derive can read it, then pruned before the
+ * writer.
  *
  * The physical field names a declaration fans out to (per-locale search/sort
  * keys) follow one convention, owned by
@@ -110,9 +114,34 @@ export interface SearchFieldBase {
    * is the search document for a root type, and the referent’s own
    * projected fields for a Reference Type – which carry an `id` only when the
    * referent is a named node, never for a blank-node one.
+   *
+   * The second argument is the {@link ProjectionContext} – the run’s
+   * projection-time values, which are about the *indexing*, not the graph (the
+   * dataset being indexed). It is what lets a derive relate a projected value
+   * to its provenance: dropping a polymorphic `isPartOf` value that merely
+   * points back at the containing dataset, say.
    */
-  readonly derive?: (document: ProjectedNode) => unknown;
+  readonly derive?: (
+    document: ProjectedNode,
+    context: ProjectionContext,
+  ) => unknown;
 }
+
+/**
+ * A projection-time value a field can be declared **over** – something the run
+ * knows that the graph does not say. `dataset` is the IRI of the dataset being
+ * indexed: every indexed document comes from exactly one, and for the many
+ * entity types that carry no containing-collection property (`Person`,
+ * `Organization`, `Place`, …) it is the only available answer to *which dataset
+ * does this come from*.
+ *
+ * A field declaring one is populated by the projection, like a `path`-bearing
+ * or `derive`d field, and carries the full range of behaviour: `output`,
+ * `filterable`, `facetable`, and – for a `reference` – a
+ * {@link ReferenceField.labelSource `labelSource`} that resolves the IRI to a
+ * readable label at query time.
+ */
+export type ProjectionValue = 'dataset';
 
 /** Full-text inclusion with a `query_by` weight (folded; per-locale for
  *  localized text). Presence is what makes a field searchable. */
@@ -149,6 +178,9 @@ export interface KeywordField extends SearchFieldBase, Searchable {
   /** Projection-time value transform (e.g. strip a media-type prefix). */
   readonly transform?: (value: string) => string;
   readonly facetRanges?: never;
+  /** Populate from a {@link ProjectionValue} instead of the graph. Mutually
+   *  exclusive with `path` and `derive`. */
+  readonly from?: ProjectionValue;
 }
 
 /** An IRI-valued reference to another entity, label-resolved at the surface. */
@@ -157,6 +189,11 @@ export interface ReferenceField extends SearchFieldBase, Searchable {
   /** Projection-time value transform. */
   readonly transform?: (value: string) => string;
   readonly facetRanges?: never;
+  /** Populate from a {@link ProjectionValue} instead of the graph – a
+   *  `dataset` reference is how a type declares the dataset it was indexed
+   *  from, resolvable to a label like any other reference. Mutually exclusive
+   *  with `path` and `derive`. */
+  readonly from?: ProjectionValue;
   /**
    * The `name` of the {@link SearchType} whose collection resolves this
    * reference’s labels – its ‘label source’. The named type must declare an
@@ -706,6 +743,11 @@ export interface SearchTypeIssue {
     | 'searchable-not-allowed'
     | 'transform-not-allowed'
     | 'derive-with-path'
+    | 'from-not-allowed'
+    | 'from-with-path'
+    | 'from-with-derive'
+    | 'unknown-projection-value'
+    | 'duplicate-projection-value'
     | 'text-not-filterable'
     | 'text-not-facetable'
     | 'reserved-field-name';
@@ -730,6 +772,17 @@ const SEARCHABLE_KINDS: readonly FieldKind[] = ['text', 'keyword', 'reference'];
 
 /** Kinds whose projection applies the {@link KeywordField.transform}. */
 const TRANSFORMABLE_KINDS: readonly FieldKind[] = ['keyword', 'reference'];
+
+/**
+ * Kinds a {@link ProjectionValue} can populate: every projection value is an
+ * IRI or a token, so only the two string-shaped kinds can hold one. `reference`
+ * is what carries a {@link ReferenceField.labelSource}, and so the kind a
+ * facet over the dataset wants.
+ */
+const FROM_KINDS: readonly FieldKind[] = ['keyword', 'reference'];
+
+/** The {@link ProjectionValue}s a declaration may name. */
+const PROJECTION_VALUES: readonly string[] = ['dataset'];
 
 /**
  * A safe logical field name: a GraphQL-style identifier. The name is
@@ -773,7 +826,12 @@ const LOCALE_PATTERN = /^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$/;
  * - `transform` only on `keyword`/`reference` (the only kinds whose
  *   projection applies it);
  * - `derive` and `path` are mutually exclusive (a field is projected or
- *   computed, never both).
+ *   computed, never both);
+ * - `from` names a known {@link ProjectionValue}, sits on a `keyword`/`reference`
+ *   field, excludes `path` and `derive` (the three are the value sources, and a
+ *   field has exactly one), and no two fields declare the same projection value
+ *   – which would leave a consumer reading the dataset off a declaration no
+ *   rule picks between.
  *
  * Pure and total: returns every issue rather than throwing;
  * {@link assertValidSearchType} is the throwing entry point.
@@ -783,6 +841,7 @@ export function validateSearchType(
 ): readonly SearchTypeIssue[] {
   const issues: SearchTypeIssue[] = [];
   const seen = new Set<string>();
+  const seenProjectionValues = new Set<string>();
   for (const declared of searchType.fields) {
     // Validation guards declarations built OUTSIDE TypeScript (a SHACL
     // generator, plain JS), so it inspects the uniform flat shape rather
@@ -869,6 +928,26 @@ export function validateSearchType(
     if (field.derive !== undefined && field.path !== undefined) {
       issue('derive-with-path');
     }
+    if (field.from !== undefined) {
+      if (!PROJECTION_VALUES.includes(field.from)) {
+        issue('unknown-projection-value');
+      } else if (seenProjectionValues.has(field.from)) {
+        // Two fields over one projection value leaves every consumer that
+        // resolves the value back to a declaration – the writer’s provenance
+        // field, above all – with no rule to pick between them.
+        issue('duplicate-projection-value');
+      }
+      seenProjectionValues.add(field.from);
+      if (!FROM_KINDS.includes(field.kind)) {
+        issue('from-not-allowed');
+      }
+      if (field.path !== undefined) {
+        issue('from-with-path');
+      }
+      if (field.derive !== undefined) {
+        issue('from-with-derive');
+      }
+    }
   }
   return issues;
 }
@@ -880,6 +959,7 @@ interface FlatField extends SearchFieldBase, Searchable, RangeFacetable {
   readonly locales?: readonly string[];
   readonly ref?: ReferenceField['ref'];
   readonly transform?: (value: string) => string;
+  readonly from?: ProjectionValue;
 }
 
 /**
@@ -1053,6 +1133,26 @@ export function referenceFields(
   searchType: SearchType,
 ): readonly ReferenceField[] {
   return searchType.fields.filter((field) => field.kind === 'reference');
+}
+
+/**
+ * The field a type declares over the dataset being indexed
+ * ({@link ProjectionValue `from: 'dataset'`}), if it declares one.
+ * {@link validateSearchType} allows at most one, so this is a total answer, not
+ * a first match.
+ *
+ * The single lookup every consumer of the declaration shares – the projection
+ * that populates it, and the engine writer that keeps its provenance
+ * bookkeeping on it rather than on a private field of its own.
+ */
+export function datasetField(
+  searchType: SearchType,
+): (KeywordField | ReferenceField) | undefined {
+  return searchType.fields.find(
+    (field): field is KeywordField | ReferenceField =>
+      (field.kind === 'keyword' || field.kind === 'reference') &&
+      field.from === 'dataset',
+  );
 }
 
 /** Look up a field by its logical name. */

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -746,6 +746,7 @@ export interface SearchTypeIssue {
     | 'from-not-allowed'
     | 'from-with-path'
     | 'from-with-derive'
+    | 'from-with-inline-ref'
     | 'unknown-projection-value'
     | 'duplicate-projection-value'
     | 'text-not-filterable'
@@ -829,9 +830,10 @@ const LOCALE_PATTERN = /^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$/;
  *   computed, never both);
  * - `from` names a known {@link ProjectionValue}, sits on a `keyword`/`reference`
  *   field, excludes `path` and `derive` (the three are the value sources, and a
- *   field has exactly one), and no two fields declare the same projection value
- *   – which would leave a consumer reading the dataset off a declaration no
- *   rule picks between.
+ *   field has exactly one), is not an `inline` reference (a projection value is
+ *   a bare IRI, with no referent to carry fields from), and no two fields
+ *   declare the same projection value – which would leave a consumer reading
+ *   the dataset off a declaration no rule picks between.
  *
  * Pure and total: returns every issue rather than throwing;
  * {@link assertValidSearchType} is the throwing entry point.
@@ -946,6 +948,14 @@ export function validateSearchType(
       }
       if (field.derive !== undefined) {
         issue('from-with-derive');
+      }
+      // An inline reference carries a referent’s projected fields, and the
+      // collection definition declares it as a nested object. A projection
+      // value has no referent – it is a bare IRI – so the two together would
+      // declare an object field the projection fills with a string, and every
+      // document import would fail.
+      if (field.ref?.strategy === 'inline') {
+        issue('from-with-inline-ref');
       }
     }
   }
@@ -1138,8 +1148,9 @@ export function referenceFields(
 /**
  * The field a type declares over the dataset being indexed
  * ({@link ProjectionValue `from: 'dataset'`}), if it declares one.
- * {@link validateSearchType} allows at most one, so this is a total answer, not
- * a first match.
+ * {@link validateSearchType} rejects a second field over the same projection
+ * value, so for any type that reached a {@link SearchSchema} this is the only
+ * such field rather than the first of several.
  *
  * The single lookup every consumer of the declaration shares – the projection
  * that populates it, and the engine writer that keeps its provenance

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -1335,3 +1335,149 @@ describe('projectRoots', () => {
     ).rejects.toThrow(/not in this engine’s schema/);
   });
 });
+
+describe('projection-time values', () => {
+  const person = defineSearchType({
+    name: 'Person',
+    class: 'http://schema.org/Person',
+    fields: [
+      {
+        name: 'dataset',
+        kind: 'reference',
+        from: 'dataset',
+        output: true,
+        filterable: true,
+        facetable: true,
+        ref: { typeName: 'Dataset', strategy: 'labelOnly' },
+      },
+    ],
+  });
+
+  it('populates a field declared over the indexed dataset', () => {
+    const document = projectDocument(
+      { '@id': 'https://ex/p/1' },
+      person,
+      undefined,
+      { dataset: 'https://ex/d/1' },
+    );
+
+    expect(document.dataset).toBe('https://ex/d/1');
+  });
+
+  it('leaves the field absent when the caller supplies no dataset', () => {
+    // Projecting a graph in isolation is legitimate; an absent value writes
+    // nothing rather than a placeholder, exactly as an unmatched path does.
+    const document = projectDocument({ '@id': 'https://ex/p/1' }, person);
+
+    expect(document).not.toHaveProperty('dataset');
+  });
+
+  it('writes the folded search companion, like any other faceted field', () => {
+    const searchable = defineSearchType({
+      name: 'Person',
+      class: 'http://schema.org/Person',
+      fields: [
+        {
+          name: 'dataset',
+          kind: 'keyword',
+          from: 'dataset',
+          facetable: true,
+          searchable: { weight: 1 },
+        },
+      ],
+    });
+
+    const document = projectDocument(
+      { '@id': 'https://ex/p/1' },
+      searchable,
+      undefined,
+      { dataset: 'https://ex/D/1' },
+    );
+
+    expect(document.dataset).toBe('https://ex/D/1');
+    expect(document.dataset_search).toBe('https://ex/d/1');
+  });
+
+  it('gives derive the context, so it can drop a value that is the containing dataset', () => {
+    // `isPartOf` is polymorphic: it may point at a containing CreativeWork as
+    // well as at the dataset. A deployment wanting only the former drops any
+    // value equal to the dataset being indexed – which is only possible if the
+    // dataset is known DURING projection.
+    const work = defineSearchType({
+      name: 'CreativeWork',
+      class: 'http://schema.org/CreativeWork',
+      fields: [
+        {
+          name: 'partOfRaw',
+          kind: 'reference',
+          path: 'http://schema.org/isPartOf',
+          array: true,
+        },
+        {
+          name: 'isPartOf',
+          kind: 'reference',
+          array: true,
+          output: true,
+          ref: { typeName: 'CreativeWork', strategy: 'labelOnly' },
+          derive: (document, context) =>
+            (document.partOfRaw as string[] | undefined)?.filter(
+              (value) => value !== context.dataset,
+            ),
+        },
+      ],
+    });
+
+    const document = projectDocument(
+      {
+        '@id': 'https://ex/w/1',
+        [alias('CreativeWork', 'partOfRaw')]: [
+          { '@id': 'https://ex/d/1' },
+          { '@id': 'https://ex/w/parent' },
+        ],
+      },
+      work,
+      undefined,
+      { dataset: 'https://ex/d/1' },
+    );
+
+    expect(document.isPartOf).toEqual(['https://ex/w/parent']);
+  });
+
+  it('reaches an inline referent’s own fields', () => {
+    const media = defineSearchType({
+      name: 'MediaObject',
+      fields: [
+        { name: 'dataset', kind: 'keyword', from: 'dataset', output: true },
+      ],
+    });
+    const work = defineSearchType({
+      name: 'CreativeWork',
+      class: 'https://schema.org/CreativeWork',
+      fields: [
+        {
+          name: 'media',
+          kind: 'reference',
+          path: 'https://schema.org/associatedMedia',
+          output: true,
+          ref: { typeName: 'MediaObject', strategy: 'inline' },
+        },
+      ],
+    });
+    const nested = searchSchema(work, media);
+
+    const document = projectDocument(
+      {
+        '@id': 'https://ex/w/1',
+        [alias('CreativeWork', 'media')]: { '@id': 'https://ex/m/1' },
+      },
+      work,
+      nested,
+      { dataset: 'https://ex/d/1' },
+    );
+
+    expect(document.media).toEqual({
+      id: 'https://ex/m/1',
+      dataset: 'https://ex/d/1',
+    });
+  });
+});

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assertTypeInSchema,
   assertValidSearchType,
+  datasetField,
   displayFieldName,
   displayFieldPattern,
   displayLangOf,
@@ -292,6 +293,26 @@ describe('schema selectors', () => {
     expect(fieldNamed(withReference, 'publisher')).toBe(publisher);
     expect(fieldNamed(withReference, 'nonexistent')).toBeUndefined();
   });
+
+  it('finds the field declared over the indexed dataset, and none where there is none', () => {
+    const declared: SearchField = {
+      name: 'dataset',
+      kind: 'reference',
+      from: 'dataset',
+      facetable: true,
+      ref: { typeName: 'Dataset', strategy: 'labelOnly' },
+    };
+    const withDataset: SearchType = {
+      name: 'Dataset',
+      class: DATASET,
+      fields: [...schema.fields, declared],
+    };
+
+    expect(datasetField(withDataset)).toBe(declared);
+    // `schema` declares text/keyword/numeric fields but nothing over a
+    // projection value.
+    expect(datasetField(schema)).toBeUndefined();
+  });
 });
 
 describe('isRangeFacet', () => {
@@ -487,6 +508,78 @@ describe('validateSearchType', () => {
         }),
       ),
     ).toEqual([{ field: 'status', reason: 'derive-with-path' }]);
+  });
+
+  it('accepts a reference declared over the indexed dataset', () => {
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'dataset',
+          kind: 'reference',
+          from: 'dataset',
+          output: true,
+          filterable: true,
+          facetable: true,
+          ref: { typeName: 'Dataset', strategy: 'labelOnly' },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('rejects a projection value the projection cannot supply', () => {
+    expect(
+      validateSearchType(
+        typeWith({ name: 'run', kind: 'keyword', from: 'no-such-value' }),
+      ),
+    ).toEqual([{ field: 'run', reason: 'unknown-projection-value' }]);
+  });
+
+  it('allows from on keyword/reference only: the other kinds cannot hold an IRI', () => {
+    expect(
+      validateSearchType(
+        typeWith({ name: 'dataset', kind: 'integer', from: 'dataset' }),
+      ),
+    ).toEqual([{ field: 'dataset', reason: 'from-not-allowed' }]);
+  });
+
+  it('rejects a field declaring from beside another value source', () => {
+    expect(
+      validateSearchType(
+        typeWith(
+          {
+            name: 'fromPath',
+            kind: 'reference',
+            from: 'dataset',
+            path: 'urn:dr:dataset',
+          },
+          {
+            name: 'fromDerive',
+            kind: 'keyword',
+            from: 'dataset',
+            derive: () => 'x',
+          },
+        ),
+      ),
+    ).toEqual([
+      { field: 'fromPath', reason: 'from-with-path' },
+      // The second field re-declares `dataset`, which no consumer could then
+      // resolve to one declaration.
+      { field: 'fromDerive', reason: 'duplicate-projection-value' },
+      { field: 'fromDerive', reason: 'from-with-derive' },
+    ]);
+  });
+
+  it('rejects two fields over the same projection value', () => {
+    expect(
+      validateSearchType(
+        typeWith(
+          { name: 'dataset', kind: 'reference', from: 'dataset' },
+          { name: 'sourceDataset', kind: 'keyword', from: 'dataset' },
+        ),
+      ),
+    ).toEqual([
+      { field: 'sourceDataset', reason: 'duplicate-projection-value' },
+    ]);
   });
 
   it('allows transform on keyword/reference only', () => {

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -569,6 +569,22 @@ describe('validateSearchType', () => {
     ]);
   });
 
+  it('rejects a projection value carried by an inline reference', () => {
+    // An inline reference is stored as a nested object; a projection value is a
+    // bare IRI. Declared together, every document import would fail.
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'dataset',
+          kind: 'reference',
+          from: 'dataset',
+          output: true,
+          ref: { typeName: 'Dataset', strategy: 'inline' },
+        }),
+      ),
+    ).toEqual([{ field: 'dataset', reason: 'from-with-inline-ref' }]);
+  });
+
   it('rejects two fields over the same projection value', () => {
     expect(
       validateSearchType(

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 99.35,
+          branches: 99.39,
           statements: 100,
         },
       },

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 99.39,
+          branches: 99.4,
           statements: 100,
         },
       },


### PR DESCRIPTION
Every indexed document already comes from exactly one dataset, but the IRI existed only as the writer’s private `source` stamp: applied after projection, forbidden to a schema, a bare string that could not resolve to a label. This makes it a **declarable projection-time value** instead.

Fix #696

## Declaring it

A `keyword`/`reference` field declares itself over the indexed dataset with `from: 'dataset'` – a third value source beside `path` and `derive`. The logical name is the deployment’s to choose, and the field carries the usual roles plus a `labelSource`, so a dataset facet arrives with names rather than URIs:

```ts
{
  name: 'dataset',
  kind: 'reference',
  from: 'dataset',
  output: true, filterable: true, facetable: true,
  labelSource: 'Dataset',
  ref: { typeName: 'Dataset', strategy: 'labelOnly' },
}
```

`SCHEMA-AP-NDE` gives `CreativeWork` an `isPartOf` but declares nothing equivalent on `Person`, `Organization`, `Place`, `Term` or `Occupation`. For those, provenance is the only available answer to *which dataset does this come from* – nothing in the data says it, so no property path yields it.

`validateSearchType` rejects `from` beside a `path` or a `derive`, on a kind that cannot hold an IRI, twice over the same projection value, and on an `inline` reference – inline carries a referent’s fields and is stored as a nested object, which a bare IRI is not.

## Seeing it during projection

`projectRoots`/`projectDocument` take a `ProjectionContext`, and every `derive` now receives it as a second argument. `searchStages` supplies it from the batch’s dataset – the stage is where it is known; the writer sees it only after projection. That is what makes the polymorphic-`isPartOf` case expressible: `schema:isPartOf` may point at a containing `CreativeWork` *or* at the dataset, and a deployment that wants only the former can now drop values equal to the containing dataset.

Projecting without a context stays legitimate – the field is left unpopulated, exactly as an unmatched `path` would be.

## One column, not two

A type declaring a dataset field makes it *the* provenance column: `InPlaceRebuild`/`BlueGreenRebuild` stamp it, and the sweeps enumerate, filter and delete by it. No private `source` is added beside it, so the facet, the label resolution, any `derive` and the membership sweep read one value rather than two copies of one IRI free to drift – which is what `sweep.ts` owning the field names was meant to prevent. A type declaring nothing keeps `source`, unchanged; so does one declaring the dataset as an *internal* field (no role, purely so a `derive` can read it), since the projection prunes that before the writer.

Because the sweep deletes by it, three constraints are checked when the writer is constructed rather than discovered mid-sweep: no `array` (`field:=[a,b]` over a `string[]` is *contains any*, so a departed dataset would take documents another still contributes), no `transform` (the sweep matches the stored value against the run’s raw dataset IRIs), and `facetable` for `InPlaceRebuild`, which facets it to enumerate the indexed datasets.

## Breaking change

`@lde/search-typesense`: `staleDocumentsFilter`, `sourceDocumentsFilter`, `thisRunDocumentsFilter` and `membershipSweepFilters` take the provenance field name as their first argument. Callers filtering on the private bookkeeping field pass the exported `SOURCE_FIELD`.

`@lde/search` is additive: `from` is optional, and `derive`’s new second argument is backward-compatible.

## Two limits, documented rather than papered over

**Adopting the field needs a fresh collection.** `InPlaceRebuild` leaves an existing collection alone, so a type that gains a `from: 'dataset'` field against a collection built without it keeps the old `source` column and has no field for the new one. The run imports (Typesense stores the unindexed value), then `commit` fails faceting a field the collection does not declare. Drop and rebuild the collection when adopting it; Blue/green builds fresh every run and needs nothing.

**The stamp reasserts the sweep’s column only.** It does not restate the folded `${name}_search` companion a `searchable` declared field also fans out to – folding is the projection’s convention, and repeating it in the writer would put it in the two places this change exists to collapse. A document that reached the writer unprojected is therefore sweepable but not full-text findable by dataset: absent, never wrong.

## Note on #697

The stamp is still single-valued, so a shared entity is attributed to whichever dataset wrote it last. This PR does not fix that, but it does put the fix in one place: under this change the declared field *is* the provenance column, so making it multi-valued means changing one column and the sweep’s handling of it – rather than fixing `source` and a declared field separately and leaving them free to disagree. The `array` constraint above is precisely what that work will lift.
