### PR TITLE
build(search-typesense): run against Typesense 30.2

### DIFF
--- a/docs/guide/build-a-search-api.md
+++ b/docs/guide/build-a-search-api.md
@@ -49,7 +49,7 @@ Create `compose.yaml` with the engine, the one-shot indexer, and the API server:
 ```yaml
 services:
   typesense:
-    image: typesense/typesense:30.0
+    image: typesense/typesense:30.2
     command: --data-dir /data --api-key=local-admin-key
     volumes:
       - typesense-data:/data

--- a/packages/search-pipeline/test/typesense-container.ts
+++ b/packages/search-pipeline/test/typesense-container.ts
@@ -18,7 +18,7 @@ export class TypesenseContainer {
   private readonly port = 8108;
 
   async start(): Promise<Client> {
-    this.container = await new GenericContainer('typesense/typesense:30.0')
+    this.container = await new GenericContainer('typesense/typesense:30.2')
       .withExposedPorts(this.port)
       .withCommand([
         '--data-dir=/tmp',

--- a/packages/search-typesense/test/typesense-container.ts
+++ b/packages/search-typesense/test/typesense-container.ts
@@ -18,16 +18,14 @@ export class TypesenseContainer {
   private readonly port = 8108;
 
   async start(): Promise<Client> {
-    this.container = await new GenericContainer('typesense/typesense:30.0')
+    this.container = await new GenericContainer('typesense/typesense:30.2')
       .withExposedPorts(this.port)
       .withCommand([
         '--data-dir=/tmp',
         `--api-key=${this.apiKey}`,
         '--enable-cors',
       ])
-      .withWaitStrategy(
-        Wait.forHttp('/health', this.port).forStatusCode(200),
-      )
+      .withWaitStrategy(Wait.forHttp('/health', this.port).forStatusCode(200))
       .start();
     return this.client();
   }


### PR DESCRIPTION
Moves the Typesense server from 30.0 to 30.2, the latest stable release (31.0 is still at rc13).

- test containers in `search-typesense` and `search-pipeline`
- the `compose.yaml` snippet in the search API guide, so the documented deployment matches what the tests run

Both 30.1 and 30.2 are bug-fix only – nothing to migrate. 30.2 fixes numeric `!=` filters, highlighting races during union searches alongside concurrent writes, reference faceting, and `/health` responsiveness under bulk inserts.

The npm client is untouched: `typesense@^3.0.6` is already `latest` (3.0.7-0 is a prerelease).

One incidental hunk in `search-typesense/test/typesense-container.ts`: the pre-commit Prettier run collapsed an already-wrapped `withWaitStrategy` call that was formatted against an older config.

Groundwork for #712 – reference fields need join support, which shipped in 26.0 and was extended in 30.0.
