### PR TITLE
feat(search)!: filter across several fields with one where clause

### DIFF
--- a/docs/decisions/0003-search-api-core-query-model.md
+++ b/docs/decisions/0003-search-api-core-query-model.md
@@ -62,13 +62,7 @@ Typesense-vocabulary types are _derived_ from `kind`, never declared.
 
 ```ts
 type FieldKind =
-  | 'text'
-  | 'keyword'
-  | 'integer'
-  | 'number'
-  | 'boolean'
-  | 'date'
-  | 'reference';
+  'text' | 'keyword' | 'integer' | 'number' | 'boolean' | 'date' | 'reference';
 
 // The public type is a DISCRIMINATED UNION by kind (TextField | KeywordField |
 // ReferenceField | NumericField | BooleanField):
@@ -137,7 +131,7 @@ shared representation in the middle keeps GraphQL and REST from drifting.
 ```ts
 interface SearchQuery {
   readonly text?: string; // undefined/'' = browse
-  readonly where: readonly Filter[]; // AND across fields
+  readonly where: readonly Filter[]; // AND across clauses
   readonly orderBy: readonly Sort[];
   readonly limit: number; // numbered pagination
   readonly offset: number;
@@ -145,13 +139,21 @@ interface SearchQuery {
   readonly locale: string; // from Accept-Language; selects per-locale fields
 }
 
-type Filter =
-  | { readonly field: string; readonly in: readonly string[] } // keyword membership, OR within field
+// One criterion: one field, one operator, fixed by that field's kind.
+type Criterion =
+  | { readonly field: string; readonly in: readonly string[] }
   | {
       readonly field: string;
       readonly range: { min?: number | string; max?: number | string };
     }
   | { readonly field: string; readonly is: boolean };
+
+// A clause is a DISJUNCTION of criteria. An ordinary single-field filter is the
+// one-criterion case, so there is no separate cross-field variant an adapter
+// could overlook. See ADR 18.
+interface Filter {
+  readonly or: readonly Criterion[];
+}
 
 interface Sort {
   readonly field: string;
@@ -193,7 +195,7 @@ maps them to the engine’s native range faceting.
 A coarse category alongside granular values (e.g. `group:rdf` next to media types, `group:person`
 next to class IRIs) is materialized into the field’s own values during projection, so at query
 time a group token is an ordinary value: faceted natively, filtered by plain membership
-(`field.in: ["group:rdf"]` unions with granular values for free), and — where the field is
+(`field.in: ["group:rdf"]` unions with granular values for free), and – where the field is
 `output` – read like any other value. There is no `_group` companion, no `group:`-prefix split,
 no filter rewriting in the adapter; the engine stays dumb and denormalization (the document
 store’s strength) does the work. A cross-source signal that is not a subset of the field (e.g. a

--- a/docs/decisions/0018-filter-across-several-fields-with-one-clause.md
+++ b/docs/decisions/0018-filter-across-several-fields-with-one-clause.md
@@ -1,0 +1,141 @@
+# 18. Filter across several fields with one clause
+
+Date: 2026-08-07
+
+## Status
+
+Accepted
+
+Amends [ADR 3 (Search API core query model)](./0003-search-api-core-query-model.md)
+and [ADR 4 (Search API GraphQL surface)](./0004-search-api-graphql-surface.md);
+settles the facet interaction left open by
+[ADR 5 (Batch facet queries through the engine port)](./0005-batch-facet-queries-through-the-engine-port.md).
+
+## Context
+
+“Show me everything related to this entity” had no answer. A `where` clause named
+exactly one field, and in Linked Data one conceptual filter routinely maps to
+**several predicates**: an agent is `creator` or `contributor` or `publisher`, a
+place is `contentLocation` or `locationCreated`. A consumer building an entity
+landing page had to issue one query per predicate and merge client-side, losing a
+correct `total`, ranking and facet counts.
+
+Typesense `filter_by` already supports `||`, so the disjunction rides the same
+round-trip. The work was in the model and the contract.
+
+## Decision
+
+### One clause model, for one field or many
+
+A clause is a **disjunction of criteria**, and a criterion is one field with one
+operator:
+
+```ts
+type Criterion = { field; in } | { field; range } | { field; is };
+interface Filter {
+  readonly or: readonly Criterion[];
+} // OR across criteria
+// SearchQuery.where: readonly Filter[]                    // AND across clauses
+```
+
+The point is that this is the **only** clause shape. An ordinary single-field
+filter is not a different thing that a cross-field filter was added alongside –
+it is this same clause carrying one criterion (`filterOn` builds it). So there is
+no second variant to discover: an adapter that iterates `or` serves one
+criterion and five by the same code, and `assertValidQuery` validates one rule
+rather than branching on which kind of clause it has. A second engine adapter
+cannot silently ignore a shape it never learned about, because there is only one.
+
+Two capabilities fall out of criteria carrying their own operator rather than the
+clause carrying it: a clause may mix kinds (`creator in […]` OR `size > 100`),
+and it may name one field twice – the only way to express “smaller than 10 **or**
+larger than 100”, a range pair no value list can collapse.
+
+### Flat, never a tree
+
+`where` is a conjunction of disjunctions and stops there. A boolean tree would
+make skip-own-filter undefinable: “remove this facet’s own clause” has no answer
+once a clause can be nested inside an `OR`. The same ceiling is what Algolia’s
+`facetFilters` (array-of-arrays, inner OR, outer AND) settled on.
+
+### A clause is a facet’s own when every criterion names that field
+
+Skip-own-filter (ADR 5) removes a facet’s own clause so the facet still offers
+the other values the user could pick. Ownership therefore follows **which axis a
+clause constrains**, not how many criteria it carries:
+
+- every criterion on one field – the ordinary filter, and equally a same-field
+  disjunction (`or: [{ created: { max: … } }, { created: { min: … } }]`, or a
+  multi-select spelled as alternatives) – **is** a selection on that axis, so it
+  drops. Keeping it would compute the facet with the user’s own selection
+  applied, offering back only what they already picked;
+- a clause spanning several fields is **nobody’s own**: the user constrained the
+  document as a whole, never one axis, so nothing on any single facet is theirs
+  to widen. It stays whole.
+
+That keeps each facet **complete on its own field** – every value it offers is one
+the user can pick, with the count they will get. Both alternatives break it for
+the cross-field case: dropping the clause’s own disjunct computes the facet over a
+different set than the page is showing (on an entity page, hiding the very entity
+the page is about); dropping the clause entirely counts the unfiltered corpus
+while sibling facets stay filtered.
+
+Since no facet owns a cross-field clause, one never splits the facet batch.
+
+### The surface names both combinators
+
+`<Type>Where` keeps its keyed shape – sibling keys AND, each typed by its field’s
+kind – and gains two combinator keys:
+
+```graphql
+input ThingWhere { id: StringFilter  created: DateRange  …  or: [ThingCriterion!]  and: [ThingWhere!] }
+input ThingCriterion @oneOf { id: StringFilter  created: DateRange  … }
+```
+
+```graphql
+where: { status: …, material: … }                                  # AND
+where: { material: …, or: [{ creator: $a }, { contributor: $a }] }  # OR, ANDed with material
+where: { and: [{ or: [{ creator: $a }, { contributor: $a }] },      # two disjunctions
+               { or: [{ contentLocation: $p }, { locationCreated: $p }] }] }
+```
+
+Three properties decided it:
+
+- **Fields are named one way – as keys**, at every level. A draft naming them
+  through a generated enum inside a cross-field key meant two vocabularies for
+  one concept.
+- **Neither combinator is positional.** A draft where `where` was a nested list
+  (`[[…]]`, inner OR, outer AND) was rejected: the two differ by one bracket,
+  both parse, and results differ silently – and since a list reads as
+  _alternatives_, the likely slip is the wrong way round.
+- **`@oneOf` keeps a criterion an atom.** A two-key criterion would be a
+  conjunction nested inside an `or`, which the flat IR cannot hold; the schema
+  rejects it instead of a runtime check. Requires graphql-js ≥ 16.9.0.
+
+`and` carries further `Where`s rather than a separate clause type. It is safe to
+be recursive because a conjunction inside a conjunction flattens, and the one
+shape that would not – an `and` inside an `or` – is unreachable: `or` holds only
+`@oneOf` criteria. So two input types serve every depth, and a reader never has
+to work out how a “clause” differs from a `where`.
+
+`and` and `or` join `id` as reserved field names (`validateSearchType`): a
+declared field of either name would shadow the combinator. Neither is plausible
+as an RDF property name, and a logical field name is deliberately not derived
+from its predicate IRI, so a deployment needing one can rename it.
+
+## Consequences
+
+- One query answers “documents referencing this IRI through any of these
+  predicates”, with a correct `total`, ranking and facet counts, in one engine
+  round-trip: `(id:=[…] || creator:=[…] || about:[…]) && …`.
+- `or: [{ id: $f }, { creator: $f }, { about: $f }]` states “the entity’s own
+  record **plus** everything referencing it”: the entity landing page in one
+  query.
+- Breaking IR change: a clause is `{ or: [...] }` rather than a field and an
+  operator.
+- No breaking surface change: the keyed form is unchanged, `or` and `and` are
+  additive.
+- The keyed form and a one-criterion `or` are two spellings of one filter.
+  Accepted: both compile to the identical clause, so they cannot diverge.
+- Cross-field `range` and `is` work throughout, so no capability is reserved to
+  membership.

--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -33,7 +33,7 @@ inputs, reference types and nullability are all derived from each field’s
 `kind` and capability flags. The common case needs no options at all:
 
 ```ts
-import { searchSchema } from '@lde/search';
+import { filterOn, searchSchema } from '@lde/search';
 import { buildGraphQLSchema } from '@lde/search-api-graphql';
 
 const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
@@ -56,7 +56,7 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON), {
     Dataset: {
       queryDefaults: (query) => ({
         ...query,
-        where: [...query.where, { field: 'status', in: ['valid'] }],
+        where: [...query.where, filterOn({ field: 'status', in: ['valid'] })],
       }),
     },
     Person: { queryField: 'people' },
@@ -161,7 +161,18 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
   `FloatRange` / `DateRange`, or `Boolean`), plus **`id: StringFilter`** on every
   type – the document’s IRI, declared by no type and filterable on all of them
   ([Lookup by IRI](./search#lookup-by-iri)). So the input always exists, even for
-  a type that declares no filterable field of its own.
+  a type that declares no filterable field of its own. Keys you write side by
+  side all apply; two more keys combine them explicitly, so neither AND nor OR is
+  ever inferred from nesting:
+  - **`or: [‹Type›Criterion!]`** matches a value in **any** of several fields –
+    the entity-page query, where a link may be recorded as `creator`, `about` or
+    `contentLocation` ([Matching a value in any of several
+    fields](./search#matching-a-value-in-any-of-several-fields)). A criterion is
+    a `@oneOf` input, so each alternative names exactly one field; a field may
+    appear more than once, which is how two ranges on one field are expressed.
+  - **`and: [‹Type›Clause!]`** carries further clauses, each of which may hold
+    its own `or`. Only needed for a **second** set of alternatives – for plain
+    filters it is equivalent to writing them side by side.
 - **`orderBy`**: `RELEVANCE` plus every `sortable` field, as an enum – field
   names SCREAMING_SNAKE_CASEd (`datePosted` → `DATE_POSTED`); `direction`
   defaults to `DESC`.

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -587,6 +587,108 @@ This is what makes an IRI a usable entry point: a client holding a reference’s
 fields from its own collection, rather than the schema having to carry them
 inline on every referring document.
 
+### Matching a value in any of several fields
+
+Filters you write side by side must **all** match:
+
+```graphql
+where: { material: { in: ["oil"] }, status: { in: ["valid"] } }
+```
+
+When you want a value matched in **any** of several fields instead, put those
+alternatives under `or`. This is the query behind an entity page – “everything
+related to Van Gogh”, where the link may be recorded as `creator`, `about` or
+`contentLocation` depending on the source:
+
+```graphql
+query Related($iri: StringFilter!) {
+  heritageObjects(
+    where: {
+      material: { in: ["oil"] }
+      or: [{ creator: $iri }, { about: $iri }, { contentLocation: $iri }]
+    }
+  ) {
+    pagination {
+      total
+    }
+    facets {
+      material {
+        value
+        count
+      }
+    }
+  }
+}
+```
+
+You get one search, so `total`, the ranking and the facet counts are all correct
+– where issuing a query per field and merging the results client-side would lose
+each of them.
+
+Add `id` to the alternatives to include the entity’s **own** record alongside
+everything referring to it: `or: [{ id: $iri }, { creator: $iri }, …]`.
+
+Three things to know when writing `or`:
+
+- **It sits alongside your other filters**, which still all apply. Above, every
+  hit is an oil painting _and_ related to the IRI.
+- **Each alternative names one field.** `{ creator: $a, about: $b }` in a single
+  entry is rejected by the schema – write it as two entries.
+- **A field may appear more than once**, which is how you ask for two ranges on
+  one field: `or: [{ created: { max: "1800" } }, { created: { min: "1900" } }]`.
+
+Any kind of field can take part, not just references: `or: [{ material: $m },
+{ technique: $m }]` works the same way.
+
+#### Asking for two `or` groups at once
+
+A `where` takes one `or`. When you need two independent sets of alternatives –
+an agent recorded either way, _and_ a place recorded either way – list them under
+`and`:
+
+```graphql
+where: {
+  and: [
+    { or: [{ creator: $agent }, { contributor: $agent }] }
+    { or: [{ contentLocation: $place }, { locationCreated: $place }] }
+  ]
+}
+```
+
+That is the only thing `and` is needed for. For plain filters it changes nothing,
+since side-by-side keys already all apply – these are the same query:
+
+```graphql
+where: { status: { in: ["valid"] }, material: { in: ["oil"] } }
+where: { and: [{ status: { in: ["valid"] } }, { material: { in: ["oil"] } }] }
+```
+
+#### Facet counts under an `or`
+
+Your facets keep describing the results you are showing. A facet normally ignores
+the filter on its own field, so you can still see – and pick – its other values.
+An `or` spanning **several** fields is not any one field’s filter, so it applies
+to every facet: on the query above the `material` facet counts within the Van
+Gogh–related set, and a `creator` facet lists Van Gogh alongside the other
+creators in that set, each with the count you would get by picking it.
+
+An `or` whose alternatives all name the **same** field is a selection on that
+field, so its own facet ignores it like any other filter – you still see the
+other values you could pick, not just the ones already selected.
+
+One thing to watch: an alternative that constrains nothing – an empty `in`, say
+a facet variable with nothing selected – makes the whole `or` match everything,
+because “no constraint OR anything” is no constraint. If you build alternatives
+from optional inputs, leave the unset ones out of the list rather than passing
+them empty.
+
+Since `and` and `or` are `where` keys, a `SearchType` cannot declare a field
+called `and` or `or`; `searchSchema()` rejects it, as it does `id`.
+
+Underneath, each of these compiles to one `Filter` – `{ or: [Criterion, …] }` –
+in the query IR, and the whole `where` to a single engine query. See
+[ADR 18](../decisions/0018-filter-across-several-fields-with-one-clause.md).
+
 Two consequences of treating identity as its own kind of filter:
 
 - **An empty `in` on `id` matches nothing**, where an empty `in` on any other

--- a/packages/search-api-graphql/package.json
+++ b/packages/search-api-graphql/package.json
@@ -30,7 +30,7 @@
     "@graphql-yoga/render-graphiql": "^5.21.2",
     "@lde/search": "^0.17.0",
     "dataloader": "^2.2.3",
-    "graphql": "^16.0.0",
+    "graphql": "^16.9.0",
     "graphql-yoga": "^5.21.2",
     "negotiator": "^1.0.0",
     "tslib": "^2.3.0"

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -17,6 +17,7 @@ import {
   type GraphQLOutputType,
 } from 'graphql';
 import {
+  type Criterion,
   type Filter,
   type LocalizedValue,
   type RootType,
@@ -27,10 +28,13 @@ import {
   type SearchType,
 } from '@lde/search';
 import {
+  AND_KEY,
   facetableFields,
   filterableFields,
+  filterOn,
   filterOperatorFor,
   ID_FIELD,
+  OR_KEY,
   isRangeFacet,
   nestedReferenceType,
   outputFields,
@@ -399,17 +403,59 @@ export function buildGraphQLSchema(
     // field and always exists – no type is unaddressable by IRI, whatever it
     // declares.
     const filterable = filterableFields(searchType);
-    const whereInput = new GraphQLInputObjectType({
+    /**
+     * One key per filterable field (plus the undeclared `id`), each typed by its
+     * OWN kind – so the operator a key accepts is fixed by the field it names,
+     * and a range on a keyword field cannot be written at all. This is the
+     * single vocabulary every level of `where` is built from: the same keys
+     * appear on the clause and on a criterion, so a field is never named a
+     * second way.
+     */
+    const fieldKeys = (): Record<string, GraphQLInputFieldConfig> => {
+      const fields: Record<string, GraphQLInputFieldConfig> = {
+        [ID_FIELD]: { type: stringFilter },
+      };
+      for (const field of filterable) {
+        fields[field.name] = { type: whereFieldType(field) };
+      }
+      return fields;
+    };
+
+    // A criterion is an ATOM: exactly one field, enforced by `@oneOf`. That is
+    // what keeps `where` a flat conjunction of disjunctions – a criterion that
+    // could carry two keys would be a conjunction nested inside an `or`, and
+    // skip-own-filter (ADR 5) has no answer for a clause buried inside another.
+    const criterionInput = new GraphQLInputObjectType({
+      name: `${typeName}Criterion`,
+      description:
+        'A condition on exactly one field. Used inside `or`, where the criteria are alternatives.',
+      isOneOf: true,
+      fields: fieldKeys,
+    });
+    const orKey: GraphQLInputFieldConfig = {
+      type: new GraphQLList(new GraphQLNonNull(criterionInput)),
+      description:
+        'A disjunction: a document matches when ANY of these criteria holds. Combined with the sibling keys by AND, so it widens across fields without widening the query as a whole.',
+    };
+    // `and` carries further `Where`s rather than a separate clause type. Safe to
+    // be recursive: a conjunction inside a conjunction FLATTENS, and the one
+    // shape that would not – an `and` inside an `or` – is unreachable, because
+    // `or` holds only `@oneOf` criteria. So `where` stays a flat conjunction of
+    // disjunctions at any nesting depth, and a reader meets one input type
+    // instead of two near-identical ones.
+    const whereInput: GraphQLInputObjectType = new GraphQLInputObjectType({
       name: `${typeName}Where`,
-      fields: () => {
-        const fields: Record<string, GraphQLInputFieldConfig> = {
-          [ID_FIELD]: { type: stringFilter },
-        };
-        for (const field of filterable) {
-          fields[field.name] = { type: whereFieldType(field) };
-        }
-        return fields;
-      },
+      description:
+        'Sibling keys are combined with AND. Use `or` for a disjunction, and `and` when a query needs more than one of them.',
+      fields: () => ({
+        ...fieldKeys(),
+        [OR_KEY]: orKey,
+        [AND_KEY]: {
+          type: new GraphQLList(new GraphQLNonNull(whereInput)),
+          description:
+            'Further groups of conditions, all of which apply. The way to carry a second `or` disjunction alongside the first.',
+        },
+      }),
     });
 
     const sortValues: GraphQLEnumValueConfigMap = {
@@ -620,40 +666,73 @@ function whereToFilters(
   where: Record<string, unknown> | undefined,
   searchType: SearchType,
 ): Filter[] {
-  if (where === undefined) {
+  // `== null` deliberately: an explicit `where: null` is as absent as an omitted
+  // one, and reading keys off it would throw.
+  if (where == null) {
     return [];
   }
-  const filters: Filter[] = [];
-  // `id` first: it is declared by no type, so the field loop below never sees it.
-  const id = where[ID_FIELD] as { in?: string[] } | undefined | null;
+  const filters = criteriaOf(where, searchType).map(filterOn);
+  // Sibling field keys AND, so each becomes a one-criterion filter of its own,
+  // while `or` becomes a SINGLE filter carrying every alternative. That is the
+  // whole AND/OR mapping: which bucket a criterion lands in, never a combinator
+  // inferred from how deeply it is nested.
+  const alternatives = (
+    (where[OR_KEY] as readonly Record<string, unknown>[] | null) ?? []
+  ).flatMap((criterion) => criteriaOf(criterion, searchType));
+  if (alternatives.length > 0) {
+    filters.push({ or: alternatives });
+  }
+  // `and` carries further groups, each contributing its own filters – which is
+  // how a query states a second `or` alongside the first. Recursing keeps the
+  // result flat: nested conjunctions collapse into this one list, and an `and`
+  // can never sit inside an `or` (which holds only criteria).
+  for (const nested of (where[AND_KEY] as
+    readonly Record<string, unknown>[] | null) ?? []) {
+    filters.push(...whereToFilters(nested, searchType));
+  }
+  return filters;
+}
+
+/**
+ * The criteria a keyed object carries, in declaration order. A `Criterion` is
+ * `@oneOf`, so it yields exactly one; a `Where`/`Clause` yields one per field
+ * key it sets. `id` is read first: no type declares it, so the field loop below
+ * never sees it.
+ */
+function criteriaOf(
+  keyed: Record<string, unknown>,
+  searchType: SearchType,
+): Criterion[] {
+  const criteria: Criterion[] = [];
+  const id = keyed[ID_FIELD] as { in?: string[] } | undefined | null;
   if (id !== undefined && id !== null) {
-    filters.push({ field: ID_FIELD, in: id.in ?? [] });
+    criteria.push({ field: ID_FIELD, in: id.in ?? [] });
   }
   for (const field of filterableFields(searchType)) {
-    const value = where[field.name];
+    const value = keyed[field.name];
     if (value === undefined || value === null) {
       continue;
     }
     switch (filterOperatorFor(field.kind)) {
       case 'in':
-        filters.push({
+        criteria.push({
           field: field.name,
           in: (value as { in?: string[] }).in ?? [],
         });
         break;
       case 'range': {
         const range = value as { min?: number | string; max?: number | string };
-        filters.push({
+        criteria.push({
           field: field.name,
           range: { min: range.min, max: range.max },
         });
         break;
       }
       default:
-        filters.push({ field: field.name, is: value as boolean });
+        criteria.push({ field: field.name, is: value as boolean });
     }
   }
-  return filters;
+  return criteria;
 }
 
 function rangeInput(

--- a/packages/search-api-graphql/src/facet-batch.ts
+++ b/packages/search-api-graphql/src/facet-batch.ts
@@ -1,6 +1,7 @@
 import DataLoader from 'dataloader';
 import type {
   FacetBucket,
+  Filter,
   RootType,
   SearchEngine,
   SearchQuery,
@@ -78,12 +79,27 @@ export function createFacetLoader(
  * a policy default on that field, e.g. valid-only `status`, so the facet
  * counts across every value.) The queries are facet-only: no hits (`limit:
  * 0`) and, with no hits to order, no `orderBy`.
+ *
+ * A clause is a facet’s **own** only when it carries exactly one criterion, on
+ * that field ({@link ownsFacet}). A disjunction (`or`) is nobody’s own and
+ * always stays: the user constrained the document as a whole, never that one
+ * axis, so there is no selection on it to widen. Keeping it is what leaves each facet
+ * *complete on its own field* – every value it offers is one the user can pick,
+ * with the count they will actually get. Dropping the clause’s own disjunct
+ * instead would hide values that do return hits (on an entity page: the very
+ * entity the page is about, absent from a sidebar beside results full of it),
+ * and dropping it whole would count a corpus the sibling facets do not.
+ * It also keeps a multi-field clause from ever splitting the batch.
  */
 export function groupFacetQueries(
   query: SearchQuery,
   fields: readonly string[],
 ): SearchQuery[] {
-  const filteredFields = new Set(query.where.map((filter) => filter.field));
+  const filteredFields = new Set(
+    query.where
+      .map(ownedField)
+      .filter((field): field is string => field !== undefined),
+  );
   const facetOnly: SearchQuery = { ...query, orderBy: [], limit: 0, offset: 0 };
   const sharedFields = fields.filter((field) => !filteredFields.has(field));
   const queries: SearchQuery[] = [];
@@ -93,9 +109,39 @@ export function groupFacetQueries(
   for (const field of fields.filter((field) => filteredFields.has(field))) {
     queries.push({
       ...facetOnly,
-      where: query.where.filter((filter) => filter.field !== field),
+      where: query.where.filter((filter) => !ownsFacet(filter, field)),
       facets: [field],
     });
   }
   return queries;
+}
+
+/** Whether a clause is `field`’s own – it constrains that field and nothing
+ *  else, so skip-own-filter removes it when counting that facet. */
+function ownsFacet(filter: Filter, field: string): boolean {
+  return ownedField(filter) === field;
+}
+
+/**
+ * The field a clause belongs to, or `undefined` when it belongs to none.
+ *
+ * A clause owns a field when **every** criterion names it – which covers the
+ * ordinary one-criterion filter and equally a same-field disjunction
+ * (`or: [{ created: { max: … } }, { created: { min: … } }]`, or a multi-select
+ * spelled as alternatives). Those ARE a selection on one axis, so skip-own-filter
+ * must drop them; leaving them in would compute the facet with the user’s own
+ * selection applied, offering back only what they already picked.
+ *
+ * A clause spanning several fields is nobody’s own: the user constrained the
+ * document as a whole, never one axis, so there is nothing on any single facet
+ * to widen.
+ */
+function ownedField(filter: Filter): string | undefined {
+  const [first, ...rest] = filter.or;
+  if (first === undefined) {
+    return undefined;
+  }
+  return rest.every((criterion) => criterion.field === first.field)
+    ? first.field
+    : undefined;
 }

--- a/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
+++ b/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
@@ -60,6 +60,9 @@ type BooleanBucket {
   count: Int!
 }
 
+"""
+Sibling keys are combined with AND. Use \`or\` for a disjunction, and \`and\` when a query needs more than one of them.
+"""
 input ThingWhere {
   id: StringFilter
   keyword: StringFilter
@@ -70,6 +73,16 @@ input ThingWhere {
   created: DateRange
   status: StringFilter
   open: Boolean
+
+  """
+  A disjunction: a document matches when ANY of these criteria holds. Combined with the sibling keys by AND, so it widens across fields without widening the query as a whole.
+  """
+  or: [ThingCriterion!]
+
+  """
+  Further groups of conditions, all of which apply. The way to carry a second \`or\` disjunction alongside the first.
+  """
+  and: [ThingWhere!]
 }
 
 input StringFilter {
@@ -89,6 +102,21 @@ input FloatRange {
 input DateRange {
   min: String
   max: String
+}
+
+"""
+A condition on exactly one field. Used inside \`or\`, where the criteria are alternatives.
+"""
+input ThingCriterion @oneOf {
+  id: StringFilter
+  keyword: StringFilter
+  creator: StringFilter
+  publisher: StringFilter
+  size: IntRange
+  score: FloatRange
+  created: DateRange
+  status: StringFilter
+  open: Boolean
 }
 
 input ThingOrderBy {

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -374,7 +374,7 @@ describe('buildGraphQLSchema', () => {
       { engine, acceptLanguage: ['nl'] },
       { iiif: facets.iiif[0].value },
     );
-    expect(received().where).toEqual([{ field: 'iiif', is: true }]);
+    expect(received().where).toEqual([{ or: [{ field: 'iiif', is: true }] }]);
   });
 
   it('resolves every selected facet key through ONE batched engine dispatch, returning [] where the engine has none', async () => {
@@ -442,9 +442,13 @@ describe('buildGraphQLSchema', () => {
     const facetQuery = batch[0];
     expect(facetQuery.facets).toEqual(['keyword']);
     expect(
-      facetQuery.where.find((filter) => filter.field === 'keyword'),
+      facetQuery.where.find((filter) =>
+        filter.or.some((criterion) => criterion.field === 'keyword'),
+      ),
     ).toBeUndefined();
-    expect(facetQuery.where).toContainEqual({ field: 'status', in: ['valid'] });
+    expect(facetQuery.where).toContainEqual({
+      or: [{ field: 'status', in: ['valid'] }],
+    });
   });
 
   it('groups the selected facets by effective where: unfiltered facets share one query, each own-filtered facet gets its own', async () => {
@@ -469,7 +473,9 @@ describe('buildGraphQLSchema', () => {
     const [batch] = facetBatches();
     expect(batch).toHaveLength(2);
     expect(batch[0].facets).toEqual(['keyword', 'publisher']);
-    expect(batch[0].where).toEqual([{ field: 'status', in: ['valid'] }]);
+    expect(batch[0].where).toEqual([
+      { or: [{ field: 'status', in: ['valid'] }] },
+    ]);
     expect(batch[1].facets).toEqual(['status']);
     expect(batch[1].where).toEqual([]);
   });
@@ -543,14 +549,15 @@ describe('buildGraphQLSchema', () => {
     );
 
     const query = received();
-    expect(query.where).toContainEqual({ field: 'status', in: ['valid'] });
-    // An empty StringFilter compiles to an empty membership.
-    expect(query.where).toContainEqual({ field: 'keyword', in: [] });
     expect(query.where).toContainEqual({
-      field: 'size',
-      range: { min: 1, max: 9 },
+      or: [{ field: 'status', in: ['valid'] }],
     });
-    expect(query.where).toContainEqual({ field: 'iiif', is: true });
+    // An empty StringFilter compiles to an empty membership.
+    expect(query.where).toContainEqual({ or: [{ field: 'keyword', in: [] }] });
+    expect(query.where).toContainEqual({
+      or: [{ field: 'size', range: { min: 1, max: 9 } }],
+    });
+    expect(query.where).toContainEqual({ or: [{ field: 'iiif', is: true }] });
     expect(query.orderBy).toEqual([{ field: 'size', direction: 'asc' }]);
     // Facets are requested per key via selection, not an arg; the listing query
     // carries none.
@@ -570,7 +577,7 @@ describe('buildGraphQLSchema', () => {
       { engine, acceptLanguage: ['nl'] },
     );
     expect(received().where).toEqual([
-      { field: 'id', in: ['https://id.example.org/a', 'urn:b'] },
+      { or: [{ field: 'id', in: ['https://id.example.org/a', 'urn:b'] }] },
     ]);
 
     // An empty StringFilter compiles to an empty membership, as for any field.
@@ -579,7 +586,151 @@ describe('buildGraphQLSchema', () => {
       engine: empty.engine,
       acceptLanguage: ['nl'],
     });
-    expect(empty.received().where).toEqual([{ field: 'id', in: [] }]);
+    expect(empty.received().where).toEqual([{ or: [{ field: 'id', in: [] }] }]);
+  });
+
+  it('maps `or` into one clause holding every alternative, ANDed with its siblings', async () => {
+    // The entity-page query: one IRI across the document's own identity and its
+    // reference fields, answered by a single search.
+    const { engine, received } = fakeEngine(canned);
+    await run(
+      `{
+        datasets(where: {
+          or: [{ id: { in: ["urn:vg"] } }, { publisher: { in: ["urn:vg"] } }]
+          status: { in: ["valid"] }
+        }) {
+          pagination { total }
+        }
+      }`,
+      { engine, acceptLanguage: ['nl'] },
+    );
+    // One clause for the disjunction…
+    expect(received().where).toContainEqual({
+      or: [
+        { field: 'id', in: ['urn:vg'] },
+        { field: 'publisher', in: ['urn:vg'] },
+      ],
+    });
+    // …and a separate clause for the sibling key, so the two AND.
+    expect(received().where).toContainEqual({
+      or: [{ field: 'status', in: ['valid'] }],
+    });
+  });
+
+  it('maps `and` into further clauses, so a query can carry two disjunctions', async () => {
+    const { engine, received } = fakeEngine(canned);
+    await run(
+      `{
+        datasets(where: {
+          and: [
+            { or: [{ publisher: { in: ["urn:vg"] } }, { keyword: { in: ["urn:vg"] } }] }
+            { or: [{ status: { in: ["valid"] } }, { size: { min: 100 } }] }
+          ]
+        }) {
+          pagination { total }
+        }
+      }`,
+      { engine, acceptLanguage: ['nl'] },
+    );
+    // Two independent disjunctions, ANDed – the shape a single `or` cannot hold.
+    expect(received().where).toEqual([
+      {
+        or: [
+          { field: 'publisher', in: ['urn:vg'] },
+          { field: 'keyword', in: ['urn:vg'] },
+        ],
+      },
+      {
+        or: [
+          { field: 'status', in: ['valid'] },
+          { field: 'size', range: { min: 100, max: undefined } },
+        ],
+      },
+    ]);
+  });
+
+  it('treats `and` over plain criteria as identical to sibling keys', async () => {
+    // Sibling keys already AND, so `and` is optional for plain criteria – it
+    // earns its keep only when a query needs a SECOND `or` (above). Pinned
+    // because the reference docs state the two forms are the same query.
+    const siblings = fakeEngine(canned);
+    await run(
+      `{
+        datasets(where: { status: { in: ["valid"] }, keyword: { in: ["atlas"] } }) {
+          pagination { total }
+        }
+      }`,
+      { engine: siblings.engine, acceptLanguage: ['nl'] },
+    );
+    const explicit = fakeEngine(canned);
+    await run(
+      `{
+        datasets(where: { and: [
+          { status: { in: ["valid"] } }
+          { keyword: { in: ["atlas"] } }
+        ] }) {
+          pagination { total }
+        }
+      }`,
+      { engine: explicit.engine, acceptLanguage: ['nl'] },
+    );
+    // Same clauses, and `where` is a conjunction – so the order they arrive in
+    // carries no meaning. Sibling keys emit in field-declaration order, `and`
+    // in the order written.
+    const clauses = (query: SearchQuery) =>
+      [...query.where].map((filter) => JSON.stringify(filter)).sort();
+    expect(clauses(explicit.received())).toEqual(clauses(siblings.received()));
+  });
+
+  it('treats an explicit `where: null` as no filter at all', async () => {
+    const { engine, received } = fakeEngine(canned);
+    const result = await run(
+      `{ datasets(where: null) { pagination { total } } }`,
+      { engine, acceptLanguage: ['nl'] },
+    );
+    expect(result.errors).toBeUndefined();
+    expect(received().where).toEqual([]);
+  });
+
+  it('nests `and` to any depth, flattening it into one conjunction', async () => {
+    // `and` carries further `Where`s, so it is recursive – safe, because a
+    // conjunction inside a conjunction collapses, and an `and` can never sit
+    // inside an `or` (which holds only criteria).
+    const { engine, received } = fakeEngine(canned);
+    await run(
+      `{
+        datasets(where: {
+          status: { in: ["valid"] }
+          and: [{ and: [{ keyword: { in: ["atlas"] } }] }]
+        }) {
+          pagination { total }
+        }
+      }`,
+      { engine, acceptLanguage: ['nl'] },
+    );
+    expect(received().where).toEqual([
+      { or: [{ field: 'status', in: ['valid'] }] },
+      { or: [{ field: 'keyword', in: ['atlas'] }] },
+    ]);
+  });
+
+  it('rejects a criterion naming two fields: a criterion is an atom', async () => {
+    // `@oneOf` is what keeps `where` a flat conjunction of disjunctions – a
+    // two-key criterion would be a conjunction nested inside an `or`, which the
+    // IR cannot represent and skip-own-filter could not reason about. Caught by
+    // GraphQL validation, before any resolver runs.
+    const { engine } = fakeEngine(canned);
+    const result = await run(
+      `{
+        datasets(where: {
+          or: [{ status: { in: ["valid"] }, keyword: { in: ["atlas"] } }]
+        }) {
+          pagination { total }
+        }
+      }`,
+      { engine, acceptLanguage: ['nl'] },
+    );
+    expect(result.errors?.[0]?.message).toMatch(/exactly one key/i);
   });
 
   it('falls back to the und locale when no Accept-Language is given', async () => {
@@ -606,7 +757,10 @@ describe('buildGraphQLSchema', () => {
         [schema.name]: {
           queryDefaults: (query) => ({
             ...query,
-            where: [...query.where, { field: 'status', in: ['valid'] }],
+            where: [
+              ...query.where,
+              { or: [{ field: 'status', in: ['valid'] }] },
+            ],
             orderBy: [{ field: 'relevance', direction: 'desc' }],
           }),
         },
@@ -617,7 +771,9 @@ describe('buildGraphQLSchema', () => {
       source: `{ datasets { pagination { total } } }`,
       contextValue: { engine, acceptLanguage: ['nl'] },
     });
-    expect(captured?.where).toEqual([{ field: 'status', in: ['valid'] }]);
+    expect(captured?.where).toEqual([
+      { or: [{ field: 'status', in: ['valid'] }] },
+    ]);
     expect(captured?.orderBy).toEqual([
       { field: 'relevance', direction: 'desc' },
     ]);
@@ -725,7 +881,22 @@ describe('buildGraphQLSchema', () => {
       expect(sdl).toMatch(/input CreativeWorkWhere/);
       // Person declares no filterable field, yet still gets a `where` input:
       // `id` is filterable on every type, so no type is unaddressable by IRI.
-      expect(sdl).toMatch(/input PersonWhere \{\s*id: StringFilter\s*\}/);
+      // A type declaring no filterable field is still addressable by IRI –
+      // through the `id` key, and through the `or`/`and` combinators, whose
+      // criteria then offer `id` alone.
+      const personWhere = sdl.slice(sdl.indexOf('input PersonWhere {'));
+      expect(personWhere.slice(0, personWhere.indexOf('\n}'))).toContain(
+        'id: StringFilter',
+      );
+      expect(sdl).toMatch(/input PersonWhere \{[^}]*or: \[PersonCriterion!\]/);
+      // `and` carries further `Where`s, so there is no second clause type.
+      expect(sdl).toMatch(/input PersonWhere \{[^}]*and: \[PersonWhere!\]/);
+      expect(sdl).not.toContain('PersonClause');
+      // A criterion is an atom, and for a type with no filterable field the
+      // only atom available is the IRI lookup.
+      expect(sdl).toMatch(
+        /input PersonCriterion @oneOf \{\s*id: StringFilter\s*\}/,
+      );
       // The shared reference shape is emitted once, reused by both types.
       expect(sdl.match(/^type Agent /gm)).toHaveLength(1);
       // One shared Pagination type across every ‹Type›SearchResult, so a

--- a/packages/search-api-graphql/test/facet-batch.test.ts
+++ b/packages/search-api-graphql/test/facet-batch.test.ts
@@ -79,8 +79,8 @@ describe('groupFacetQueries', () => {
     const filtered: SearchQuery = {
       ...baseQuery,
       where: [
-        { field: 'keyword', in: ['x'] },
-        { field: 'status', in: ['valid'] },
+        { or: [{ field: 'keyword', in: ['x'] }] },
+        { or: [{ field: 'status', in: ['valid'] }] },
       ],
     };
     const queries = groupFacetQueries(filtered, [
@@ -94,18 +94,111 @@ describe('groupFacetQueries', () => {
       { ...filtered, facets: ['publisher'], limit: 0, offset: 0 },
       {
         ...filtered,
-        where: [{ field: 'status', in: ['valid'] }],
+        where: [{ or: [{ field: 'status', in: ['valid'] }] }],
         facets: ['keyword'],
         limit: 0,
         offset: 0,
       },
       {
         ...filtered,
-        where: [{ field: 'keyword', in: ['x'] }],
+        where: [{ or: [{ field: 'keyword', in: ['x'] }] }],
         facets: ['status'],
         limit: 0,
         offset: 0,
       },
+    ]);
+  });
+
+  it('keeps a multi-field clause whole: it is no single facet’s own', () => {
+    // The entity-page query: one IRI across several fields. The user never made
+    // a selection on `keyword` or `publisher`, so there is nothing to widen
+    // there – keeping the clause is what leaves each facet complete on its own
+    // field, offering exactly the values that would return hits.
+    const related: SearchQuery = {
+      ...baseQuery,
+      where: [
+        {
+          or: [
+            { field: 'keyword', in: ['urn:vg'] },
+            { field: 'publisher', in: ['urn:vg'] },
+          ],
+        },
+      ],
+    };
+    const queries = groupFacetQueries(related, ['keyword', 'publisher']);
+    // No facet owns the clause, so the sidebar stays ONE query, and its where
+    // is untouched.
+    expect(queries).toEqual([
+      {
+        ...related,
+        facets: ['keyword', 'publisher'],
+        limit: 0,
+        offset: 0,
+      },
+    ]);
+  });
+
+  it('drops a facet’s own single-field clause while keeping a multi-field one', () => {
+    const both: SearchQuery = {
+      ...baseQuery,
+      where: [
+        {
+          or: [
+            { field: 'keyword', in: ['urn:vg'] },
+            { field: 'publisher', in: ['urn:vg'] },
+          ],
+        },
+        { or: [{ field: 'keyword', in: ['atlas'] }] },
+      ],
+    };
+    const queries = groupFacetQueries(both, ['keyword']);
+    // Only the clause that names `keyword` ALONE is its own and drops; the
+    // cross-field clause stays, so the buckets still describe the related set.
+    expect(queries).toEqual([
+      {
+        ...both,
+        where: [
+          {
+            or: [
+              { field: 'keyword', in: ['urn:vg'] },
+              { field: 'publisher', in: ['urn:vg'] },
+            ],
+          },
+        ],
+        facets: ['keyword'],
+        limit: 0,
+        offset: 0,
+      },
+    ]);
+  });
+
+  it('drops a same-field disjunction from its own facet', () => {
+    // Every criterion names `keyword`, so the clause IS a selection on that one
+    // axis – a multi-select, or two ranges on one field. Skip-own-filter must
+    // drop it; keeping it would compute the facet with the user’s own selection
+    // applied, offering back only what they already picked.
+    const sameField: SearchQuery = {
+      ...baseQuery,
+      where: [
+        {
+          or: [
+            { field: 'keyword', in: ['atlas'] },
+            { field: 'keyword', in: ['kaarten'] },
+          ],
+        },
+      ],
+    };
+    expect(groupFacetQueries(sameField, ['keyword'])).toEqual([
+      { ...sameField, where: [], facets: ['keyword'], limit: 0, offset: 0 },
+    ]);
+  });
+
+  it('treats a clause with no criteria as nobody’s own', () => {
+    // A vacuous clause constrains nothing, so it is not a selection on any
+    // axis – it stays put and no facet claims it.
+    const vacuous: SearchQuery = { ...baseQuery, where: [{ or: [] }] };
+    expect(groupFacetQueries(vacuous, ['keyword'])).toEqual([
+      { ...vacuous, facets: ['keyword'], limit: 0, offset: 0 },
     ]);
   });
 
@@ -194,7 +287,7 @@ describe('createFacetLoader', () => {
     };
     const filtered: SearchQuery = {
       ...baseQuery,
-      where: [{ field: 'status', in: ['valid'] }],
+      where: [{ or: [{ field: 'status', in: ['valid'] }] }],
     };
     const load = createFacetLoader(engine, dataset, filtered, (field) =>
       failed.push(field),

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -22,7 +22,7 @@ export default mergeConfig(
           lines: 100,
           // Full-suite baseline, re-anchored when covered branches are
           // deleted (autoUpdate only ever raises; see AGENTS.md).
-          branches: 95.1,
+          branches: 95.42,
           statements: 100,
         },
       },

--- a/packages/search-typesense/src/query-compiler.ts
+++ b/packages/search-typesense/src/query-compiler.ts
@@ -1,6 +1,7 @@
 import type { SearchParams } from 'typesense/lib/Typesense/Documents.js';
 import { fold } from '@lde/text-normalization';
 import {
+  type Criterion,
   type FacetRange,
   type Filter,
   type SearchField,
@@ -183,38 +184,93 @@ function compileFilterBy(
     .join(' && ');
 }
 
+/**
+ * One `where` clause: each of its criteria compiled and OR-joined with `||`,
+ * parenthesised so the disjunction binds tighter than the `&&` between clauses.
+ * A one-criterion clause – the ordinary single-field filter – compiles to a bare
+ * term: the parentheses would be harmless but would make every ordinary
+ * `filter_by` noisier to read and to assert on.
+ *
+ * A criterion that yields no term is dropped or voids the clause depending on
+ * **why**, because the two readings differ under `||`:
+ *
+ * - a **vacuous** criterion states no constraint (an empty `in` on a value
+ *   field – a facet UI with nothing selected – or a `range` with no usable
+ *   bound). It is therefore *true*, and `true || X` is true, so the whole clause
+ *   constrains nothing and is skipped. Dropping only the criterion would
+ *   NARROW the result to its siblings, the opposite of what an unset filter
+ *   means;
+ * - an **unsatisfiable** or malformed criterion (an empty `id` membership, an
+ *   unknown field, an operator that mismatches the field’s kind) is *false*, and
+ *   `false || X` is X, so it drops out and its siblings still stand.
+ *
+ * A clause left with no terms either way is skipped and reported to
+ * `onIgnoredFilter`.
+ */
 function compileFilter(
   filter: Filter,
   searchType: SearchType,
 ): string | undefined {
+  const terms: string[] = [];
+  for (const criterion of filter.or) {
+    const outcome = compileCriterion(criterion, searchType);
+    if (outcome === VACUOUS) {
+      return undefined;
+    }
+    if (outcome !== UNUSABLE) {
+      terms.push(outcome);
+    }
+  }
+  if (terms.length === 0) {
+    return undefined;
+  }
+  return terms.length === 1 ? terms[0] : `(${terms.join(' || ')})`;
+}
+
+/** A criterion that states **no constraint** – true for every document. */
+const VACUOUS = Symbol('vacuous');
+/** A criterion that matches nothing, or cannot be compiled at all – false. */
+const UNUSABLE = Symbol('unusable');
+
+/**
+ * What one criterion contributes: a Typesense term, or which of the two ways it
+ * yields none. The distinction is load-bearing under `||` ({@link compileFilter})
+ * and cannot be recovered from a bare `undefined`, so it is returned rather than
+ * re-derived by a second pass over the same rules.
+ */
+function compileCriterion(
+  criterion: Criterion,
+  searchType: SearchType,
+): string | typeof VACUOUS | typeof UNUSABLE {
   // `id` is the Typesense document key, not a declared field. Exact `:=`
   // membership, like a non-facet field ({@link compileMembership}), so an IRI
   // cannot partial-match on a shared path segment. (`fetchLabels` resolves
   // labels with the looser `id:[…]`; these are deliberately not the same
-  // clause.)
-  if (filter.field === ID_FIELD) {
-    return 'in' in filter && filter.in.length > 0
-      ? `${ID_FIELD}:=[${filter.in.map(escapeFilterValue).join(',')}]`
-      : undefined;
+  // clause.) An empty identity membership enumerates NO document, so it is
+  // unusable rather than vacuous – the one place the two readings diverge.
+  if (criterion.field === ID_FIELD) {
+    return 'in' in criterion && criterion.in.length > 0
+      ? `${ID_FIELD}:=[${criterion.in.map(escapeFilterValue).join(',')}]`
+      : UNUSABLE;
   }
-  const field = fieldNamed(searchType, filter.field);
+  const field = fieldNamed(searchType, criterion.field);
   if (field === undefined) {
-    return undefined;
+    return UNUSABLE;
   }
-  // A clause whose operator does not match the field's kind (e.g. `range` on a
-  // keyword) would reach the engine as garbage syntax – skip it instead.
-  if (filterOperatorFor(field.kind) !== filterOperator(filter)) {
-    return undefined;
+  // A criterion whose operator does not match the field's kind (e.g. `range` on
+  // a keyword) would reach the engine as garbage syntax – skip it instead.
+  if (filterOperatorFor(field.kind) !== filterOperator(criterion)) {
+    return UNUSABLE;
   }
-  if ('in' in filter) {
-    return filter.in.length > 0
-      ? compileMembership(field, filter.in)
-      : undefined;
+  if ('in' in criterion) {
+    return criterion.in.length > 0
+      ? compileMembership(field, criterion.in)
+      : VACUOUS;
   }
-  if ('range' in filter) {
-    return compileRange(field, filter.range);
+  if ('range' in criterion) {
+    return compileRange(field, criterion.range) ?? VACUOUS;
   }
-  return `${field.name}:=${filter.is}`;
+  return `${field.name}:=${criterion.is}`;
 }
 
 /**

--- a/packages/search-typesense/test/parse-response.test.ts
+++ b/packages/search-typesense/test/parse-response.test.ts
@@ -636,12 +636,12 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
       engine.searchFacets(schema, [
         {
           ...facetBrowse,
-          where: [{ field: 'id', in: [] }],
+          where: [{ or: [{ field: 'id', in: [] }] }],
           facets: ['status'],
         },
         {
           ...facetBrowse,
-          where: [{ field: 'id', in: [] }],
+          where: [{ or: [{ field: 'id', in: [] }] }],
           facets: ['keyword'],
         },
       ]),
@@ -815,7 +815,7 @@ describe('createTypesenseSearchEngine searchFacets (multi_search batching)', () 
       { ...facetBrowse, facets: ['publisher'] },
       {
         ...facetBrowse,
-        where: [{ field: 'status', in: ['valid'] }],
+        where: [{ or: [{ field: 'status', in: ['valid'] }] }],
         facets: ['publisher'],
       },
     ]);

--- a/packages/search-typesense/test/query-compiler.test.ts
+++ b/packages/search-typesense/test/query-compiler.test.ts
@@ -95,12 +95,12 @@ describe('buildSearchParams', () => {
       {
         ...base,
         where: [
-          { field: 'status', in: ['valid'] },
-          { field: 'keyword', in: ['kaarten', 'atlas'] },
-          { field: 'catalog', in: ['urn:cat'] },
-          { field: 'format', in: ['text/turtle', 'group:rdf'] },
-          { field: 'size', range: { min: 1, max: 10 } },
-          { field: 'iiif', is: true },
+          { or: [{ field: 'status', in: ['valid'] }] },
+          { or: [{ field: 'keyword', in: ['kaarten', 'atlas'] }] },
+          { or: [{ field: 'catalog', in: ['urn:cat'] }] },
+          { or: [{ field: 'format', in: ['text/turtle', 'group:rdf'] }] },
+          { or: [{ field: 'size', range: { min: 1, max: 10 } }] },
+          { or: [{ field: 'iiif', is: true }] },
         ],
       },
       schema,
@@ -115,6 +115,172 @@ describe('buildSearchParams', () => {
     );
   });
 
+  it('compiles a disjunction to one parenthesised `||` group', () => {
+    // The whole point: one engine round-trip, not one query per field. Each
+    // criterion keeps its OWN field's membership operator – `catalog` is
+    // non-facet so it stays exact `:=`, while the facet fields use `:` – and
+    // the parentheses keep the `||` binding tighter than the `&&` between
+    // clauses.
+    const params = buildSearchParams(
+      {
+        ...base,
+        where: [
+          {
+            or: [
+              { field: 'id', in: ['urn:vg'] },
+              { field: 'keyword', in: ['urn:vg'] },
+              { field: 'catalog', in: ['urn:vg'] },
+            ],
+          },
+          { or: [{ field: 'status', in: ['valid'] }] },
+        ],
+      },
+      schema,
+    );
+    expect(params.filter_by).toBe(
+      '(id:=[`urn:vg`] || keyword:[`urn:vg`] || catalog:=[`urn:vg`])' +
+        ' && status:[`valid`]',
+    );
+  });
+
+  it('mixes operators inside one disjunction, each on its own field', () => {
+    // A criterion carries its own operator, so a clause may range over a
+    // keyword and a numeric field at once – and over ONE field twice, which is
+    // the only way to say “smaller than 10 or larger than 100”.
+    expect(
+      buildSearchParams(
+        {
+          ...base,
+          where: [
+            {
+              or: [
+                { field: 'size', range: { max: 10 } },
+                { field: 'size', range: { min: 100 } },
+                { field: 'iiif', is: true },
+              ],
+            },
+          ],
+        },
+        schema,
+      ).filter_by,
+    ).toBe('(size:<=10 || size:>=100 || iiif:=true)');
+  });
+
+  it('leaves a one-criterion clause unparenthesised', () => {
+    // The ordinary single-field filter, which must compile exactly as it did
+    // before clauses could hold more than one criterion.
+    expect(
+      buildSearchParams(
+        { ...base, where: [{ or: [{ field: 'status', in: ['valid'] }] }] },
+        schema,
+      ).filter_by,
+    ).toBe('status:[`valid`]');
+  });
+
+  it('drops a non-compiling criterion, keeping the rest of the disjunction', () => {
+    // `nonexistent` contributes no term, but the caller still asked about
+    // `keyword`, so the clause survives on the criteria that do compile.
+    expect(
+      buildSearchParams(
+        {
+          ...base,
+          where: [
+            {
+              or: [
+                { field: 'keyword', in: ['atlas'] },
+                { field: 'nonexistent', in: ['atlas'] },
+              ],
+            },
+          ],
+        },
+        schema,
+      ).filter_by,
+    ).toBe('keyword:[`atlas`]');
+  });
+
+  it('voids the whole clause when an alternative states no constraint', () => {
+    // An empty `in` on a value field means “no constraint” – true – and
+    // `true || X` is true, so the clause constrains nothing. Dropping only that
+    // criterion would NARROW the result to its siblings, turning an unset
+    // filter (a facet UI with nothing selected) into an active one.
+    const ignored: unknown[] = [];
+    const params = buildSearchParams(
+      {
+        ...base,
+        where: [
+          {
+            or: [
+              { field: 'status', in: [] },
+              { field: 'keyword', in: ['atlas'] },
+            ],
+          },
+          { or: [{ field: 'format', in: ['text/turtle'] }] },
+        ],
+      },
+      schema,
+      { onIgnoredFilter: (filter) => ignored.push(filter) },
+    );
+    // Only the untouched sibling clause survives – NOT `keyword:[atlas]`.
+    expect(params.filter_by).toBe('format:[`text/turtle`]');
+    expect(ignored).toHaveLength(1);
+  });
+
+  it('drops an unsatisfiable alternative, keeping its siblings', () => {
+    // An empty `id` membership is the request for NO document – false – and
+    // `false || X` is X, so unlike a vacuous value filter it drops out and the
+    // rest of the disjunction still stands.
+    expect(
+      buildSearchParams(
+        {
+          ...base,
+          where: [
+            {
+              or: [
+                { field: 'id', in: [] },
+                { field: 'keyword', in: ['atlas'] },
+              ],
+            },
+          ],
+        },
+        schema,
+      ).filter_by,
+    ).toBe('keyword:[`atlas`]');
+  });
+
+  it('voids a clause whose alternative range has no usable bound', () => {
+    expect(
+      buildSearchParams(
+        {
+          ...base,
+          where: [
+            {
+              or: [
+                { field: 'size', range: {} },
+                { field: 'keyword', in: ['atlas'] },
+              ],
+            },
+          ],
+        },
+        schema,
+      ).filter_by,
+    ).toBeUndefined();
+  });
+
+  it('ignores a clause when no criterion compiles', () => {
+    const ignored: unknown[] = [];
+    const clause = {
+      or: [
+        { field: 'nope', in: ['x'] },
+        { field: 'alsoNope', in: ['x'] },
+      ],
+    };
+    const params = buildSearchParams({ ...base, where: [clause] }, schema, {
+      onIgnoredFilter: (filter) => ignored.push(filter),
+    });
+    expect(params.filter_by).toBeUndefined();
+    expect(ignored).toEqual([clause]);
+  });
+
   it('compiles an `id` clause to exact membership on the document key', () => {
     // `id` is declared by no type: it is the document's IRI, filtered by the
     // same exact clause label resolution uses. Backtick-wrapped, so the IRI's
@@ -123,8 +289,8 @@ describe('buildSearchParams', () => {
       {
         ...base,
         where: [
-          { field: 'id', in: ['https://id.example.org/a', 'urn:b'] },
-          { field: 'status', in: ['valid'] },
+          { or: [{ field: 'id', in: ['https://id.example.org/a', 'urn:b'] }] },
+          { or: [{ field: 'status', in: ['valid'] }] },
         ],
       },
       schema,
@@ -140,8 +306,8 @@ describe('buildSearchParams', () => {
       {
         ...base,
         where: [
-          { field: 'id', in: [] },
-          { field: 'id', range: { min: 1 } },
+          { or: [{ field: 'id', in: [] }] },
+          { or: [{ field: 'id', range: { min: 1 } }] },
         ],
       },
       schema,
@@ -149,8 +315,8 @@ describe('buildSearchParams', () => {
     );
     expect(params.filter_by).toBeUndefined();
     expect(ignored).toEqual([
-      { field: 'id', in: [] },
-      { field: 'id', range: { min: 1 } },
+      { or: [{ field: 'id', in: [] }] },
+      { or: [{ field: 'id', range: { min: 1 } }] },
     ]);
   });
 
@@ -160,11 +326,11 @@ describe('buildSearchParams', () => {
       {
         ...base,
         where: [
-          { field: 'status', in: ['valid'] }, // fine – kept
-          { field: 'nonexistent', in: ['x'] }, // unknown field
-          { field: 'keyword', range: { min: 1 } }, // operator ≠ field kind
-          { field: 'status', in: [] }, // empty membership
-          { field: 'size', range: {} }, // no usable bound
+          { or: [{ field: 'status', in: ['valid'] }] }, // fine – kept
+          { or: [{ field: 'nonexistent', in: ['x'] }] }, // unknown field
+          { or: [{ field: 'keyword', range: { min: 1 } }] }, // operator ≠ field kind
+          { or: [{ field: 'status', in: [] }] }, // empty membership
+          { or: [{ field: 'size', range: {} }] }, // no usable bound
         ],
       },
       schema,
@@ -172,16 +338,16 @@ describe('buildSearchParams', () => {
     );
     expect(params.filter_by).toBe('status:[`valid`]');
     expect(ignored).toEqual([
-      { field: 'nonexistent', in: ['x'] },
-      { field: 'keyword', range: { min: 1 } },
-      { field: 'status', in: [] },
-      { field: 'size', range: {} },
+      { or: [{ field: 'nonexistent', in: ['x'] }] },
+      { or: [{ field: 'keyword', range: { min: 1 } }] },
+      { or: [{ field: 'status', in: [] }] },
+      { or: [{ field: 'size', range: {} }] },
     ]);
   });
 
   it('skips a non-compiling clause silently when no onIgnoredFilter is given', () => {
     const params = buildSearchParams(
-      { ...base, where: [{ field: 'nonexistent', in: ['x'] }] },
+      { ...base, where: [{ or: [{ field: 'nonexistent', in: ['x'] }] }] },
       schema,
     );
     expect(params.filter_by).toBeUndefined();
@@ -190,13 +356,13 @@ describe('buildSearchParams', () => {
   it('compiles a one-sided range bound', () => {
     expect(
       buildSearchParams(
-        { ...base, where: [{ field: 'size', range: { min: 5 } }] },
+        { ...base, where: [{ or: [{ field: 'size', range: { min: 5 } }] }] },
         schema,
       ).filter_by,
     ).toBe('size:>=5');
     expect(
       buildSearchParams(
-        { ...base, where: [{ field: 'size', range: { max: 9 } }] },
+        { ...base, where: [{ or: [{ field: 'size', range: { max: 9 } }] }] },
         schema,
       ).filter_by,
     ).toBe('size:<=9');
@@ -211,11 +377,15 @@ describe('buildSearchParams', () => {
           ...base,
           where: [
             {
-              field: 'datePosted',
-              range: {
-                min: '2024-01-01T00:00:00Z',
-                max: '2025-01-01T00:00:00Z',
-              },
+              or: [
+                {
+                  field: 'datePosted',
+                  range: {
+                    min: '2024-01-01T00:00:00Z',
+                    max: '2025-01-01T00:00:00Z',
+                  },
+                },
+              ],
             },
           ],
         },
@@ -229,8 +399,12 @@ describe('buildSearchParams', () => {
           ...base,
           where: [
             {
-              field: 'datePosted',
-              range: { min: 'not-a-date', max: '2025-01-01T00:00:00Z' },
+              or: [
+                {
+                  field: 'datePosted',
+                  range: { min: 'not-a-date', max: '2025-01-01T00:00:00Z' },
+                },
+              ],
             },
           ],
         },

--- a/packages/search-typesense/test/search-engine.test.ts
+++ b/packages/search-typesense/test/search-engine.test.ts
@@ -230,7 +230,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
   it('filters by status, sorts by the localized title key, and resolves reference labels', async () => {
     const result = await engine.search(datasetSchema, {
       ...baseQuery,
-      where: [{ field: 'status', in: ['valid'] }],
+      where: [{ or: [{ field: 'status', in: ['valid'] }] }],
       orderBy: [
         { field: 'title', direction: 'asc' },
         { field: 'statusRank', direction: 'asc' },
@@ -262,7 +262,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
     // Document per referent – `id` only on the referent that had one.
     const result = await engine.search(datasetSchema, {
       ...baseQuery,
-      where: [{ field: 'id', in: ['d1'] }],
+      where: [{ or: [{ field: 'id', in: ['d1'] }] }],
     });
 
     expect(result.hits[0].document.media).toEqual([
@@ -276,7 +276,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
     // A document without referents nests nothing rather than an empty list.
     const others = await engine.search(datasetSchema, {
       ...baseQuery,
-      where: [{ field: 'id', in: ['d2'] }],
+      where: [{ or: [{ field: 'id', in: ['d2'] }] }],
     });
     expect(others.hits[0].document.media).toBeUndefined();
   });
@@ -284,7 +284,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
   it('looks documents up by `id`, the field no type declares', async () => {
     const result = await engine.search(datasetSchema, {
       ...baseQuery,
-      where: [{ field: 'id', in: ['d3', 'd1'] }],
+      where: [{ or: [{ field: 'id', in: ['d3', 'd1'] }] }],
       orderBy: [{ field: 'statusRank', direction: 'asc' }],
     });
 
@@ -307,7 +307,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
     );
     const result = await engine.search(datasetSchema, {
       ...baseQuery,
-      where: [{ field: 'id', in: [...iris, 'd2'] }],
+      where: [{ or: [{ field: 'id', in: [...iris, 'd2'] }] }],
     });
 
     // Only the one real id matches; the rest simply are not there.
@@ -320,7 +320,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
     // asked for no document; the whole collection would be the wrong answer.
     const result = await engine.search(datasetSchema, {
       ...baseQuery,
-      where: [{ field: 'id', in: [] }],
+      where: [{ or: [{ field: 'id', in: [] }] }],
     });
 
     expect(result.total).toBe(0);
@@ -332,7 +332,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
       {
         ...baseQuery,
         limit: 0,
-        where: [{ field: 'id', in: [] }],
+        where: [{ or: [{ field: 'id', in: [] }] }],
         facets: ['status'],
       },
       { ...baseQuery, limit: 0, facets: ['status'] },
@@ -398,7 +398,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
       {
         ...baseQuery,
         limit: 0,
-        where: [{ field: 'status', in: ['valid'] }],
+        where: [{ or: [{ field: 'status', in: ['valid'] }] }],
         facets: ['keyword'],
       },
     ]);
@@ -447,7 +447,7 @@ describe('createTypesenseSearchEngine (integration)', () => {
     await expect(
       engine.search(datasetSchema, {
         ...baseQuery,
-        where: [{ field: 'nonexistent', in: ['x'] }],
+        where: [{ or: [{ field: 'nonexistent', in: ['x'] }] }],
       }),
     ).rejects.toThrow(/Invalid search query for “Dataset”/);
     await expect(
@@ -468,10 +468,10 @@ describe('createTypesenseSearchEngine (integration)', () => {
 
     const result = await reporting.search(datasetSchema, {
       ...baseQuery,
-      where: [{ field: 'status', in: [] }],
+      where: [{ or: [{ field: 'status', in: [] }] }],
     });
 
     expect(result.total).toBeGreaterThan(0); // empty membership = no constraint
-    expect(ignored).toEqual([{ field: 'status', in: [] }]);
+    expect(ignored).toEqual([{ or: [{ field: 'status', in: [] }] }]);
   });
 });

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these – see AGENTS.md.
-          functions: 98.78,
-          lines: 99.15,
-          branches: 95.05,
-          statements: 99.17,
+          functions: 98.79,
+          lines: 99.17,
+          branches: 95.18,
+          statements: 99.19,
         },
       },
     },

--- a/packages/search/src/adapter.ts
+++ b/packages/search/src/adapter.ts
@@ -28,6 +28,8 @@ export {
   fieldNamed,
   datasetField,
   ID_FIELD,
+  AND_KEY,
+  OR_KEY,
   labelFieldOf,
   isRangeFacet,
   isoToUnixSeconds,
@@ -38,6 +40,7 @@ export { physicalNameTokens } from './physical-name.js';
 export {
   filterOperatorFor,
   filterOperator,
+  filterOn,
   isUnsatisfiable,
   validateQuery,
   assertValidQuery,

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -23,6 +23,8 @@ export {
   validateSearchType,
   assertValidSearchType,
   ID_FIELD,
+  AND_KEY,
+  OR_KEY,
 } from './schema.js';
 export type {
   FieldKind,
@@ -46,7 +48,11 @@ export type {
 
 // Engine- and protocol-neutral query IR (what a `queryDefaults` policy or an
 // in-process caller writes).
-export type { SearchQuery, Filter, Sort } from './query.js';
+// `filterOn` builds the ordinary one-criterion clause – the shape a consumer
+// policy (`queryDefaults`) appends to `where`, so it belongs on the authoring
+// surface and not only on the adapter one.
+export { filterOn } from './query.js';
+export type { SearchQuery, Filter, Criterion, Sort } from './query.js';
 
 // Engine port + the logical result document returned across it. An engine is
 // bound to the whole SearchSchema at construction by its adapter factory.

--- a/packages/search/src/query.ts
+++ b/packages/search/src/query.ts
@@ -14,7 +14,7 @@ import {
 export interface SearchQuery {
   /** Free-text query; `undefined`/`''` means browse (no text ranking). */
   readonly text?: string;
-  /** AND across fields. */
+  /** AND across clauses; each clause is a disjunction ({@link Filter}). */
   readonly where: readonly Filter[];
   /** Primary public sort plus any server tie-breaks, in precedence order. */
   readonly orderBy: readonly Sort[];
@@ -28,12 +28,17 @@ export interface SearchQuery {
 }
 
 /**
- * One `where` clause. The operator is fixed by the target field’s {@link FieldKind}
- * ({@link filterOperatorFor}): keyword/reference use `in` (OR within the field),
- * the numeric/date kinds use an inclusive `range`, boolean uses `is`. Bounds are
- * inclusive only – no `gt`/`gte`/`lt`/`lte`.
+ * One criterion on one field. The operator is fixed by that field’s
+ * {@link FieldKind} ({@link filterOperatorFor}): keyword/reference use `in` (OR
+ * within the value list), the numeric/date kinds use an inclusive `range`,
+ * boolean uses `is`. Bounds are inclusive only – no `gt`/`gte`/`lt`/`lte`.
+ *
+ * Criteria are the atoms a {@link Filter} is built from, so each carries its own
+ * field AND its own operator: one clause may range over a `reference` and a
+ * `keyword` field at once, and each field is constrained the way its kind
+ * allows.
  */
-export type Filter =
+export type Criterion =
   | { readonly field: string; readonly in: readonly string[] }
   | {
       readonly field: string;
@@ -43,6 +48,22 @@ export type Filter =
       };
     }
   | { readonly field: string; readonly is: boolean };
+
+/**
+ * One `where` clause: a disjunction, matching a document that satisfies **any**
+ * of its criteria. An ordinary single-field filter is the one-criterion case,
+ * so there is no separate cross-field variant for a consumer to overlook – an
+ * adapter that iterates `or` serves one criterion and five by the same code.
+ *
+ * Clauses AND together ({@link SearchQuery.where}), so a query is a **flat**
+ * conjunction of disjunctions. Deliberately flat rather than a boolean tree:
+ * skip-own-filter (ADR 5) removes *a facet’s own clause*, which has no answer
+ * once a clause can be nested inside another. A criterion is therefore an atom –
+ * it can never itself be a conjunction.
+ */
+export interface Filter {
+  readonly or: readonly Criterion[];
+}
 
 /** A single sort dimension. */
 export interface Sort {
@@ -57,14 +78,21 @@ export { filterOperatorFor } from './schema.js';
 export type { FilterOperator } from './schema.js';
 import type { FilterOperator } from './schema.js';
 
-/** The operator a {@link Filter} value carries, from its discriminating key. */
-export function filterOperator(filter: Filter): FilterOperator {
-  return 'in' in filter ? 'in' : 'range' in filter ? 'range' : 'is';
+/** The operator a {@link Criterion} carries, from its discriminating key. */
+export function filterOperator(criterion: Criterion): FilterOperator {
+  return 'in' in criterion ? 'in' : 'range' in criterion ? 'range' : 'is';
+}
+
+/** A one-criterion clause – the ordinary single-field filter, and the shape a
+ *  keyed API surface compiles each of its keys into. */
+export function filterOn(criterion: Criterion): Filter {
+  return { or: [criterion] };
 }
 
 /**
  * Whether the query asks for nothing, so no engine can answer it with a hit.
- * True for an empty `in` on {@link ID_FIELD} – and only there, deliberately:
+ * True for an empty `in` on a clause naming {@link ID_FIELD} **alone** – and
+ * only there, deliberately:
  *
  * An **identity** filter enumerates the documents wanted, so the empty set
  * wants none. A **value** filter constrains a dimension, so an empty set
@@ -75,21 +103,36 @@ export function filterOperator(filter: Filter): FilterOperator {
  * specific things – the likely shape being a client mapping a possibly-empty
  * reference array (`id: { in: doc.publisher }`) into a batch lookup.
  *
+ * The identity reading needs the clause to be *only* about identity, so it must
+ * carry that one criterion and nothing else. A clause pairing `id` with a value
+ * field (`{ or: [{ field: 'id', in: [] }, { field: 'creator', in: [] }] }`)
+ * is a disjunction that happens to include identity, not an enumeration of
+ * wanted documents, so it stays the vacuous no-op every other empty `in` is.
+ *
  * An adapter MUST answer an unsatisfiable query with an empty result rather
  * than dispatching it.
  */
 export function isUnsatisfiable(query: SearchQuery): boolean {
-  return query.where.some(
-    (filter) =>
-      filter.field === ID_FIELD && 'in' in filter && filter.in.length === 0,
-  );
+  return query.where.some((filter) => {
+    const [criterion] = filter.or;
+    return (
+      filter.or.length === 1 &&
+      criterion !== undefined &&
+      criterion.field === ID_FIELD &&
+      'in' in criterion &&
+      criterion.in.length === 0
+    );
+  });
 }
 
 /**
  * One structural problem {@link validateQuery} found: the query references a
  * field the search type does not declare, or uses it in a role it does not
- * opt into. Vacuous-but-valid clauses (an empty `in` list, a `range` with no
- * bound) are NOT issues – a compiler skips those as no-ops.
+ * opt into. Reported per **criterion**, so a clause carrying two criteria over
+ * unknown fields yields two issues, each naming its own field.
+ *
+ * Vacuous-but-valid clauses (an empty `in` list, a `range` with no bound, a
+ * clause with no criteria) are NOT issues – a compiler skips those as no-ops.
  */
 export interface QueryIssue {
   readonly part: 'where' | 'facets' | 'orderBy';
@@ -99,11 +142,13 @@ export interface QueryIssue {
 }
 
 /**
- * Structurally validate a query against its search type: every `where` clause
- * targets a declared, `filterable` field with the operator its kind accepts
- * ({@link filterOperatorFor}) – or the undeclared, always-filterable
- * {@link ID_FIELD}, which takes `in`; every requested facet is a declared, `facetable`
- * field; every sort is `relevance` or a declared field. Sorting deliberately
+ * Structurally validate a query against its search type: **every criterion of
+ * every `where` clause** names a declared, `filterable` field whose kind accepts
+ * that criterion’s operator ({@link filterOperatorFor}) – or the undeclared,
+ * always-filterable {@link ID_FIELD}, which takes `in`; every requested facet is
+ * a declared, `facetable` field; every sort is `relevance` or a declared field.
+ * Because each criterion is matched against its own field’s kind, one clause may
+ * range over fields of different kinds. Sorting deliberately
  * checks declaration only, not the `sortable` flag: that flag means *publicly
  * selectable*, and a deployment policy may sort on a private tie-break field.
  *
@@ -118,38 +163,38 @@ export function validateQuery(
 ): readonly QueryIssue[] {
   const issues: QueryIssue[] = [];
   for (const filter of query.where) {
-    // `id` is filterable on every type without being declared by any: it is the
-    // document’s IRI, so the lookup exists wherever documents do. Membership
-    // only – an IRI has no range and no truth value.
-    if (filter.field === ID_FIELD) {
-      if (filterOperator(filter) !== 'in') {
+    // Each criterion is checked on its own, so a multi-criterion clause needs
+    // no rule of its own: naming an undeclared or non-filterable field is the
+    // same mistake whether the clause carries one criterion or five, and each
+    // criterion is matched against ITS OWN field’s kind – so one clause may mix
+    // a `reference` membership with a `date` range without either being wrong.
+    for (const criterion of filter.or) {
+      const name = criterion.field;
+      // `id` is filterable on every type without being declared by any: it is
+      // the document’s IRI, so the lookup exists wherever documents do.
+      // Membership only – an IRI has no range and no truth value.
+      if (name === ID_FIELD) {
+        if (filterOperator(criterion) !== 'in') {
+          issues.push({
+            part: 'where',
+            field: name,
+            reason: 'operator-mismatch',
+          });
+        }
+        continue;
+      }
+      const field = fieldNamed(searchType, name);
+      if (field === undefined) {
+        issues.push({ part: 'where', field: name, reason: 'unknown-field' });
+      } else if (field.filterable !== true) {
+        issues.push({ part: 'where', field: name, reason: 'not-filterable' });
+      } else if (filterOperatorFor(field.kind) !== filterOperator(criterion)) {
         issues.push({
           part: 'where',
-          field: filter.field,
+          field: name,
           reason: 'operator-mismatch',
         });
       }
-      continue;
-    }
-    const field = fieldNamed(searchType, filter.field);
-    if (field === undefined) {
-      issues.push({
-        part: 'where',
-        field: filter.field,
-        reason: 'unknown-field',
-      });
-    } else if (field.filterable !== true) {
-      issues.push({
-        part: 'where',
-        field: filter.field,
-        reason: 'not-filterable',
-      });
-    } else if (filterOperatorFor(field.kind) !== filterOperator(filter)) {
-      issues.push({
-        part: 'where',
-        field: filter.field,
-        reason: 'operator-mismatch',
-      });
     }
   }
   for (const name of query.facets) {

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -768,6 +768,27 @@ export interface SearchTypeIssue {
  */
 export const ID_FIELD = 'id';
 
+/**
+ * The reserved `where` keys that name a **combinator** rather than a field.
+ * Sibling keys in a `where` object already AND, so `or` is what makes a
+ * disjunction expressible at all, and `and` is what lets a query carry more
+ * than one of them.
+ *
+ * They live in the same namespace a declaration draws from, so a field called
+ * `and` or `or` would shadow the combinator in `where` and silently answer a
+ * different question – exactly as a declared `id` would.
+ * {@link validateSearchType} rejects all three as `reserved-field-name`.
+ * Neither is plausible as an RDF property name; a deployment that needs one
+ * anyway can declare it under a different logical name, since the logical name
+ * is deliberately not derived from the predicate IRI.
+ */
+export const AND_KEY = 'and';
+export const OR_KEY = 'or';
+
+/** The logical field names no {@link SearchType} may declare, each because a
+ *  surface already gives that name a meaning of its own. */
+const RESERVED_FIELD_NAMES: readonly string[] = [ID_FIELD, AND_KEY, OR_KEY];
+
 /** Kinds that can feed full-text search (project a folded search field). */
 const SEARCHABLE_KINDS: readonly FieldKind[] = ['text', 'keyword', 'reference'];
 
@@ -860,10 +881,11 @@ export function validateSearchType(
     if (!FIELD_NAME_PATTERN.test(field.name)) {
       issue('invalid-field-name');
     }
-    // `id` is the document’s IRI, surfaced and filtered for every type; a
-    // declared field of that name would shadow it in the API output and in
-    // `where`, silently answering a different question.
-    if (field.name === ID_FIELD) {
+    // `id` is the document’s IRI, surfaced and filtered for every type, and
+    // `and`/`or` are the `where` combinators; a declared field of any of those
+    // names would shadow it in the API output or in `where`, silently
+    // answering a different question.
+    if (RESERVED_FIELD_NAMES.includes(field.name)) {
       issue('reserved-field-name');
     }
     // Every kind-dependent rule below would silently pass for a kind outside

--- a/packages/search/src/testing.ts
+++ b/packages/search/src/testing.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { SearchEngine } from './engine.js';
 import {
+  filterOn,
   filterOperatorFor,
   type Filter,
   type FilterOperator,
@@ -72,7 +73,7 @@ export function describeSearchEngineContract(
       for (const searchType of types()) {
         const query: SearchQuery = {
           ...browse(searchType),
-          where: [{ field: 'fieldThatDoesNotExist', in: ['x'] }],
+          where: [filterOn({ field: 'fieldThatDoesNotExist', in: ['x'] })],
         };
         await expect(engine().search(searchType, query)).rejects.toThrow(
           /unknown-field/,
@@ -89,7 +90,9 @@ export function describeSearchEngineContract(
       for (const searchType of types()) {
         const query: SearchQuery = {
           ...browse(searchType),
-          where: [{ field: ID_FIELD, in: ['urn:test:no-such-document'] }],
+          where: [
+            filterOn({ field: ID_FIELD, in: ['urn:test:no-such-document'] }),
+          ],
         };
         const result = await engine().search(searchType, query);
         expect(result.total).toBe(0);
@@ -274,8 +277,8 @@ function mismatchedFilter(
   operator: FilterOperator | undefined,
 ): Filter {
   return operator === 'in'
-    ? { field, range: { min: 0 } }
-    : { field, in: ['x'] };
+    ? filterOn({ field, range: { min: 0 } })
+    : filterOn({ field, in: ['x'] });
 }
 
 /** The locale a query against this type may select (any is contract-valid). */

--- a/packages/search/test/query.test.ts
+++ b/packages/search/test/query.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   assertValidQuery,
+  filterOn,
   filterOperator,
   filterOperatorFor,
   isUnsatisfiable,
@@ -11,10 +12,18 @@ import {
 import type { SearchType } from '../src/schema.js';
 
 describe('filterOperator', () => {
-  it('reads the operator off a filter’s discriminating key', () => {
+  it('reads the operator off a criterion’s discriminating key', () => {
     expect(filterOperator({ field: 'format', in: ['text/turtle'] })).toBe('in');
     expect(filterOperator({ field: 'size', range: { min: 1 } })).toBe('range');
     expect(filterOperator({ field: 'iiif', is: true })).toBe('is');
+  });
+});
+
+describe('filterOn', () => {
+  it('wraps one criterion as a clause – the ordinary single-field filter', () => {
+    expect(filterOn({ field: 'status', in: ['valid'] })).toEqual({
+      or: [{ field: 'status', in: ['valid'] }],
+    });
   });
 });
 
@@ -41,21 +50,46 @@ describe('isUnsatisfiable', () => {
   };
 
   it('holds only for an empty `id` membership – the request for no document', () => {
-    expect(isUnsatisfiable({ ...base, where: [{ field: 'id', in: [] }] })).toBe(
-      true,
-    );
+    expect(
+      isUnsatisfiable({ ...base, where: [{ or: [{ field: 'id', in: [] }] }] }),
+    ).toBe(true);
     // A non-empty lookup asks for something.
     expect(
-      isUnsatisfiable({ ...base, where: [{ field: 'id', in: ['urn:a'] }] }),
+      isUnsatisfiable({
+        ...base,
+        where: [{ or: [{ field: 'id', in: ['urn:a'] }] }],
+      }),
     ).toBe(false);
     // A value field's empty membership stays a no-op: no values means no
     // constraint (a facet UI with nothing selected), not "no documents".
     expect(
-      isUnsatisfiable({ ...base, where: [{ field: 'status', in: [] }] }),
+      isUnsatisfiable({
+        ...base,
+        where: [{ or: [{ field: 'status', in: [] }] }],
+      }),
     ).toBe(false);
     // Other operators on `id` are already an operator-mismatch, not this.
     expect(
-      isUnsatisfiable({ ...base, where: [{ field: 'id', is: true }] }),
+      isUnsatisfiable({
+        ...base,
+        where: [{ or: [{ field: 'id', is: true }] }],
+      }),
+    ).toBe(false);
+    // A clause pairing `id` WITH a value field is a disjunction that happens to
+    // include identity, not an enumeration of wanted documents – so the
+    // identity reading does not apply and it stays a vacuous no-op.
+    expect(
+      isUnsatisfiable({
+        ...base,
+        where: [
+          {
+            or: [
+              { field: 'id', in: [] },
+              { field: 'creator', in: [] },
+            ],
+          },
+        ],
+      }),
     ).toBe(false);
     expect(isUnsatisfiable(base)).toBe(false);
   });
@@ -70,6 +104,8 @@ describe('validateQuery', () => {
       { name: 'size', kind: 'integer', filterable: true },
       { name: 'license', kind: 'keyword' }, // declared, but no roles opted into
       { name: 'statusRank', kind: 'integer', sortable: true },
+      { name: 'creator', kind: 'reference', filterable: true },
+      { name: 'about', kind: 'reference', filterable: true },
     ],
   };
   const base: SearchQuery = {
@@ -87,8 +123,8 @@ describe('validateQuery', () => {
         {
           ...base,
           where: [
-            { field: 'status', in: ['valid'] },
-            { field: 'size', range: { min: 1 } },
+            { or: [{ field: 'status', in: ['valid'] }] },
+            { or: [{ field: 'size', range: { min: 1 } }] },
           ],
           facets: ['status'],
           orderBy: [
@@ -109,8 +145,8 @@ describe('validateQuery', () => {
         {
           ...base,
           where: [
-            { field: 'status', in: [] },
-            { field: 'size', range: {} },
+            { or: [{ field: 'status', in: [] }] },
+            { or: [{ field: 'size', range: {} }] },
           ],
         },
         searchType,
@@ -123,9 +159,9 @@ describe('validateQuery', () => {
       {
         ...base,
         where: [
-          { field: 'nonexistent', in: ['x'] },
-          { field: 'license', in: ['MIT'] },
-          { field: 'status', range: { min: 1 } },
+          { or: [{ field: 'nonexistent', in: ['x'] }] },
+          { or: [{ field: 'license', in: ['MIT'] }] },
+          { or: [{ field: 'status', range: { min: 1 } }] },
         ],
         facets: ['nonexistent', 'size'],
         orderBy: [{ field: 'nonexistent', direction: 'asc' }],
@@ -145,7 +181,10 @@ describe('validateQuery', () => {
   it('accepts `id`, which no type declares but every type carries', () => {
     expect(
       validateQuery(
-        { ...base, where: [{ field: 'id', in: ['https://example.org/1'] }] },
+        {
+          ...base,
+          where: [{ or: [{ field: 'id', in: ['https://example.org/1'] }] }],
+        },
         searchType,
       ),
     ).toEqual([]);
@@ -154,16 +193,118 @@ describe('validateQuery', () => {
   it('rejects a non-membership operator on `id`: an IRI has no range', () => {
     expect(
       validateQuery(
-        { ...base, where: [{ field: 'id', range: { min: 1 } }] },
+        { ...base, where: [{ or: [{ field: 'id', range: { min: 1 } }] }] },
         searchType,
       ),
     ).toEqual([{ part: 'where', field: 'id', reason: 'operator-mismatch' }]);
   });
 
+  it('accepts a disjunction over several fields – the cross-field clause', () => {
+    const iri = 'https://example.org/vg';
+    expect(
+      validateQuery(
+        {
+          ...base,
+          where: [
+            {
+              or: [
+                { field: 'id', in: [iri] },
+                { field: 'creator', in: [iri] },
+                { field: 'about', in: [iri] },
+              ],
+            },
+          ],
+        },
+        searchType,
+      ),
+    ).toEqual([]);
+  });
+
+  it('checks every criterion of a clause, reporting one issue each', () => {
+    expect(
+      validateQuery(
+        {
+          ...base,
+          where: [
+            {
+              or: [
+                { field: 'creator', in: ['x'] },
+                { field: 'nonexistent', in: ['x'] },
+                { field: 'license', in: ['x'] },
+              ],
+            },
+          ],
+        },
+        searchType,
+      ),
+    ).toEqual([
+      { part: 'where', field: 'nonexistent', reason: 'unknown-field' },
+      { part: 'where', field: 'license', reason: 'not-filterable' },
+    ]);
+  });
+
+  it('lets one clause mix kinds: each criterion is matched to its own field', () => {
+    // `creator` takes `in` and `size` takes `range`. Because a criterion carries
+    // its own operator, a disjunction over both is well-formed – “made by this
+    // person OR larger than 100”.
+    expect(
+      validateQuery(
+        {
+          ...base,
+          where: [
+            {
+              or: [
+                { field: 'creator', in: ['x'] },
+                { field: 'size', range: { min: 100 } },
+              ],
+            },
+          ],
+        },
+        searchType,
+      ),
+    ).toEqual([]);
+    // …while an operator that does not match ITS OWN field is still rejected.
+    expect(
+      validateQuery(
+        { ...base, where: [{ or: [{ field: 'size', in: ['x'] }] }] },
+        searchType,
+      ),
+    ).toEqual([{ part: 'where', field: 'size', reason: 'operator-mismatch' }]);
+  });
+
+  it('accepts several criteria on one field – the same-field disjunction', () => {
+    // Two ranges on one field is the case a value list cannot express:
+    // “smaller than 10 or larger than 100”.
+    expect(
+      validateQuery(
+        {
+          ...base,
+          where: [
+            {
+              or: [
+                { field: 'size', range: { max: 10 } },
+                { field: 'size', range: { min: 100 } },
+              ],
+            },
+          ],
+        },
+        searchType,
+      ),
+    ).toEqual([]);
+  });
+
+  it('treats a clause with no criteria as vacuous, not invalid', () => {
+    // Like an empty `in` or a boundless `range`: it constrains nothing, so a
+    // compiler skips it as a no-op rather than the query being rejected.
+    expect(validateQuery({ ...base, where: [{ or: [] }] }, searchType)).toEqual(
+      [],
+    );
+  });
+
   it('assertValidQuery names the type and every issue', () => {
     expect(() =>
       assertValidQuery(
-        { ...base, where: [{ field: 'nonexistent', in: ['x'] }] },
+        { ...base, where: [{ or: [{ field: 'nonexistent', in: ['x'] }] }] },
         searchType,
       ),
     ).toThrow(

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -382,6 +382,19 @@ describe('validateSearchType', () => {
     ).toEqual([]);
   });
 
+  it('rejects a field named `and` or `or`, the reserved `where` combinators', () => {
+    // Sibling keys in `where` already AND, so `or` is what makes a disjunction
+    // expressible and `and` what carries a second one. A declared field of
+    // either name would shadow the combinator and silently answer a different
+    // question, exactly as a declared `id` would.
+    expect(
+      validateSearchType(typeWith({ name: 'and', kind: 'keyword' })),
+    ).toEqual([{ field: 'and', reason: 'reserved-field-name' }]);
+    expect(
+      validateSearchType(typeWith({ name: 'or', kind: 'keyword' })),
+    ).toEqual([{ field: 'or', reason: 'reserved-field-name' }]);
+  });
+
   it('rejects a declared locale containing an underscore', () => {
     // `_` is the reserved name↔locale separator; a locale carrying one would
     // collide with the physical/display field naming.


### PR DESCRIPTION
Fix #611

“Show me everything related to this entity” had no answer: a `where` clause named exactly one field, and in Linked Data one conceptual filter routinely maps to several predicates (an agent is `creator` or `contributor`, a place is `contentLocation` or `locationCreated`). A consumer had to issue one query per predicate and merge client-side, losing `total`, ranking and facet counts.

## Query model

A clause is now a **disjunction of criteria**, each naming one field and carrying the operator that field’s kind accepts:

```ts
type Criterion = { field; in } | { field; range } | { field; is };
interface Filter { readonly or: readonly Criterion[] }   // OR across criteria
// SearchQuery.where: readonly Filter[]                   // AND across clauses
```

There is **one clause model, not two**: an ordinary single-field filter is the one-criterion case (`filterOn` builds it), so no engine adapter can overlook a cross-field variant, and `validateQuery` keeps applying one rule. Because a criterion carries its own operator, a clause may mix kinds and may name one field twice – the only way to express “smaller than 10 **or** larger than 100”.

`where` stays a flat conjunction of disjunctions rather than a boolean tree: “remove this facet’s own clause” (ADR 5) has no answer once a clause can nest inside an `OR`.

## GraphQL surface

Sibling keys still AND and keep their per-kind types; two keys name the combinators, so neither is inferred from nesting:

```graphql
where: { material: { in: ["oil"] }, or: [{ creator: $iri }, { about: $iri }] }
where: { and: [{ or: [{ creator: $a }, { contributor: $a }] },
               { or: [{ contentLocation: $p }, { locationCreated: $p }] }] }
```

`‹Type›Criterion` is `@oneOf`, so a criterion is an atom – a conjunction nested inside an `or` is unrepresentable, which is what keeps the model flat. `and` carries further `‹Type›Where`s (safe to recurse: a conjunction inside a conjunction flattens, and an `and` can never sit inside an `or`), so two input types serve every depth.

Existing queries are unaffected – the keyed form is unchanged and both keys are additive.

## Facets

A clause is a facet’s own when **every** criterion names that field, so an ordinary filter and a same-field disjunction both drop under skip-own-filter. A clause spanning several fields is nobody’s own and stays whole, which keeps every facet complete on its own field and never splits the facet batch.

## Breaking

- `SearchQuery.where` clauses are `{ or: [Criterion] }` rather than a field plus an operator.
- `and` and `or` join `id` as reserved field names, so a `SearchType` declaring either no longer validates.
- `@lde/search-api-graphql` requires `graphql` `^16.9.0`, where `@oneOf` landed.

## Notes

- A vacuous alternative (empty `in`, boundless `range`) **voids** its clause instead of narrowing it to its siblings – “no constraint OR anything” is no constraint – while an unsatisfiable one (an empty `id` membership) drops out and its siblings stand.
- Decision and rejected alternatives (enum-named fields, nested `[[…]]` lists, a single non-recursive clause type) recorded in ADR 18.
