### PR TITLE
feat(search-api-graphql)!: serve a reference’s label as label, not name

### DIFF
--- a/docs/decisions/0004-search-api-graphql-surface.md
+++ b/docs/decisions/0004-search-api-graphql-surface.md
@@ -8,6 +8,10 @@ Accepted
 
 Builds on [ADR 3 (Search API core query model)](./0003-search-api-core-query-model.md).
 
+Amended 2026-08-10: a `labelOnly` reference serves its resolved label as
+`label`, not `name` – the word the label source declares and a reference
+facet’s bucket already carries. The `name` below is historical.
+
 ## Context
 
 Given the engine-neutral core of [ADR 3](./0003-search-api-core-query-model.md), the first

--- a/docs/guide/build-a-search-api.md
+++ b/docs/guide/build-a-search-api.md
@@ -49,7 +49,7 @@ Create `compose.yaml` with the engine, the one-shot indexer, and the API server:
 ```yaml
 services:
   typesense:
-    image: typesense/typesense:30.0
+    image: typesense/typesense:30.2
     command: --data-dir /data --api-key=local-admin-key
     volumes:
       - typesense-data:/data

--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -148,7 +148,9 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
 
 - **Output type** (the `SearchType`’s `name`): localized text → best-first `[LanguageString!]!`
   (`[0].language` is the language actually served); references → named per-shape
-  types (`Organization`, `Term`) with a `name` – a reference whose `typeName`
+  types (`Organization`, `Term`) with an `id` and a `label` – the same word the
+  [label source](./search#field-model) declares, so a reference reads like the
+  collection it points at – a reference whose `typeName`
   names a root type (`creator` → `Person`) is served under a derived name
   (`PersonReference`), since GraphQL type names must be unique; a **surfaced
   inline reference** instead gets a type built from its Reference Type’s own

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -347,6 +347,12 @@ type must declare an `output`, `searchable` text field called `label` –
 `searchSchema` validates this schema-wide, so a dangling or unsuitable label
 source fails at startup. A reference without a `labelSource` stays id-only.
 
+The resolved label is called **`label`** wherever it surfaces: on the label
+source’s own type, on the reference that resolves against it (`dataset { id
+label }`), and on a reference facet’s bucket. One word, one meaning – so a
+collection reads the same whether you arrive at it directly or through a
+reference.
+
 ### Facet buckets
 
 A `FacetBucket` always carries its `value` and `count`; what else it carries is

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -278,7 +278,10 @@ export function buildGraphQLSchema(
           nested === undefined
             ? {
                 id: { type: new GraphQLNonNull(GraphQLString) },
-                name: labelList(
+                // `label`, the same word the label source declares and a
+                // reference facet’s bucket carries: one resolved label, one
+                // name for it wherever it surfaces.
+                label: labelList(
                   (source) => source.label as LocalizedValue | undefined,
                 ),
               }

--- a/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
+++ b/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
@@ -32,7 +32,7 @@ type LanguageString {
 
 type Agent {
   id: String!
-  name: [LanguageString!]!
+  label: [LanguageString!]!
 }
 
 type Pagination {

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -168,8 +168,8 @@ describe('buildGraphQLSchema', () => {
             id
             title { language value }
             keyword
-            publisher { id name { language value } }
-            terminologySource { id name { language value } }
+            publisher { id label { language value } }
+            terminologySource { id label { language value } }
             size
             datePosted
             score
@@ -194,13 +194,13 @@ describe('buildGraphQLSchema', () => {
     expect(item.keyword).toEqual(['kaarten']);
     expect(item.publisher).toEqual({
       id: 'https://org/1',
-      name: [{ language: 'nl', value: 'Het Utrechts Archief' }],
+      label: [{ language: 'nl', value: 'Het Utrechts Archief' }],
     });
     expect(item.size).toBe(1234);
     expect(item.datePosted).toBe('2023-11-14T22:13:20.000Z');
     expect(item.score).toBe(4.5);
     expect(item.terminologySource).toEqual([
-      { id: 'https://term/1', name: [{ language: 'nl', value: 'Kaarten' }] },
+      { id: 'https://term/1', label: [{ language: 'nl', value: 'Kaarten' }] },
     ]);
     expect(item.iiif).toBe(true);
     expect(data.facets).toEqual({
@@ -957,7 +957,7 @@ describe('buildGraphQLSchema', () => {
       expect(sdl.match(/^type Person /gm)).toHaveLength(1);
       expect(sdl).toMatch(/author: PersonReference/);
       expect(sdl).toMatch(
-        /type PersonReference \{\s+id: String!\s+name: \[LanguageString!\]!\s+\}/,
+        /type PersonReference \{\s+id: String!\s+label: \[LanguageString!\]!\s+\}/,
       );
     });
 

--- a/packages/search-pipeline/test/typesense-container.ts
+++ b/packages/search-pipeline/test/typesense-container.ts
@@ -18,7 +18,7 @@ export class TypesenseContainer {
   private readonly port = 8108;
 
   async start(): Promise<Client> {
-    this.container = await new GenericContainer('typesense/typesense:30.0')
+    this.container = await new GenericContainer('typesense/typesense:30.2')
       .withExposedPorts(this.port)
       .withCommand([
         '--data-dir=/tmp',

--- a/packages/search-typesense/test/typesense-container.ts
+++ b/packages/search-typesense/test/typesense-container.ts
@@ -18,16 +18,14 @@ export class TypesenseContainer {
   private readonly port = 8108;
 
   async start(): Promise<Client> {
-    this.container = await new GenericContainer('typesense/typesense:30.0')
+    this.container = await new GenericContainer('typesense/typesense:30.2')
       .withExposedPorts(this.port)
       .withCommand([
         '--data-dir=/tmp',
         `--api-key=${this.apiKey}`,
         '--enable-cors',
       ])
-      .withWaitStrategy(
-        Wait.forHttp('/health', this.port).forStatusCode(200),
-      )
+      .withWaitStrategy(Wait.forHttp('/health', this.port).forStatusCode(200))
       .start();
     return this.client();
   }


### PR DESCRIPTION
A `labelOnly` reference served its resolved label as `name`, while the label
source that produces it must declare the field as `label` – and a reference
facet’s bucket already carries it as `label` too. So one collection read two
ways depending on whether you arrived at it directly or through a reference,
with nothing in the declaration hinting at the rename.

Rather than document the discrepancy, this removes it: the reference field is
now `label`.

```graphql
{ creativeWorks { items { dataset { id label } } } }
```

- `packages/search-api-graphql/src/build-schema.ts` – the `labelOnly` reference
  type serves `label` instead of `name`
- `docs/reference/search.md` – state the convention where `labelSource` is
  described, since that is where a reader forms the expectation
- `docs/reference/search-api-graphql.md` – describe the reference type as
  `id` + `label`
- `docs/decisions/0004-search-api-graphql-surface.md` – note the rename; its
  `name` is now historical
- tests and the SDL snapshot follow the rename

**Breaking:** clients selecting `name` on a reference type must select `label`.

Fix #714
