### PR TITLE
feat(search)!: filter across collections through declared joins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Each package uses conditional exports with a `development` condition for local d
 - Test files use `.test.ts` suffix in `test/` directory
 - Fixtures in `test/fixtures/`
 - HTTP mocking with Nock
-- Tests that start a local SPARQL endpoint (`@lde/local-sparql-endpoint`) must use unique ports across packages to avoid conflicts when Nx runs tests in parallel. Current port allocations: `dataset-registry-client` (3002), `pipeline` sparqlQuery (3001), `pipeline` executor (3003), `pipeline` provenance store (3004), `pipeline-void` namespace-normalization (3005–3006), `search-pipeline` extraction round-trip (3007), `search-pipeline` searchIndexerPipeline end-to-end (3008), `search-pipeline` registry-sourced extraction (3009)
+- Tests that start a local SPARQL endpoint (`@lde/local-sparql-endpoint`) must use unique ports across packages to avoid conflicts when Nx runs tests in parallel. Current port allocations: `dataset-registry-client` (3002), `pipeline` sparqlQuery (3001), `pipeline` executor (3003), `pipeline` provenance store (3004), `pipeline-void` namespace-normalization (3005–3006), `search-pipeline` extraction round-trip (3007), `search-pipeline` searchIndexerPipeline end-to-end (3008), `search-pipeline` registry-sourced extraction (3009), `search-pipeline` joins end-to-end (3010)
 
 ### Key Dependencies
 

--- a/docs/decisions/0019-filter-across-collections-through-declared-joins.md
+++ b/docs/decisions/0019-filter-across-collections-through-declared-joins.md
@@ -1,0 +1,283 @@
+# 19. Filter across collections through declared joins
+
+Date: 2026-08-10
+
+## Status
+
+Accepted
+
+Amends
+[ADR 18 (Filter across several fields with one clause)](./0018-filter-across-several-fields-with-one-clause.md)
+– a criterion gains an `on` path – and weakens
+[ADR 9 (Route a whole-schema projection to per-type collections)](./0009-route-a-whole-schema-projection-to-per-type-collections.md)
+– the unit of isolation becomes the join component rather than the collection.
+Builds on the reference model of
+[ADR 8 (Resolve reference labels from per-reference label sources)](./0008-resolve-reference-labels-from-per-reference-label-sources.md).
+
+## Context
+
+“Every object published by institution X” had no answer in one query. Each root
+type owns its own collection ([ADR 9](./0009-route-a-whole-schema-projection-to-per-type-collections.md)),
+and a `reference` field carried only an IRI, so a consumer had to list the
+institution’s datasets, then query the objects of each – two round trips, a
+`total` that had to be summed client-side, and facet counts that could not be
+computed at all.
+
+The fact needed to close that gap was already declared. A `reference` field
+whose `labelSource` names a root type asserts that its values are ids of
+documents in that type’s collection – exactly what an engine-level reference
+field needs. In [limburg/lol](https://codeberg.org/limburg/lol),
+`CreativeWork.dataset → Dataset.publisher → Publisher` is two such assertions in
+a row.
+
+What was missing was permission to use them that way, and a home for the rules
+that come with using them.
+
+## Decision
+
+### `joinable` is a capability flag, not a reinterpretation
+
+A `reference` field opts in with `joinable: true`, valid only alongside
+`labelSource`. It joins `filterable` / `facetable` / `sortable` – the same
+vocabulary, the same shape: a field carries exactly the roles it declares.
+
+Auto-deriving a join from every `labelSource` was rejected. Typesense silently
+refuses to index a mutual reference, so an existing schema would lose a field
+with no error – and every `labelSource` added for display alone would start
+paying the rebuild coupling below. As it is, a `labelSource` costs what it
+costs today; only an opted-in edge pays.
+
+**At most one `joinable` field per (type, label source)**, enforced when the
+schema is built and naming both fields. Typesense addresses a join by
+_collection_, not by field: a second reference to the same collection is
+accepted, indexed, and then unreachable (see [Constraints](#constraints-verified-against-typesense-302)).
+`publisher` and `creator` both resolving to `Organization` is the ordinary case,
+so it has to be a declaration error rather than a surprise at query time.
+
+### One concept holds the edges: `joinGraph(schema)`
+
+`joinGraph` has two members, because consumers ask exactly two questions:
+
+```ts
+interface JoinGraph {
+  readonly components: readonly (readonly RootType[])[]; // which rebuild together
+  resolve(from: SearchType, path: readonly string[]): RootType | undefined; // what a path reaches
+}
+```
+
+It hides edge derivation from `joinable` + `labelSource`, the uniqueness rule,
+cycle rejection, the depth cap, and one asymmetry worth naming: component
+**membership** is the _undirected_ connected component (a referrer and its
+referent rebuild together whichever way the edge points), while the order
+**within** a component is the _directed_ topological sort (a collection cannot
+be created before the one its reference names).
+
+`searchSchema` builds it eagerly, so a schema whose joins do not hold up fails
+at startup rather than on the first query or halfway through the first rebuild.
+
+`resolve` returns a `RootType`, never a collection name. How a type is named in
+an engine is engine- and deployment-specific, and stays in the adapter.
+
+### The criterion carries the path
+
+```ts
+{ on: ['dataset', 'publisher'], field: 'id', in: ['X'] }
+```
+
+`on` is a **path of field names**, not boolean structure, so the criterion stays
+an atom and [ADR 18](./0018-filter-across-several-fields-with-one-clause.md)’s
+“a criterion can never itself be a conjunction” holds verbatim. `where` is still
+a flat conjunction of disjunctions; the nesting lives in each criterion’s path.
+Skip-own-filter ([ADR 5](./0005-batch-facet-queries-through-the-engine-port.md))
+still scans one level, now keyed by `(on, field)` – a hop out is a different
+axis, so a joined clause is no facet’s own.
+
+Putting `on` on the `Filter` was rejected: it would scope a whole disjunction
+and make `$publishers(country:=NL) || title:=x` inexpressible.
+
+**Depth is capped at 3**, fixed, and checked in `validateQuery` with a
+`join-too-deep` issue. Typesense imposes no limit of its own, and
+`graphql-armor`’s max-depth counts selection sets rather than input nesting. The
+cap lives in the IR so a later REST surface inherits it.
+
+### The surface makes the capability visible
+
+Per joinable target, one shared input:
+
+```graphql
+input PublisherReferenceFilter @oneOf {
+  in: [String!]
+  where: PublisherWhere
+}
+```
+
+One per **target**, not per field: what it can express is a property of the
+referenced type, so `publisher` and `creator` share it. `in` keeps its meaning –
+the ids the field itself holds, no hop – while `where` states a condition on the
+referent. `‹Target›Where` is the same input the target’s own query field takes,
+so a consumer learns one vocabulary.
+
+A non-joinable reference keeps plain `StringFilter`, so the difference is
+visible in the schema rather than discovered from a runtime error.
+`whereToFilters` flattens a nested `where` into an `on` path exactly as it
+already flattens `and`.
+
+### Reference fields are emitted with all three settings forced
+
+An emitted Typesense reference carries `async_reference: true`,
+`cascade_delete: false`, and always targets `.id`. None is a knob:
+
+- without `async_reference`, a document whose referent is not indexed yet is
+  rejected with a 400 – and the batch import runs `throwOnFail: false`, so those
+  would be **silently dropped documents**. Documents stream per dataset
+  ([ADR 13](./0013-project-inside-the-batch-per-root-type.md)), so out-of-order
+  arrival is normal, not exceptional;
+- `cascade_delete` defaults to `true`, so a sweep removing a departed source’s
+  `Publisher` documents would delete other sources’ `CreativeWork` documents
+  with them. Disabling it requires `async_reference`, so the two travel
+  together;
+- a reference match hitting more than one document is also a 400, and `id` is
+  the only field the schema guarantees unique.
+
+### The join component is the unit of rebuild
+
+`searchIndexWriter` already opens one run per root type in a single pipeline
+run, so this is an ordering and commit change, not new orchestration:
+
+- **open** in topological order, referenced first – an engine cannot create a
+  collection whose reference names one that does not exist yet;
+- **commit** per component, and within a component sequentially in the reverse
+  order, referrers first: a blue/green commit drops the collection it
+  supersedes, so committing the referent first would delete a collection the
+  still-live referrer’s documents point at. The first failure stops the rest of
+  its component from going live, so a component ships whole or not at all.
+
+Locking needs no change: this is still the single deterministic pass that takes
+every lock in a fixed order, which is what makes lock-ordering deadlock
+impossible.
+
+This weakens [ADR 9](./0009-route-a-whole-schema-projection-to-per-type-collections.md):
+the unit of isolation becomes the component rather than the collection. Types
+with no joinable edge are singleton components and keep today’s behaviour
+exactly, so the weakening applies only where a schema author opted in.
+
+### `collectionNameFor` replaces `name`
+
+The rebuild options take `collectionNameFor: (searchType) => string` instead of
+a bare `name`, so a writer can derive a **peer’s** collection name as readily as
+its own. That is what a blue/green build needs: Typesense resolves an alias to a
+concrete collection at create time and keeps the concrete name, so referencing
+the alias would pin a fresh build to the collection the peer is about to
+supersede. No coordinator is needed – every writer in a run receives the same
+`RunContext`, so `Date.parse(context.startedAt)` is already identical across
+them.
+
+### An In-place rebuild fails loudly rather than altering
+
+When a collection exists but lacks a declared reference field, `InPlaceRebuild`
+throws with a drop-and-rebuild message. It never alters. `ensureCollectionExists`
+only creates on a 404, so without this an existing deployment would index and
+commit successfully and then 400 on every join query. Failing keeps the
+invariant the component-scoped rebuild rests on: a component’s collections come
+into existence _with_ their references, and never acquire them later. Scoped to
+reference fields only – every other schema difference is self-correcting, and
+general drift detection is a separate feature.
+
+## Consequences
+
+- “Every object published by institution X” is one query with a correct `total`,
+  ranking and facet counts: `filter_by: $datasets($publishers(id:=X))`.
+- Breaking for `@lde/search-typesense`: the rebuild and collection-definition
+  options take `collectionNameFor` instead of `name`.
+- Additive for `@lde/search` (`joinable`, `on`, `joinGraph`) and for the GraphQL
+  surface (a joinable reference’s input type widens; nothing narrows).
+- A deployment that adds `joinable` to a live In-place index must drop the
+  affected collections once. That is stated by an error, not discovered from
+  failing queries.
+
+### Out of scope, deliberately
+
+- **Reverse joins** – Typesense can search from either side of a reference, but
+  the schema has no name for the inverse edge, so the surface would have to
+  invent one.
+- **Facets on joined fields** – leaves [ADR 5](./0005-batch-facet-queries-through-the-engine-port.md)
+  untouched. The `(on, field)` key already anticipates them.
+- **Sort through joins** – cheap and symmetric (`Sort` gains the same `on`), but
+  the joined per-locale sort key and the many-to-one representative-value
+  semantics need their own decision.
+- **Free text through joins** – not expressible: a join clause is `filter_by`
+  only, with no `q`.
+- **Shadow collections** – one materialised join-target collection per edge
+  would make `joinable` uniform, but aliases cannot provide it (a reference
+  resolves an alias to the concrete collection at create time and discards it),
+  so it means real duplicated storage and extra component members. Deferred, and
+  unblocked by the API shape: it lives entirely in the collection definition and
+  the writer fan-out.
+
+### Documented limitations
+
+- **A reference written while its referent collection is being written
+  concurrently can be lost permanently.** This is the sharp one, and it was
+  found by the integration test rather than reasoned about. Sequentially,
+  `async_reference` is exact: the referrer import is accepted and the reference
+  resolves the moment the referent lands (pinned by the reference-back-fill
+  test). But per-type stages import into a referring and a referenced collection
+  **at the same time**, and in 30.2 a reference written in that window can end
+  up never resolved – not delayed, never – with the documents themselves all
+  present. Which edge loses varies per run.
+
+  The consequence is that a **single** indexing run does not yet guarantee
+  resolved joins for a component built from scratch. A subsequent run does: it
+  meets referents that already exist, so every reference resolves at write time.
+  A steady-state deployment (daily runs over a mostly-stable corpus) is
+  therefore fine; a first build should be run twice. `async_reference` is still
+  strictly right – without it those documents would be rejected outright and,
+  under `throwOnFail: false`, dropped in silence.
+
+  Not ours to fix, and worth re-testing on every engine upgrade: when it is
+  fixed, the second run and this note both go.
+
+- **Only one edge per (type, target type) can be joinable.** Other edges keep
+  their labels, facets and id filtering; they just do not gain cross-collection
+  filtering.
+- **Sibling joined conditions are independent hops.** `dataset: { where: { a, b } }`
+  compiles to two criteria, each joined on its own, so under a multi-valued
+  reference `a` and `b` may be satisfied by different referents. For the
+  single-valued case – the common one – the readings coincide.
+- **Blue/green has a brief inconsistency window at the alias flip.** Typesense
+  stores the concrete collection name in a reference and re-resolves the alias
+  at query time, and there is no atomic multi-alias swap, so a join query can
+  see `400 Failed to join on …` for one round trip. Because a component rebuilds
+  both sides, we never hit the steady-state form of
+  [typesense#2827](https://github.com/typesense/typesense/issues/2827).
+- **An unindexed referent is indistinguishable from no value.** A reference
+  whose target is never indexed stays unresolved and its document is silently
+  excluded from join filters. Normal in linked data, where an IRI may point
+  outside the indexed corpus.
+
+## Constraints verified against Typesense 30.2
+
+Checked against the docs, the `v30.2` source, and a live
+`typesense/typesense:30.2` container.
+
+- **Joins landed in v26**, not 28. Our containers already run 30.x, so there is
+  no version floor to raise.
+- **Altering a collection to add a reference field is supported** in 30.x,
+  despite the note still on the joins docs page saying otherwise (v30.0 release
+  notes; `CollectionJoinTest.AlterReferenceField` passes at v30.2). We do not use
+  it – see the In-place decision above.
+- **A collection can only be joined through one reference field per target
+  collection.** Every join API resolves through a reverse map keyed by
+  collection name (`referenced_in`, `include/collection.h:476`), populated with a
+  non-overwriting `emplace` (`src/collection.cpp:8540`); the forward check
+  discards which field matched (`:8504`). Reproduced live: with `books.author_id`
+  and `books.editor_id` both referencing `people.id`,
+  `filter_by=$people(name:=Ann)` returns the book, `$people(name:=Bob)` returns
+  nothing though the book is edited by Bob, `include_fields=$people(*)` nests
+  only the author, and `$editor_id(…)` fails with
+  `Referenced collection 'editor_id' not found`. Filed upstream as
+  [typesense#3021](https://github.com/typesense/typesense/issues/3021). The docs
+  neither promise nor forbid it.
+- **Dropping a referenced collection is not blocked** and leaves a dangling
+  reference, which is why a component must commit all-or-nothing rather than per
+  collection.

--- a/docs/decisions/0019-filter-across-collections-through-declared-joins.md
+++ b/docs/decisions/0019-filter-across-collections-through-declared-joins.md
@@ -106,7 +106,7 @@ Per joinable target, one shared input:
 
 ```graphql
 input PublisherReferenceFilter @oneOf {
-  in: [String!]
+  in: [IRI!]
   where: PublisherWhere
 }
 ```
@@ -117,7 +117,10 @@ the ids the field itself holds, no hop – while `where` states a condition on t
 referent. `‹Target›Where` is the same input the target’s own query field takes,
 so a consumer learns one vocabulary.
 
-A non-joinable reference keeps plain `StringFilter`, so the difference is
+The `in` arm is typed `[IRI!]`, the same as the target’s own identity filter –
+it asks the same question, so it must take the same variable.
+
+A non-joinable reference keeps its plain identity filter, so the difference is
 visible in the schema rather than discovered from a runtime error.
 `whereToFilters` flattens a nested `where` into an `on` path exactly as it
 already flattens `and`.

--- a/docs/decisions/0019-filter-across-collections-through-declared-joins.md
+++ b/docs/decisions/0019-filter-across-collections-through-declared-joins.md
@@ -150,7 +150,15 @@ run, so this is an ordering and commit change, not new orchestration:
   order, referrers first: a blue/green commit drops the collection it
   supersedes, so committing the referent first would delete a collection the
   still-live referrer’s documents point at. The first failure stops the rest of
-  its component from going live, so a component ships whole or not at all.
+  its component from going live, so a component ships whole or not at all;
+- **abort** leaves a component that went _partly_ live alone entirely. Aborting
+  a committed rebuild would drop its now-live collection; aborting an
+  uncommitted **peer** of one is the same mistake one edge out, because the
+  half-built collection it would drop is exactly what the member that did
+  commit now references by concrete name. Dropping it would break every join
+  through the live index permanently – the next run builds fresh collections
+  rather than repairing that one – so the collection is left orphaned instead,
+  for an operator to reclaim.
 
 Locking needs no change: this is still the single deterministic pass that takes
 every lock in a fixed order, which is what makes lock-ordering deadlock
@@ -194,6 +202,9 @@ general drift detection is a separate feature.
 - A deployment that adds `joinable` to a live In-place index must drop the
   affected collections once. That is stated by an error, not discovered from
   failing queries.
+- A run whose commit fails partway through a component can leave an orphaned
+  blue/green collection behind (see `abort` above). Preferred over the
+  alternative, which is a live index whose joins are permanently broken.
 
 ### Out of scope, deliberately
 

--- a/docs/decisions/0019-filter-across-collections-through-declared-joins.md
+++ b/docs/decisions/0019-filter-across-collections-through-declared-joins.md
@@ -151,14 +151,21 @@ run, so this is an ordering and commit change, not new orchestration:
   supersedes, so committing the referent first would delete a collection the
   still-live referrer’s documents point at. The first failure stops the rest of
   its component from going live, so a component ships whole or not at all;
-- **abort** leaves a component that went _partly_ live alone entirely. Aborting
-  a committed rebuild would drop its now-live collection; aborting an
-  uncommitted **peer** of one is the same mistake one edge out, because the
-  half-built collection it would drop is exactly what the member that did
-  commit now references by concrete name. Dropping it would break every join
-  through the live index permanently – the next run builds fresh collections
-  rather than repairing that one – so the collection is left orphaned instead,
-  for an operator to reclaim.
+- **abort** gains a third outcome, because a component makes “undo” destructive
+  in a way it never was per collection. Aborting a committed rebuild would drop
+  its now-live collection; aborting an uncommitted **peer** of one is the same
+  mistake one edge out, since the half-built collection it would drop is
+  exactly what the member that did commit now references by concrete name.
+  Those peers are therefore **abandoned** – a new optional `RunWriter.abandon`
+  meaning _finalize, release run-level resources, keep what you built_.
+
+  Skipping them outright is not enough, and was the first thing tried: `abort`
+  is the only path that releases the cross-pod rebuild lock, so a skipped peer
+  holds its lock for the full TTL and fails the _next_ run before it starts –
+  a worse blast radius than the leak it avoids. `abandon` keeps the collection
+  (orphaned until a later run supersedes it) _and_ releases the lock. It falls
+  back to `abort`, which is already right for every writer whose abort does not
+  discard built state.
 
 Locking needs no change: this is still the single deterministic pass that takes
 every lock in a fixed order, which is what makes lock-ordering deadlock
@@ -197,14 +204,17 @@ general drift detection is a separate feature.
   ranking and facet counts: `filter_by: $datasets($publishers(id:=X))`.
 - Breaking for `@lde/search-typesense`: the rebuild and collection-definition
   options take `collectionNameFor` instead of `name`.
-- Additive for `@lde/search` (`joinable`, `on`, `joinGraph`) and for the GraphQL
-  surface (a joinable reference’s input type widens; nothing narrows).
+- Additive for `@lde/search` (`joinable`, `on`, `joinGraph`), for `@lde/pipeline`
+  (`RunWriter.abandon`, optional and falling back to `abort`) and for the
+  GraphQL surface (a joinable reference’s input type widens; nothing narrows).
 - A deployment that adds `joinable` to a live In-place index must drop the
   affected collections once. That is stated by an error, not discovered from
   failing queries.
-- A run whose commit fails partway through a component can leave an orphaned
-  blue/green collection behind (see `abort` above). Preferred over the
-  alternative, which is a live index whose joins are permanently broken.
+- A run whose commit fails partway through a component leaves the abandoned
+  blue/green collections behind (see `abort` above), for a later run to
+  supersede. Preferred over the alternatives: dropping them breaks the live
+  index’s joins permanently, and skipping them holds the rebuild lock for its
+  whole TTL and fails the next run outright.
 
 ### Out of scope, deliberately
 

--- a/docs/reference/pipeline.md
+++ b/docs/reference/pipeline.md
@@ -341,6 +341,8 @@ Writes generated quads to a destination. A `Writer` is transactional: each pipel
 
 A `RunWriter` may also implement the optional `reset(dataset)`, which discards a dataset’s already-written output. The pipeline invokes it before re-running all stages against a fallback dump ([reactive fallback](#distribution-resolver)); a custom writer without `reset` appends the re-run’s output to the endpoint-sourced partial output instead of replacing it.
 
+The other optional method, `abandon(error)`, is the half-way house between `commit` and `abort`: **finalize, release run-level resources, keep what you built**. The pipeline never calls it – it exists for a caller coordinating several writers whose outputs reference one another, where one has already gone live pointing at what another built, so dropping that half-built output would break the live one ([`@lde/search-pipeline`](./search-pipeline#per-component-isolation) is the case it was added for). It falls back to `abort`, which is already correct for every writer whose abort does not discard built state; a writer whose abort _does_ discard should implement it, or such a caller has to choose between leaking its lock and breaking a live destination.
+
 #### `SparqlUpdateWriter`
 
 Writes to a SPARQL endpoint via SPARQL UPDATE queries (options: `SparqlWriterOptions`):

--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -184,6 +184,24 @@ editor.
   - **`and: [‹Type›Clause!]`** carries further clauses, each of which may hold
     its own `or`. Only needed for a **second** set of alternatives – for plain
     filters it is equivalent to writing them side by side.
+
+  A reference declaring [`joinable`](./search#filtering-across-collections)
+  takes a **`‹Target›ReferenceFilter`** instead of `StringFilter` – `@oneOf`
+  over `in` (the ids the field itself holds, unchanged) and `where` (a condition
+  on the referent, typed by the target’s own `‹Target›Where`, so the vocabulary
+  is the same one its query field takes). One filter type per **target**, shared
+  by every field pointing at it, since what it can express is a property of the
+  referenced type. A non-joinable reference keeps `StringFilter`, so the
+  capability difference is visible in the schema rather than being a runtime
+  error.
+
+  A nested `where` flattens into a join path on each criterion it produces, so
+  its own `or` and `and` work one hop out too. The one shape it cannot take is a
+  **multi-key** joined `where` inside an `or`: that is a conjunction nested in a
+  disjunction, which the flat query IR has nowhere to put, and it is rejected
+  naming the rewrite (one `or` alternative per criterion, or move the
+  conjunction into `and`).
+
 - **`orderBy`**: `RELEVANCE` plus every `sortable` field, as an enum – field
   names SCREAMING_SNAKE_CASEd (`datePosted` → `DATE_POSTED`); `direction`
   defaults to `DESC`.

--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -186,14 +186,15 @@ editor.
     filters it is equivalent to writing them side by side.
 
   A reference declaring [`joinable`](./search#filtering-across-collections)
-  takes a **`‹Target›ReferenceFilter`** instead of `StringFilter` – `@oneOf`
-  over `in` (the ids the field itself holds, unchanged) and `where` (a condition
-  on the referent, typed by the target’s own `‹Target›Where`, so the vocabulary
-  is the same one its query field takes). One filter type per **target**, shared
-  by every field pointing at it, since what it can express is a property of the
-  referenced type. A non-joinable reference keeps `StringFilter`, so the
-  capability difference is visible in the schema rather than being a runtime
-  error.
+  takes a **`‹Target›ReferenceFilter`** instead of its plain identity filter –
+  `@oneOf` over `in` (the ids the field itself holds, unchanged, and typed
+  `[IRI!]` exactly as `‹Target›Filter` types it) and `where` (a condition on the
+  referent, typed by the target’s own `‹Target›Where`, so the vocabulary is the
+  same one its query field takes). One filter type per **target**, shared by
+  every field pointing at it, since what it can express is a property of the
+  referenced type. A non-joinable reference keeps `‹Target›Filter` /
+  `IRIFilter`, so the capability difference is visible in the schema rather than
+  being a runtime error.
 
   A nested `where` flattens into a join path on each criterion it produces, so
   its own `or` and `and` work one hop out too. The one shape it cannot take is a

--- a/docs/reference/search-pipeline.md
+++ b/docs/reference/search-pipeline.md
@@ -361,9 +361,13 @@ isolation:
   the still-live referrer points at – and stop at the first failure, so a
   component ships whole or not at all;
 - because the pipeline aborts a run whose `commit` throws, `abort` finalizes only
-  the collections that did **not** already go live (aborting a committed
-  blue/green rebuild would drop its now-live collection), dropping the half-built
-  ones and releasing their locks.
+  the components that did **not** already go live, dropping the half-built
+  collections and releasing their locks. A component that went _partly_ live is
+  left alone entirely: aborting a committed blue/green rebuild would drop its
+  now-live collection, and aborting an uncommitted **peer** of one would drop
+  exactly the collection that live member references by name – breaking every
+  join through it permanently. The orphaned collection that leaves behind is the
+  lesser evil.
 
 See [ADR 9](../decisions/0009-route-a-whole-schema-projection-to-per-type-collections)
 and [ADR 19](../decisions/0019-filter-across-collections-through-declared-joins).

--- a/docs/reference/search-pipeline.md
+++ b/docs/reference/search-pipeline.md
@@ -360,14 +360,13 @@ isolation:
   collection it supersedes, so committing the referent first would delete one
   the still-live referrer points at – and stop at the first failure, so a
   component ships whole or not at all;
-- because the pipeline aborts a run whose `commit` throws, `abort` finalizes only
-  the components that did **not** already go live, dropping the half-built
-  collections and releasing their locks. A component that went _partly_ live is
-  left alone entirely: aborting a committed blue/green rebuild would drop its
-  now-live collection, and aborting an uncommitted **peer** of one would drop
-  exactly the collection that live member references by name – breaking every
-  join through it permanently. The orphaned collection that leaves behind is the
-  lesser evil.
+- because the pipeline aborts a run whose `commit` throws, `abort` has three
+  outcomes rather than two. A collection that went live is left alone (aborting
+  a committed blue/green rebuild would drop it); a collection in a component
+  that went _partly_ live is **abandoned** – finalized without dropping what it
+  built, since that is exactly what the live member references by name, while
+  still releasing its cross-pod lock; everything else is aborted as before,
+  dropping the half-built collection and releasing its lock.
 
 See [ADR 9](../decisions/0009-route-a-whole-schema-projection-to-per-type-collections)
 and [ADR 19](../decisions/0019-filter-across-collections-through-declared-joins).

--- a/docs/reference/search-pipeline.md
+++ b/docs/reference/search-pipeline.md
@@ -219,7 +219,11 @@ import { BlueGreenRebuild, deriveCollectionName } from '@lde/search-typesense';
 writerFor: (searchType, schema) =>
   new BlueGreenRebuild(typesenseClient, searchType, {
     schema,
-    name: `${process.env.INDEX_PREFIX}_${deriveCollectionName(searchType)}`,
+    // A function of the type, not a bare name: a writer names its own
+    // collection AND the peers its joins reference, so the prefix has to apply
+    // to both.
+    collectionNameFor: (type) =>
+      `${process.env.INDEX_PREFIX}_${deriveCollectionName(type)}`,
   });
 ```
 
@@ -328,10 +332,15 @@ readers:
   the stage’s projected documents into the write. A projected document is far
   heavier than a quad, so lower it where documents are large.
 
-## Per-collection isolation
+## Per-component isolation
 
 Each root type is an independent engine run – its own collection, alias and
-cross-pod lock – so the collections commit, sweep and fail in isolation:
+cross-pod lock – and the unit those runs are isolated **by** is the
+[join component](./search#filtering-across-collections): the group of types that
+reference one another through a `joinable` reference, and therefore cannot go
+live apart. A type declaring none is a singleton component, so a schema without
+joins behaves exactly as before, and the collections commit, sweep and fail in
+isolation:
 
 - a type whose projection is empty this run affects only its own collection,
   never another’s – in particular the `datasets` index still goes live;
@@ -339,16 +348,25 @@ cross-pod lock – so the collections commit, sweep and fail in isolation:
   collection an earlier dataset held documents for still needs its sweep or
   discard), with failures aggregated after all have been attempted – one
   collection’s failure never skips another’s;
-- `commit` finalizes every collection independently and, if any fails, throws an
-  `AggregateError` _after_ attempting them all, so a non-critical
-  label-collection failure never blocks the collections that did commit, while
-  the failure is still surfaced (the run is marked failed);
+- runs are **opened** in join order, referenced first: an engine cannot create a
+  collection whose reference names one that does not exist yet. It is still the
+  single deterministic pass that takes every lock in a fixed order, so
+  lock-ordering deadlock stays impossible;
+- `commit` finalizes every **component** independently and, if any fails, throws
+  an `AggregateError` _after_ attempting them all, so a non-critical
+  label-collection failure never blocks the components that did commit, while
+  the failure is still surfaced (the run is marked failed). Within a component
+  the commits are sequential and referrers first – a blue/green commit drops the
+  collection it supersedes, so committing the referent first would delete one
+  the still-live referrer points at – and stop at the first failure, so a
+  component ships whole or not at all;
 - because the pipeline aborts a run whose `commit` throws, `abort` finalizes only
   the collections that did **not** already go live (aborting a committed
   blue/green rebuild would drop its now-live collection), dropping the half-built
   ones and releasing their locks.
 
-See [ADR 9](../decisions/0009-route-a-whole-schema-projection-to-per-type-collections).
+See [ADR 9](../decisions/0009-route-a-whole-schema-projection-to-per-type-collections)
+and [ADR 19](../decisions/0019-filter-across-collections-through-declared-joins).
 
 ## Memory
 

--- a/docs/reference/search-typesense.md
+++ b/docs/reference/search-typesense.md
@@ -324,8 +324,10 @@ referenced first – an engine cannot create a collection whose reference names
 one that does not exist yet – and commits per component, referrers first, so a
 blue/green build never drops a collection the still-live referrer points at. The
 first failure stops the rest of its component from going live, and the abort
-that follows leaves that component’s collections alone – dropping an uncommitted
-peer would delete exactly what the member that did commit now references.
+that follows **abandons** that component’s uncommitted collections rather than
+dropping them – dropping one would delete exactly what the member that did
+commit now references, while abandoning keeps it and still releases the rebuild
+lock, so the next run is not locked out.
 
 Two consequences worth planning for:
 

--- a/docs/reference/search-typesense.md
+++ b/docs/reference/search-typesense.md
@@ -44,12 +44,12 @@ Elasticsearch/OpenSearch index names are kebab-case and
 bytes), so a future `@lde/search-elasticsearch` formats the same neutral tokens
 (`@lde/search`’s `physicalNameTokens`) its own way. The core stays engine-neutral.
 
-Pass an explicit name to **override** the convention – an env prefix, a
+Pass `collectionNameFor` to **override** the convention – an env prefix, a
 multi-tenant name, a collection that already exists, a migration:
 
 ```ts
 const writer = new BlueGreenRebuild(client, CREATIVE_WORK, {
-  name: 'staging_creative_works',
+  collectionNameFor: (type) => `staging_${deriveCollectionName(type)}`,
 });
 const engine = createTypesenseSearchEngine(client, schema, {
   collections: { CreativeWork: 'staging_creative_works' },
@@ -58,7 +58,14 @@ writer.collectionName; // 'staging_creative_works' – read-only, for logs/healt
 engine.collectionNameFor(CREATIVE_WORK); // the same name, resolved once at construction
 ```
 
-`collections` overrides only the types it names; the rest stay derived.
+It is a function of the type rather than a bare name because a writer names more
+than its own collection: a [joinable reference](#joins-across-collections) is
+emitted as a Typesense reference field naming its **peer’s** collection, and a
+blue/green build has to name the peer’s _fresh_ collection, not its live alias.
+One function covers both.
+
+On the read side, `collections` overrides only the types it names; the rest stay
+derived.
 
 Everything the convention cannot do, it refuses to guess at, when the writer or
 engine is constructed rather than on the first rebuild or search:
@@ -74,7 +81,7 @@ engine is constructed rather than on the first rebuild or search:
 
 ## Collection schema and engine
 
-`buildCollectionDefinition(searchType, { name?, schema?, defaultSortingField, … })`
+`buildCollectionDefinition(searchType, { collectionNameFor?, schema?, defaultSortingField, … })`
 derives a Typesense collection from the unified `SearchField` model – the
 Typesense field type comes from each field’s `kind`, and the physical fanout
 (per-locale search/sort keys, plus one regex display field per output text
@@ -90,6 +97,56 @@ carries `output` only, so it is display weight on disk, like the language
 labels. Pass the `schema` option for a type that surfaces one – it is what
 resolves the Reference Type; a type declaring one without it throws here, rather
 than building a collection whose documents would all fail to import.
+
+### Joins across collections
+
+A reference declaring [`joinable: true`](./search#filtering-across-collections)
+is emitted as a Typesense **reference field**, so a query can filter this
+collection by a condition on the referenced one:
+
+```json
+{
+  "name": "publisher",
+  "type": "string",
+  "reference": "publishers.id",
+  "async_reference": true,
+  "cascade_delete": false
+}
+```
+
+All three are forced, none is a knob:
+
+- **`reference` always targets `.id`.** A reference match hitting more than one
+  document is a 400, and `id` is the only field the schema guarantees unique.
+- **`async_reference: true`.** Without it, a document whose referent has not been
+  indexed yet is rejected with a 400 – and the batch import runs
+  `throwOnFail: false`, so those would be silently dropped documents. Documents
+  stream per dataset, so out-of-order arrival is normal, and the engine
+  back-fills the reference when the referent lands.
+
+  ::: warning First build: run the indexer twice
+  Back-fill is exact when the two collections are written one after the other,
+  but per-type stages write them **concurrently**, and Typesense 30.2 can lose a
+  reference written in that window permanently – the documents all land, the
+  join just finds nothing. A second run meets referents that already exist, so
+  every reference resolves at write time. Steady-state runs over a stable corpus
+  are unaffected; a component built from scratch should be indexed twice. See
+  [ADR 19](../decisions/0019-filter-across-collections-through-declared-joins#documented-limitations).
+  :::
+
+- **`cascade_delete: false`.** It defaults to `true`, so a sweep removing a
+  departed source’s `Publisher` documents would delete other sources’
+  `CreativeWork` documents with them. Disabling it requires `async_reference`, so
+  the two travel together.
+
+A query’s `on` path compiles to one `$collection(…)` wrapper per hop –
+`$datasets($publishers(id:=X))` – with the leaf term compiled against the
+_target_ type’s declaration, so a date bound one hop out is still stored as Unix
+seconds and a facetable keyword still takes the loose membership. The join graph
+names the type; `collections` / `collectionNameFor` names the collection.
+
+The `schema` option is required for a type declaring a joinable reference, as it
+is for a surfaced inline one – it is what resolves the target.
 
 **Memory lever.** Typesense keeps the index in RAM (with a raw copy of each
 document on disk), so RAM tracks the _indexed_ surface – roughly 2–3× the size
@@ -248,6 +305,35 @@ and `last_seen` (the run id); deletion is a sweep, never special-cased:
   stays until the next run reconciles.
 
 Document ids must be unique per (source, entity) – the caller keys them.
+
+`openRun` creates the collection on demand and otherwise leaves an existing one
+alone – with one exception. If the collection exists but does not carry every
+[reference field](#joins-across-collections) the declaration asks for (a
+`joinable` added to a schema whose index predates it), the run **fails**, naming
+the drop-and-rebuild that fixes it. Without that it would index and commit
+happily and then 400 on every join query: the values would be there, the
+reference would not. Scoped to reference fields only – every other schema
+difference is self-correcting.
+
+### The join component is the unit of rebuild
+
+Types connected by a [joinable reference](#joins-across-collections) form a
+**join component**, and a component rebuilds as a unit. `searchIndexWriter`
+([`@lde/search-pipeline`](./search-pipeline)) opens the runs in join order,
+referenced first – an engine cannot create a collection whose reference names
+one that does not exist yet – and commits per component, referrers first, so a
+blue/green build never drops a collection the still-live referrer points at. The
+first failure stops the rest of its component from going live.
+
+Two consequences worth planning for:
+
+- a type with **no** joinable reference is a singleton component and behaves
+  exactly as it did: its collection still commits, sweeps and fails in
+  isolation. The coupling is opt-in, per edge;
+- blue/green has a brief inconsistency window at the alias flip. Typesense
+  stores the concrete collection name in a reference and re-resolves the alias
+  at query time, and there is no atomic multi-alias swap, so a join query can see
+  `400 Failed to join on …` for one round trip.
 
 ### Provenance
 

--- a/docs/reference/search-typesense.md
+++ b/docs/reference/search-typesense.md
@@ -323,7 +323,9 @@ Types connected by a [joinable reference](#joins-across-collections) form a
 referenced first – an engine cannot create a collection whose reference names
 one that does not exist yet – and commits per component, referrers first, so a
 blue/green build never drops a collection the still-live referrer points at. The
-first failure stops the rest of its component from going live.
+first failure stops the rest of its component from going live, and the abort
+that follows leaves that component’s collections alone – dropping an uncommitted
+peer would delete exactly what the member that did commit now references.
 
 Two consequences worth planning for:
 

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -375,6 +375,13 @@ label }`), and on a reference facet’s bucket. One word, one meaning – so a
 collection reads the same whether you arrive at it directly or through a
 reference.
 
+A reference with a label source may additionally declare **`joinable: true`**,
+which turns it into an engine-level edge a query can filter across – see
+[Filtering across collections](#filtering-across-collections). It is a
+capability flag like `filterable` or `facetable`, not something derived from
+`labelSource`: a label source added for display costs exactly what it costs
+today.
+
 #### Naming the label field
 
 That word is `label` by default, but a type may name its own display field with
@@ -804,6 +811,87 @@ Keep `id` distinct from a domain identifier. `id` is _what the thing is_; a
 declared field like `identifier` (`schema:identifier`) is _what a source system
 calls it_ – an inventory or catalogue number. Both may exist on one type; they
 answer different questions.
+
+### Filtering across collections
+
+Each root type has its own collection, so “every object published by institution
+X” used to mean two queries: list the institution’s datasets, then ask for the
+objects of each – losing a correct `total`, ranking and facet counts on the way.
+
+Declare the edge and it becomes one query. A `reference` with a `labelSource`
+already asserts that its values are ids of documents in that type’s collection;
+`joinable: true` lets the engine use that assertion:
+
+```ts
+{ name: 'dataset',   kind: 'reference', filterable: true,
+  labelSource: 'Dataset',   joinable: true },   // on CreativeWork
+{ name: 'publisher', kind: 'reference', filterable: true,
+  labelSource: 'Publisher', joinable: true },   // on Dataset
+```
+
+A joinable reference then takes a richer filter on the surface – its ids, **or**
+a condition on the referent, nested as deep as the edges go:
+
+```graphql
+{
+  creativeWorks(
+    where: {
+      dataset: {
+        where: { publisher: { where: { id: { in: [$institution] } } } }
+      }
+    }
+  ) {
+    pagination {
+      total
+    }
+  }
+}
+```
+
+That is one engine round-trip (`filter_by: $datasets($publishers(id:=X))`), with
+a correct `total`, ranking and facet counts. `in` on the same key keeps its
+ordinary meaning – the ids the field itself holds, no hop – so the capability is
+additive.
+
+In the IR each nested `where` becomes an `on` **path** on the criterion it
+produces, never extra clause structure:
+
+```ts
+{
+  or: [{ on: ['dataset', 'publisher'], field: 'id', in: [institution] }];
+}
+```
+
+so `where` stays the flat conjunction of disjunctions it was, a joined criterion
+can sit inside an `or` beside a local one, and skip-own-filter still works.
+Paths are capped at **three hops**.
+
+Four rules come with declaring one, all enforced when the schema is built:
+
+- **`joinable` needs a `labelSource`.** The join addresses the referent’s
+  collection, which is the one the label source names.
+- **At most one joinable reference per (type, target type).** An engine
+  addresses a join by _collection_, not by field, so a second reference to the
+  same collection would be indexed and then unreachable. `publisher` and
+  `creator` both resolving to `Organization` is the ordinary case, so it is a
+  declaration error naming both fields. Drop `joinable` from one – it keeps its
+  labels, facets and id filtering.
+- **No cycles.** The types a joinable edge connects form a **join component**,
+  and a component’s collections must have an order to be created in.
+- **A component rebuilds together.** That is the one real cost: see
+  [component-scoped rebuilds](./search-typesense#the-join-component-is-the-unit-of-rebuild).
+  A type with no joinable edge is a singleton component and is unaffected.
+
+`joinGraph(schema)` is where all of that lives – `components` for a writer,
+`resolve(from, path)` for a query compiler. `searchSchema` builds it eagerly, so
+a schema whose joins do not hold up fails at startup.
+
+Not yet supported through a join: facets, sorting, free-text search, and the
+reverse direction. And one engine-level caveat worth knowing before you deploy:
+a component built from scratch needs its **indexer run twice** before its joins
+resolve – see
+[ADR 19](../decisions/0019-filter-across-collections-through-declared-joins.md)
+for that and the other limitations.
 
 Sorting has two deliberate wrinkles. `orderBy` accepts the sentinel field
 **`relevance`** – text-match ranking, not a declared field (Typesense compiles

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -380,7 +380,10 @@ which turns it into an engine-level edge a query can filter across – see
 [Filtering across collections](#filtering-across-collections). It is a
 capability flag like `filterable` or `facetable`, not something derived from
 `labelSource`: a label source added for display costs exactly what it costs
-today.
+today. Never on an `inline` reference, though: that carries its referent as a
+nested object rather than as an id an engine can point a reference at, so the
+two are mutually exclusive (`searchSchema` rejects the pair). Carry the referent
+inline, or join to its collection – not both.
 
 #### Naming the label field
 

--- a/packages/pipeline/src/writer/writer.ts
+++ b/packages/pipeline/src/writer/writer.ts
@@ -108,6 +108,29 @@ export interface RunWriter<Item = Quad> extends DatasetWriter<Item> {
    * @param error The failure that ended the run
    */
   abort(error: unknown): Promise<void>;
+
+  /**
+   * End the run releasing its run-level resources (locks, connections) but
+   * **keeping** whatever it built – the half-way house between
+   * {@link commit} and {@link abort}.
+   *
+   * It exists for the one case where undoing is the more destructive choice: a
+   * caller coordinating several writers whose outputs reference each other,
+   * where one has already gone live pointing at what another built. Dropping
+   * that half-built output would break the live one, so the caller asks for it
+   * to be kept and reconciled by a later run instead
+   * ([ADR 19](https://github.com/ldelements/lde/blob/main/docs/decisions/0019-filter-across-collections-through-declared-joins.md)).
+   *
+   * Optional: it falls back to {@link abort}, which is already correct for
+   * every writer whose `abort` does not discard built state (an In-place
+   * rebuild releasing its lock, a writer with no run-level state at all). A
+   * writer whose `abort` DOES discard – a Blue/green rebuild dropping its
+   * fresh collection – must implement this, or a coordinating caller has to
+   * choose between leaking its lock and breaking a live destination.
+   *
+   * @param error The failure that ended the run
+   */
+  abandon?(error: unknown): Promise<void>;
 }
 
 /**

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -40,12 +40,14 @@ import {
   isAbsoluteIri,
   OR_KEY,
   isRangeFacet,
+  joinGraph,
   labelFieldNameOf,
   nestedReferenceType,
   outputFields,
   pageForOffset,
   sortableFields,
   unixSecondsToIso,
+  type JoinGraph,
 } from '@lde/search/adapter';
 import {
   defaultLanguageOrder,
@@ -412,6 +414,13 @@ export function buildGraphQLSchema(
       : labelFieldNameOf(rootTypesByName.get(field.labelSource)!);
   }
 
+  // The declared joins, and the input types they make shareable. Each map is
+  // keyed by the SearchType `name`, so a type reached as a join target and the
+  // same type queried in its own right meet exactly one `‹Name›Where`.
+  const joins = joinGraph(schema);
+  const whereInputs = new Map<string, GraphQLInputObjectType>();
+  const referenceFilters = new Map<string, GraphQLInputObjectType>();
+
   /**
    * Register the GraphQL type one reference field is served as, once per
    * referenced shape. A **surfaced inline** reference is served as the nested
@@ -595,10 +604,26 @@ export function buildGraphQLSchema(
     }
   }
 
+  function whereFieldType(
+    field: SearchField,
+    owner: RootType,
+  ): GraphQLInputType {
+    // A joinable reference is filterable in two ways at once – by the ids it
+    // holds, and by a condition on the referent – so it earns a richer input
+    // than the plain membership every other reference gets. Making the
+    // difference visible in the schema is the point: a consumer sees which
+    // references can be filtered through, instead of discovering it from a
+    // runtime error.
+    const target = joins.resolve(owner, [field.name]);
+    return target !== undefined
+      ? referenceFilterFor(target)
+      : plainWhereFieldType(field);
+  }
+
   /** The filter input one field accepts, fixed by what the field keys on: a
    *  `reference` keys on identity (its target’s filter, or `IRIFilter` when it
    *  names no target), a `keyword` on literals. */
-  function whereFieldType(field: SearchField): GraphQLInputType {
+  function plainWhereFieldType(field: SearchField): GraphQLInputType {
     switch (filterOperatorFor(field.kind)) {
       case 'in':
         if (field.kind !== 'reference') {
@@ -616,6 +641,118 @@ export function buildGraphQLSchema(
       default:
         return GraphQLBoolean;
     }
+  }
+
+  /**
+   * The filter input a joinable reference to `target` takes, created once per
+   * target type and shared by EVERY field pointing at it – `publisher` and
+   * `creator` both resolving to `Organization` take the same
+   * `OrganizationReferenceFilter`, because what it can express is a property of
+   * the referenced type, not of the referring field.
+   *
+   * `@oneOf`, so a criterion stays an atom: filter by the ids the field holds,
+   * **or** by a condition on the referent, never both in one term.
+   */
+  function referenceFilterFor(target: RootType): GraphQLInputObjectType {
+    const existing = referenceFilters.get(target.name);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const created = new GraphQLInputObjectType({
+      name: `${target.name}ReferenceFilter`,
+      description: `A condition on a joinable reference to ${target.name}: the ids it holds, or a condition on the referenced ${target.name} itself.`,
+      isOneOf: true,
+      // A thunk: the target’s own `where` may point back through further
+      // joinable references (the join graph is acyclic, so this terminates).
+      fields: () => ({
+        in: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+        where: { type: whereInputFor(target) },
+      }),
+    });
+    referenceFilters.set(target.name, created);
+    return created;
+  }
+
+  /**
+   * One key per filterable field (plus the undeclared `id`), each typed by its
+   * OWN kind – so the operator a key accepts is fixed by the field it names,
+   * and a range on a keyword field cannot be written at all. This is the
+   * single vocabulary every level of `where` is built from: the same keys
+   * appear on the clause and on a criterion, so a field is never named a
+   * second way.
+   */
+  function fieldKeys(
+    searchType: RootType,
+  ): Record<string, GraphQLInputFieldConfig> {
+    const fields: Record<string, GraphQLInputFieldConfig> = {
+      // Typed self-referentially – `TermWhere.id: TermFilter` – so a consumer
+      // can resolve “the collection I am browsing” to “the filter type that
+      // accepts its IRIs”, which is what makes the refined discovery strategy
+      // work without hardcoding a single domain name.
+      [ID_FIELD]: { type: targetFilter(searchType.name) },
+    };
+    for (const field of filterableFields(searchType)) {
+      fields[field.name] = {
+        type: whereFieldType(field, searchType),
+        description: field.description,
+      };
+    }
+    return fields;
+  }
+
+  /**
+   * The `where` input of one root type, created once and shared: it is both the
+   * argument of that type’s own query field and – through a
+   * {@link referenceFilterFor} – the shape a *joined* condition on it takes
+   * from another type. One input either way, so the vocabulary a consumer
+   * learns for `datasets(where: …)` is the same one they write inside
+   * `creativeWorks(where: { dataset: { where: … } })`.
+   */
+  function whereInputFor(searchType: RootType): GraphQLInputObjectType {
+    const existing = whereInputs.get(searchType.name);
+    if (existing !== undefined) {
+      return existing;
+    }
+    // A criterion is an ATOM: exactly one field, enforced by `@oneOf`. That is
+    // what keeps `where` a flat conjunction of disjunctions – a criterion that
+    // could carry two keys would be a conjunction nested inside an `or`, and
+    // skip-own-filter (ADR 5) has no answer for a clause buried inside another.
+    // Created here rather than on its own, because it exists for exactly one
+    // `where` and shares its memoization.
+    const criterionInput = new GraphQLInputObjectType({
+      name: `${searchType.name}Criterion`,
+      description:
+        'A condition on exactly one field. Used inside `or`, where the criteria are alternatives.',
+      isOneOf: true,
+      fields: () => fieldKeys(searchType),
+    });
+    const orKey: GraphQLInputFieldConfig = {
+      type: new GraphQLList(new GraphQLNonNull(criterionInput)),
+      description:
+        'A disjunction: a document matches when ANY of these criteria holds. Combined with the sibling keys by AND, so it widens across fields without widening the query as a whole.',
+    };
+    // `and` carries further `Where`s rather than a separate clause type. Safe to
+    // be recursive: a conjunction inside a conjunction FLATTENS, and the one
+    // shape that would not – an `and` inside an `or` – is unreachable, because
+    // `or` holds only `@oneOf` criteria. So `where` stays a flat conjunction of
+    // disjunctions at any nesting depth, and a reader meets one input type
+    // instead of two near-identical ones.
+    const created: GraphQLInputObjectType = new GraphQLInputObjectType({
+      name: `${searchType.name}Where`,
+      description:
+        'Sibling keys are combined with AND. Use `or` for a disjunction, and `and` when a query needs more than one of them.',
+      fields: () => ({
+        ...fieldKeys(searchType),
+        [OR_KEY]: orKey,
+        [AND_KEY]: {
+          type: new GraphQLList(new GraphQLNonNull(created)),
+          description:
+            'Further groups of conditions, all of which apply. The way to carry a second `or` disjunction alongside the first.',
+        },
+      }),
+    });
+    whereInputs.set(searchType.name, created);
+    return created;
   }
 
   /** The root query field for one {@link RootType}, with its derived types. */
@@ -643,69 +780,9 @@ export function buildGraphQLSchema(
 
     // Every type is filterable on `id`, so the input always has at least one
     // field and always exists – no type is unaddressable by IRI, whatever it
-    // declares.
-    const filterable = filterableFields(searchType);
-    /**
-     * One key per filterable field (plus the undeclared `id`), each typed by its
-     * OWN kind – so the operator a key accepts is fixed by the field it names,
-     * and a range on a keyword field cannot be written at all. This is the
-     * single vocabulary every level of `where` is built from: the same keys
-     * appear on the clause and on a criterion, so a field is never named a
-     * second way.
-     */
-    const fieldKeys = (): Record<string, GraphQLInputFieldConfig> => {
-      const fields: Record<string, GraphQLInputFieldConfig> = {
-        // Typed self-referentially – `TermWhere.id: TermFilter` – so a consumer
-        // can resolve “the collection I am browsing” to “the filter type that
-        // accepts its IRIs”, which is what makes the refined discovery strategy
-        // work without hardcoding a single domain name.
-        [ID_FIELD]: { type: targetFilter(typeName) },
-      };
-      for (const field of filterable) {
-        fields[field.name] = {
-          type: whereFieldType(field),
-          description: field.description,
-        };
-      }
-      return fields;
-    };
-
-    // A criterion is an ATOM: exactly one field, enforced by `@oneOf`. That is
-    // what keeps `where` a flat conjunction of disjunctions – a criterion that
-    // could carry two keys would be a conjunction nested inside an `or`, and
-    // skip-own-filter (ADR 5) has no answer for a clause buried inside another.
-    const criterionInput = new GraphQLInputObjectType({
-      name: `${typeName}Criterion`,
-      description:
-        'A condition on exactly one field. Used inside `or`, where the criteria are alternatives.',
-      isOneOf: true,
-      fields: fieldKeys,
-    });
-    const orKey: GraphQLInputFieldConfig = {
-      type: new GraphQLList(new GraphQLNonNull(criterionInput)),
-      description:
-        'A disjunction: a document matches when ANY of these criteria holds. Combined with the sibling keys by AND, so it widens across fields without widening the query as a whole.',
-    };
-    // `and` carries further `Where`s rather than a separate clause type. Safe to
-    // be recursive: a conjunction inside a conjunction FLATTENS, and the one
-    // shape that would not – an `and` inside an `or` – is unreachable, because
-    // `or` holds only `@oneOf` criteria. So `where` stays a flat conjunction of
-    // disjunctions at any nesting depth, and a reader meets one input type
-    // instead of two near-identical ones.
-    const whereInput: GraphQLInputObjectType = new GraphQLInputObjectType({
-      name: `${typeName}Where`,
-      description:
-        'Sibling keys are combined with AND. Use `or` for a disjunction, and `and` when a query needs more than one of them.',
-      fields: () => ({
-        ...fieldKeys(),
-        [OR_KEY]: orKey,
-        [AND_KEY]: {
-          type: new GraphQLList(new GraphQLNonNull(whereInput)),
-          description:
-            'Further groups of conditions, all of which apply. The way to carry a second `or` disjunction alongside the first.',
-        },
-      }),
-    });
+    // declares. It may already have been created as a joined type’s filter
+    // shape; `whereInputFor` hands back the same instance either way.
+    const whereInput = whereInputFor(searchType);
 
     const sortValues: GraphQLEnumValueConfigMap = {
       RELEVANCE: { value: 'relevance' },
@@ -792,6 +869,7 @@ export function buildGraphQLSchema(
           context,
           searchType,
           maxPerPage,
+          joins,
         );
         const finalQuery = typeOptions?.queryDefaults
           ? typeOptions.queryDefaults(built, context)
@@ -908,8 +986,9 @@ interface QueryArgs {
 function argsToQuery(
   args: QueryArgs,
   context: SearchContext,
-  searchType: SearchType,
+  searchType: RootType,
   maxPerPage: number,
+  joins: JoinGraph,
 ): SearchQuery {
   const perPage = args.perPage ?? 20;
   const page = args.page ?? 1;
@@ -924,7 +1003,7 @@ function argsToQuery(
   }
   return {
     text: args.query,
-    where: whereToFilters(args.where, searchType),
+    where: whereToFilters(args.where, searchType, joins),
     orderBy: args.orderBy
       ? [{ field: args.orderBy.field, direction: args.orderBy.direction }]
       : [],
@@ -936,23 +1015,46 @@ function argsToQuery(
   };
 }
 
+/**
+ * Compile one `Where` input into the flat conjunction of disjunctions the IR
+ * holds, at `on` hops out from the searched type (`[]` at the top level).
+ *
+ * A **joined** key carrying `where` recurses with the path extended by that
+ * key, and its clauses join this list – exactly how `and` already flattens. The
+ * result is still flat: the nesting lives in each criterion’s `on` path, never
+ * in the clause structure, so skip-own-filter (ADR 5) still scans one level.
+ */
 function whereToFilters(
   where: Record<string, unknown> | undefined,
-  searchType: SearchType,
+  searchType: RootType,
+  joins: JoinGraph,
+  on: readonly string[] = [],
 ): Filter[] {
   // `== null` deliberately: an explicit `where: null` is as absent as an omitted
   // one, and reading keys off it would throw.
   if (where == null) {
     return [];
   }
-  const filters = criteriaOf(where, searchType).map(filterOn);
+  const filters: Filter[] = [];
   // Sibling field keys AND, so each becomes a one-criterion filter of its own,
   // while `or` becomes a SINGLE filter carrying every alternative. That is the
   // whole AND/OR mapping: which bucket a criterion lands in, never a combinator
   // inferred from how deeply it is nested.
+  for (const entry of keyEntriesOf(where, searchType, joins)) {
+    if ('nested' in entry) {
+      filters.push(
+        ...whereToFilters(entry.nested, entry.target, joins, [
+          ...on,
+          entry.name,
+        ]),
+      );
+      continue;
+    }
+    filters.push(filterOn(withPath(entry.criterion, on)));
+  }
   const alternatives = (
     (where[OR_KEY] as readonly Record<string, unknown>[] | null) ?? []
-  ).flatMap((criterion) => criteriaOf(criterion, searchType));
+  ).flatMap((criterion) => criteriaOf(criterion, searchType, joins, on));
   if (alternatives.length > 0) {
     filters.push({ or: alternatives });
   }
@@ -962,51 +1064,123 @@ function whereToFilters(
   // can never sit inside an `or` (which holds only criteria).
   for (const nested of (where[AND_KEY] as
     readonly Record<string, unknown>[] | null) ?? []) {
-    filters.push(...whereToFilters(nested, searchType));
+    filters.push(...whereToFilters(nested, searchType, joins, on));
   }
   return filters;
 }
 
+/** A criterion with its join path attached, or unchanged at the top level –
+ *  so an ordinary query’s IR is byte-for-byte what it was. */
+function withPath(criterion: Criterion, on: readonly string[]): Criterion {
+  return on.length === 0 ? criterion : { ...criterion, on };
+}
+
 /**
- * The criteria a keyed object carries, in declaration order. A `Criterion` is
- * `@oneOf`, so it yields exactly one; a `Where`/`Clause` yields one per field
- * key it sets. `id` is read first: no type declares it, so the field loop below
- * never sees it.
+ * The criteria a keyed object carries, in declaration order, `on` hops out. A
+ * `Criterion` is `@oneOf`, so it yields exactly one; a `Where` yields one per
+ * field key it sets.
+ *
+ * A joined key carrying `where` is compiled through {@link whereToFilters} and
+ * must come back as exactly ONE one-criterion clause. Anything else – two field
+ * keys, an `or`, an `and` – is a conjunction, and a conjunction cannot sit
+ * inside the `or` this feeds (ADR 18’s flat IR has nowhere to put it), so it is
+ * rejected with the rewrite that expresses it instead.
  */
 function criteriaOf(
   keyed: Record<string, unknown>,
-  searchType: SearchType,
+  searchType: RootType,
+  joins: JoinGraph,
+  on: readonly string[] = [],
 ): Criterion[] {
   const criteria: Criterion[] = [];
+  for (const entry of keyEntriesOf(keyed, searchType, joins)) {
+    if (!('nested' in entry)) {
+      criteria.push(withPath(entry.criterion, on));
+      continue;
+    }
+    const path = [...on, entry.name];
+    const nested = whereToFilters(entry.nested, entry.target, joins, path);
+    const [only] = nested;
+    if (nested.length !== 1 || only.or.length !== 1) {
+      throw new Error(
+        `The joined condition on “${entry.name}” states more than one criterion, so it is a conjunction – which cannot sit inside an “or”. Write one “or” alternative per criterion, or move the conjunction into “and”.`,
+      );
+    }
+    criteria.push(only.or[0]);
+  }
+  return criteria;
+}
+
+/** One key of a `Where`/`Criterion` input, compiled: either a leaf criterion or
+ *  a joined `where` to recurse into. */
+type KeyEntry =
+  | { readonly criterion: Criterion }
+  | {
+      readonly name: string;
+      readonly nested: Record<string, unknown>;
+      readonly target: RootType;
+    };
+
+/**
+ * The field keys a keyed input sets, in declaration order. `id` is read first:
+ * no type declares it, so the field loop never sees it.
+ *
+ * A joinable reference takes a `‹Target›ReferenceFilter` rather than a plain
+ * `StringFilter`, and its two `@oneOf` arms mean different things: `in` filters
+ * by the ids the field itself holds – no join, the same membership every other
+ * reference gets – while `where` states a condition on the referent and yields
+ * a nested entry the caller walks into.
+ */
+function keyEntriesOf(
+  keyed: Record<string, unknown>,
+  searchType: RootType,
+  joins: JoinGraph,
+): KeyEntry[] {
+  const entries: KeyEntry[] = [];
   const id = keyed[ID_FIELD] as { in?: string[] } | undefined | null;
   if (id !== undefined && id !== null) {
-    criteria.push({ field: ID_FIELD, in: id.in ?? [] });
+    entries.push({ criterion: { field: ID_FIELD, in: id.in ?? [] } });
   }
   for (const field of filterableFields(searchType)) {
     const value = keyed[field.name];
     if (value === undefined || value === null) {
       continue;
     }
+    const target = joins.resolve(searchType, [field.name]);
+    if (target !== undefined) {
+      const nested = (value as { where?: Record<string, unknown> | null })
+        .where;
+      if (nested !== undefined && nested !== null) {
+        entries.push({ name: field.name, nested, target });
+        continue;
+      }
+    }
     switch (filterOperatorFor(field.kind)) {
       case 'in':
-        criteria.push({
-          field: field.name,
-          in: (value as { in?: string[] }).in ?? [],
+        entries.push({
+          criterion: {
+            field: field.name,
+            in: (value as { in?: string[] }).in ?? [],
+          },
         });
         break;
       case 'range': {
         const range = value as { min?: number | string; max?: number | string };
-        criteria.push({
-          field: field.name,
-          range: { min: range.min, max: range.max },
+        entries.push({
+          criterion: {
+            field: field.name,
+            range: { min: range.min, max: range.max },
+          },
         });
         break;
       }
       default:
-        criteria.push({ field: field.name, is: value as boolean });
+        entries.push({
+          criterion: { field: field.name, is: value as boolean },
+        });
     }
   }
-  return criteria;
+  return entries;
 }
 
 function rangeInput(

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -1101,6 +1101,14 @@ function criteriaOf(
     const path = [...on, entry.name];
     const nested = whereToFilters(entry.nested, entry.target, joins, path);
     const [only] = nested;
+    // An `or` alternative must be exactly one criterion. Empty and
+    // more-than-one are opposite mistakes, so they are named separately rather
+    // than sharing a message that fits only one of them.
+    if (only === undefined) {
+      throw new Error(
+        `The joined condition on “${entry.name}” states no criterion, so it constrains nothing – and an “or” alternative that constrains nothing would make the whole disjunction match everything. Give it a condition, or leave the alternative out.`,
+      );
+    }
     if (nested.length !== 1 || only.or.length !== 1) {
       throw new Error(
         `The joined condition on “${entry.name}” states more than one criterion, so it is a conjunction – which cannot sit inside an “or”. Write one “or” alternative per criterion, or move the conjunction into “and”.`,

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -665,7 +665,12 @@ export function buildGraphQLSchema(
       // A thunk: the target’s own `where` may point back through further
       // joinable references (the join graph is acyclic, so this terminates).
       fields: () => ({
-        in: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+        // `IRI`, exactly as `‹Target›Filter` types it: this arm asks the same
+        // question that filter asks – which of the target’s ids the field
+        // holds – so it must accept the same variable a consumer declares
+        // `[IRI!]` for. Typing it `String` here would make the join arm the
+        // one place identity is not `IRI`-keyed.
+        in: { type: new GraphQLList(new GraphQLNonNull(iriScalar)) },
         where: { type: whereInputFor(target) },
       }),
     });

--- a/packages/search-api-graphql/src/facet-batch.ts
+++ b/packages/search-api-graphql/src/facet-batch.ts
@@ -1,5 +1,6 @@
 import DataLoader from 'dataloader';
 import type {
+  Criterion,
   FacetBucket,
   Filter,
   RootType,
@@ -141,7 +142,22 @@ function ownedField(filter: Filter): string | undefined {
   if (first === undefined) {
     return undefined;
   }
-  return rest.every((criterion) => criterion.field === first.field)
-    ? first.field
-    : undefined;
+  const key = axisOf(first);
+  return rest.every((criterion) => axisOf(criterion) === key) ? key : undefined;
+}
+
+/**
+ * The axis one criterion constrains: its field, qualified by the join path it
+ * reaches that field through. Two criteria are the same axis only when both
+ * agree – `dataset.publisher` and a local `publisher` are different questions,
+ * so a selection on one is no selection on the other.
+ *
+ * Facets are not yet offered on joined fields, so a joined clause’s key can
+ * never equal a requested facet name and such a clause simply never drops. That
+ * falls out of the key rather than being a rule of its own, and stays right if
+ * joined facets land later.
+ */
+function axisOf(criterion: Criterion): string {
+  const on = criterion.on ?? [];
+  return on.length === 0 ? criterion.field : [...on, criterion.field].join('.');
 }

--- a/packages/search-api-graphql/test/facet-batch.test.ts
+++ b/packages/search-api-graphql/test/facet-batch.test.ts
@@ -138,6 +138,21 @@ describe('groupFacetQueries', () => {
     ]);
   });
 
+  it('keeps a joined clause: a hop out is a different axis', () => {
+    // Ownership is keyed by (path, field), so a condition on the publisher of a
+    // work’s dataset is not a selection on the work’s OWN publisher facet.
+    // Dropping it would count a corpus the sidebar is not showing.
+    const joined: SearchQuery = {
+      ...baseQuery,
+      where: [
+        { or: [{ on: ['dataset'], field: 'publisher', in: ['urn:vg'] }] },
+      ],
+    };
+    expect(groupFacetQueries(joined, ['publisher'])).toEqual([
+      { ...joined, facets: ['publisher'], limit: 0, offset: 0 },
+    ]);
+  });
+
   it('drops a facet’s own single-field clause while keeping a multi-field one', () => {
     const both: SearchQuery = {
       ...baseQuery,

--- a/packages/search-api-graphql/test/joins.test.ts
+++ b/packages/search-api-graphql/test/joins.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import { graphql, printSchema } from 'graphql';
+import {
+  defineSearchType,
+  searchSchema,
+  type ReferenceField,
+  type SearchEngine,
+  type SearchQuery,
+  type SearchResult,
+  type SearchType,
+} from '@lde/search';
+import { buildGraphQLSchema, type SearchContext } from '../src/build-schema.js';
+
+/** A label-source-shaped root type: indexed, serving a `label`. */
+function labelSource(name: string, fields: SearchType['fields'] = []) {
+  return defineSearchType({
+    name,
+    class: `https://example.org/${name}`,
+    fields: [
+      {
+        name: 'label',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+      { name: 'country', kind: 'keyword', filterable: true, facetable: true },
+      ...fields,
+    ],
+  });
+}
+
+const joinable = (name: string, source: string): ReferenceField => ({
+  name,
+  kind: 'reference',
+  filterable: true,
+  labelSource: source,
+  joinable: true,
+});
+
+const PUBLISHER = labelSource('Publisher');
+const DATASET = labelSource('Dataset', [joinable('publisher', 'Publisher')]);
+const CREATIVE_WORK = labelSource('CreativeWork', [
+  joinable('dataset', 'Dataset'),
+  // Same target, no join: labels and id filtering, nothing more.
+  {
+    name: 'sponsor',
+    kind: 'reference',
+    filterable: true,
+    labelSource: 'Publisher',
+  },
+]);
+const SCHEMA = searchSchema(PUBLISHER, DATASET, CREATIVE_WORK);
+
+const empty: SearchResult = { total: 0, hits: [], facets: {} };
+
+/** An engine that records the query it received. */
+function recordingEngine(): {
+  engine: SearchEngine;
+  received: () => SearchQuery;
+} {
+  let captured: SearchQuery;
+  return {
+    engine: {
+      schema: SCHEMA,
+      async search(_searchType, query) {
+        captured = query;
+        return empty;
+      },
+      async searchFacets(_searchType, queries) {
+        return queries.map(() => ({ facets: empty.facets }));
+      },
+    },
+    received: () => captured,
+  };
+}
+
+async function whereOf(where: string): Promise<SearchQuery['where']> {
+  const { engine, received } = recordingEngine();
+  const context: SearchContext = { engine, acceptLanguage: ['nl'] };
+  const result = await graphql({
+    schema: buildGraphQLSchema(SCHEMA),
+    source: `{ creativeWorks(where: ${where}) { pagination { total } } }`,
+    contextValue: context,
+  });
+  if (result.errors !== undefined) {
+    throw result.errors[0];
+  }
+  return received().where;
+}
+
+describe('the GraphQL surface of a declared join', () => {
+  const sdl = printSchema(buildGraphQLSchema(SCHEMA));
+
+  it('gives a joinable reference a ‹Target›ReferenceFilter, shared per target', () => {
+    // One filter type per TARGET, not per field: what it can express is a
+    // property of the referenced type, so every field pointing there shares it.
+    expect(sdl).toContain(
+      'input PublisherReferenceFilter @oneOf {\n  in: [String!]\n  where: PublisherWhere\n}',
+    );
+    expect(sdl).toContain('publisher: PublisherReferenceFilter');
+    expect(sdl).toContain('dataset: DatasetReferenceFilter');
+  });
+
+  it('leaves a non-joinable reference the plain membership filter', () => {
+    // The capability difference is visible in the schema rather than being a
+    // runtime error: `sponsor` points at Publisher too, but states no join.
+    expect(sdl).toContain('sponsor: StringFilter');
+  });
+
+  it('serves one ‹Type›Where whether the type is queried or joined to', () => {
+    // `DatasetWhere` is both the argument of `datasets(where: …)` and the shape
+    // of a joined condition on it, so a consumer learns one vocabulary.
+    expect(sdl.match(/input DatasetWhere /g)).toHaveLength(1);
+    expect(sdl).toContain('datasets(query: String, where: DatasetWhere');
+  });
+
+  it('flattens a nested `where` into an `on` path', async () => {
+    expect(
+      await whereOf(
+        '{ dataset: { where: { publisher: { where: { country: { in: ["NL"] } } } } } }',
+      ),
+    ).toEqual([
+      {
+        or: [{ on: ['dataset', 'publisher'], field: 'country', in: ['NL'] }],
+      },
+    ]);
+  });
+
+  it('reads `in` as the ids the field itself holds – no hop', async () => {
+    expect(await whereOf('{ dataset: { in: ["urn:d"] } }')).toEqual([
+      { or: [{ field: 'dataset', in: ['urn:d'] }] },
+    ]);
+  });
+
+  it('keeps the result flat: a joined `and`/`or` contributes its own clauses', async () => {
+    expect(
+      await whereOf(`{
+        dataset: { where: {
+          country: { in: ["NL"] }
+          or: [{ id: { in: ["urn:a"] } }, { country: { in: ["BE"] } }]
+        } }
+      }`),
+    ).toEqual([
+      // The nesting lives in each criterion’s path, never in the clause
+      // structure – so skip-own-filter still scans one level.
+      { or: [{ on: ['dataset'], field: 'country', in: ['NL'] }] },
+      {
+        or: [
+          { on: ['dataset'], field: 'id', in: ['urn:a'] },
+          { on: ['dataset'], field: 'country', in: ['BE'] },
+        ],
+      },
+    ]);
+  });
+
+  it('mixes a joined criterion with a local one inside one `or`', async () => {
+    expect(
+      await whereOf(`{
+        or: [
+          { dataset: { where: { country: { in: ["NL"] } } } }
+          { country: { in: ["BE"] } }
+        ]
+      }`),
+    ).toEqual([
+      {
+        or: [
+          { on: ['dataset'], field: 'country', in: ['NL'] },
+          { field: 'country', in: ['BE'] },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects a joined conjunction inside an `or`, which the flat IR cannot hold', async () => {
+    // Two keys under one joined `where` is a conjunction; nested in an `or` it
+    // would be a clause inside a clause, which ADR 18’s flat IR has nowhere to
+    // put. Named as a rewrite rather than mis-compiled.
+    await expect(
+      whereOf(`{
+        or: [{ dataset: { where: {
+          country: { in: ["NL"] }
+          id: { in: ["urn:a"] }
+        } } }]
+      }`),
+    ).rejects.toThrow(
+      /joined condition on “dataset” states more than one criterion/,
+    );
+  });
+});

--- a/packages/search-api-graphql/test/joins.test.ts
+++ b/packages/search-api-graphql/test/joins.test.ts
@@ -96,23 +96,33 @@ describe('the GraphQL surface of a declared join', () => {
     // One filter type per TARGET, not per field: what it can express is a
     // property of the referenced type, so every field pointing there shares it.
     expect(sdl).toContain(
-      'input PublisherReferenceFilter @oneOf {\n  in: [String!]\n  where: PublisherWhere\n}',
+      'input PublisherReferenceFilter @oneOf {\n  in: [IRI!]\n  where: PublisherWhere\n}',
     );
     expect(sdl).toContain('publisher: PublisherReferenceFilter');
     expect(sdl).toContain('dataset: DatasetReferenceFilter');
   });
 
-  it('leaves a non-joinable reference the plain membership filter', () => {
+  it('leaves a non-joinable reference the plain identity filter', () => {
     // The capability difference is visible in the schema rather than being a
-    // runtime error: `sponsor` points at Publisher too, but states no join.
-    expect(sdl).toContain('sponsor: StringFilter');
+    // runtime error: `sponsor` points at Publisher too, but states no join, so
+    // it keeps the ordinary identity filter every reference gets.
+    expect(sdl).toContain('sponsor: IRIFilter');
+  });
+
+  it('keys the join’s `in` arm on IRI, like every other identity filter', () => {
+    // The arm asks what `‹Target›Filter` asks – which of the target’s ids the
+    // field holds – so it must accept the same `[IRI!]` variable. Typing it
+    // `String` would make the join the one place identity is not IRI-keyed.
+    expect(sdl).toContain(
+      'input DatasetReferenceFilter @oneOf {\n  in: [IRI!]\n  where: DatasetWhere\n}',
+    );
   });
 
   it('serves one ‹Type›Where whether the type is queried or joined to', () => {
     // `DatasetWhere` is both the argument of `datasets(where: …)` and the shape
     // of a joined condition on it, so a consumer learns one vocabulary.
     expect(sdl.match(/input DatasetWhere /g)).toHaveLength(1);
-    expect(sdl).toContain('datasets(query: String, where: DatasetWhere');
+    expect(sdl).toMatch(/datasets\([\s\S]*?where: DatasetWhere/);
   });
 
   it('flattens a nested `where` into an `on` path', async () => {

--- a/packages/search-api-graphql/test/joins.test.ts
+++ b/packages/search-api-graphql/test/joins.test.ts
@@ -187,4 +187,15 @@ describe('the GraphQL surface of a declared join', () => {
       /joined condition on “dataset” states more than one criterion/,
     );
   });
+
+  it('rejects an empty joined condition inside an `or` on its own terms', async () => {
+    // The opposite mistake, and it used to crash on the missing clause rather
+    // than say anything: an alternative that constrains nothing would make the
+    // whole disjunction match everything.
+    await expect(
+      whereOf('{ or: [{ dataset: { where: {} } }] }'),
+    ).rejects.toThrow(
+      /joined condition on “dataset” states no criterion, so it constrains nothing/,
+    );
+  });
 });

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -23,7 +23,7 @@ export default mergeConfig(
           lines: 100,
           // Full-suite baseline, re-anchored when covered branches are
           // deleted (autoUpdate only ever raises; see AGENTS.md).
-          branches: 96.44,
+          branches: 96.91,
           statements: 100,
         },
       },

--- a/packages/search-indexer/src/composition.ts
+++ b/packages/search-indexer/src/composition.ts
@@ -10,7 +10,12 @@ import {
   type DistributionResolver,
   type Writer,
 } from '@lde/pipeline';
-import type { RootType, SearchDocument, SearchSchema } from '@lde/search';
+import type {
+  RootType,
+  SearchDocument,
+  SearchSchema,
+  SearchType,
+} from '@lde/search';
 import {
   BlueGreenRebuild,
   deriveCollectionName,
@@ -50,7 +55,11 @@ export function writerFactoryFrom(
       schema,
       ...(config.collectionPrefix
         ? {
-            name: `${config.collectionPrefix}${deriveCollectionName(searchType)}`,
+            // The prefix applies to EVERY type the writer names – its own and
+            // the peers its joins reference – so a prefixed deployment’s
+            // reference fields point at prefixed collections.
+            collectionNameFor: (type: SearchType) =>
+              `${config.collectionPrefix}${deriveCollectionName(type)}`,
           }
         : {}),
     };

--- a/packages/search-pipeline/src/search-index-writer.ts
+++ b/packages/search-pipeline/src/search-index-writer.ts
@@ -6,7 +6,12 @@ import {
   type RunWriter,
   type Writer,
 } from '@lde/pipeline';
-import type { RootType, SearchDocument, SearchSchema } from '@lde/search';
+import {
+  joinGraph,
+  type RootType,
+  type SearchDocument,
+  type SearchSchema,
+} from '@lde/search';
 import type { TypedSearchDocument } from './typed-search-document.js';
 
 /** Options for {@link searchIndexWriter}. */
@@ -50,17 +55,27 @@ export interface SearchIndexWriterOptions {
  * made it.
  *
  * Each root type is an independent engine run (its own collection, alias and
- * lock), so the collections commit, sweep and fail in isolation:
+ * lock), and the unit those runs are isolated **by** is the join component –
+ * the group of types that reference one another through a
+ * {@link ReferenceField.joinable} reference and therefore cannot go live apart
+ * ([ADR 19](https://github.com/ldelements/lde/blob/main/docs/decisions/0019-filter-across-collections-through-declared-joins.md)).
+ * A type with no joinable reference is a singleton component, so a schema
+ * without joins behaves exactly as it did:
  *
  * - a type whose projection is empty this run affects only its own collection,
  *   never another’s – in particular the `datasets` index still goes live;
- * - `commit` finalizes every collection independently and, if any fails, throws
+ * - runs are **opened** in join order, referenced first: an engine cannot
+ *   create a collection whose reference names a collection that does not exist
+ *   yet;
+ * - `commit` finalizes every component independently and, if any fails, throws
  *   an `AggregateError` *after* attempting them all, so a non-critical
- *   label-collection failure never blocks the collections that did commit,
+ *   label-collection failure never blocks the components that did commit,
  *   while the failure is still surfaced (the pipeline marks the run failed).
- *   Because the pipeline then calls {@link RunWriter.abort}, `abort` finalizes
- *   only the collections that did **not** already go live – aborting a
- *   committed blue/green rebuild would drop its now-live collection;
+ *   Within a component the commits are sequential, referrers first, and stop
+ *   at the first failure – so a component ships whole or not at all. Because
+ *   the pipeline then calls {@link RunWriter.abort}, `abort` finalizes only the
+ *   collections that did **not** already go live – aborting a committed
+ *   blue/green rebuild would drop its now-live collection;
  * - `abort` (a run failure, or a partial commit) drops every half-built
  *   collection that has not committed and leaves the live ones untouched.
  *
@@ -80,6 +95,13 @@ export function searchIndexWriter(
       writerFor(searchType, schema),
     ]),
   );
+  // The declared join components – the unit a rebuild opens and commits by.
+  // A type with no joinable reference is a singleton here, so a schema without
+  // joins keeps per-collection isolation exactly as before.
+  const components = joinGraph(schema).components;
+  // Referenced first, across every component: the order the collections may be
+  // created in.
+  const openOrder = components.flat();
 
   return {
     async openRun(
@@ -87,8 +109,16 @@ export function searchIndexWriter(
     ): Promise<RunWriter<TypedSearchDocument>> {
       const runs = new Map<string, RunWriter<SearchDocument>>();
       try {
-        for (const [typeIri, writer] of writers) {
-          runs.set(typeIri, await writer.openRun(context));
+        // Open in join order: a collection whose reference names a peer’s
+        // collection cannot be created before that peer’s exists, so a
+        // component’s referenced types open first. Locking needs no change –
+        // this is still the single deterministic pass that takes every lock in
+        // a fixed order, which is what keeps lock-ordering deadlock impossible.
+        for (const searchType of openOrder) {
+          const writer = writers.get(
+            searchType.class,
+          ) as Writer<SearchDocument>;
+          runs.set(searchType.class, await writer.openRun(context));
         }
       } catch (error) {
         // One engine run failed to open (e.g. its lock is held); roll the
@@ -164,7 +194,7 @@ export function searchIndexWriter(
           // have rolled back or swept. Every collection is flushed, not just the
           // ones that received documents this dataset: a collection an earlier
           // run held documents for still needs its sweep to reconcile.
-          await settleAll(runs.values(), 'flush', (run) =>
+          await settleAll(runs.values(), 'flush', 'collection', (run) =>
             run.flush?.(dataset, outcome),
           );
         },
@@ -173,20 +203,45 @@ export function searchIndexWriter(
           // Let every collection’s run discard whatever it already holds for the
           // dataset – independently, so one collection’s reset failure never
           // leaves another holding the discarded documents into the re-run.
-          await settleAll(runs.values(), 'reset', (run) =>
+          await settleAll(runs.values(), 'reset', 'collection', (run) =>
             run.reset?.(dataset),
           );
         },
 
         commit: async () => {
-          // Commit every collection independently, so one failure neither
-          // blocks nor wipes another – the `datasets` index goes live even if a
-          // label collection cannot. Record each collection that went live, so
-          // the abort that follows a failed commit never drops it.
-          await settleAll(runs, 'commit', async ([typeIri, run]) => {
-            await run.commit();
-            committed.add(typeIri);
-          });
+          // Commit every join COMPONENT independently, so one failure neither
+          // blocks nor wipes another – the `datasets` index goes live even if
+          // an unrelated label collection cannot. Record each collection that
+          // went live, so the abort that follows a failed commit never drops
+          // it.
+          //
+          // Within a component the commits are sequential and in REVERSE join
+          // order – referrers before the types they reference. A blue/green
+          // commit drops the collection it supersedes, so committing the
+          // referent first would delete a collection the still-live referrer’s
+          // documents point at. Going the other way, the referrer swaps onto
+          // the fresh build (whose references already name the peer’s fresh
+          // collection) before the peer’s old collection is dropped, and the
+          // only inconsistency left is the alias-flip window Typesense gives no
+          // way to close.
+          //
+          // Sequential, and stopping at the first failure, is what makes the
+          // component the unit: a member that cannot commit leaves the rest of
+          // its component un-swapped rather than shipping half a rebuild.
+          await settleAll(
+            components,
+            'commit',
+            'join component',
+            async (component) => {
+              for (const searchType of [...component].reverse()) {
+                const run = runs.get(
+                  searchType.class,
+                ) as RunWriter<SearchDocument>;
+                await run.commit();
+                committed.add(searchType.class);
+              }
+            },
+          );
         },
 
         abort: async (error: unknown) => {
@@ -205,15 +260,19 @@ export function searchIndexWriter(
 }
 
 /**
- * Run `operation` on every collection concurrently and independently, so one
- * collection’s failure never skips another’s (a flush’s rollback, a reset’s
- * discard, a commit’s alias swap). Surface the failures together once all have
- * been attempted, as an `AggregateError` – the run is still marked failed, but
- * every collection got its chance to reconcile or go live first.
+ * Run `operation` on every item concurrently and independently, so one
+ * failure never skips another’s work (a flush’s rollback, a reset’s discard, a
+ * commit’s alias swap). Surface the failures together once all have been
+ * attempted, as an `AggregateError` – the run is still marked failed, but every
+ * item got its chance to reconcile or go live first.
+ *
+ * `unit` names what was iterated, because that differs by phase: a flush and a
+ * reset are per collection, a commit is per join component.
  */
 async function settleAll<Item>(
   items: Iterable<Item>,
   verb: string,
+  unit: string,
   operation: (item: Item) => Promise<void> | undefined,
 ): Promise<void> {
   const targets = [...items];
@@ -226,7 +285,7 @@ async function settleAll<Item>(
   if (failures.length > 0) {
     throw new AggregateError(
       failures,
-      `${failures.length} of ${targets.length} search collections failed to ${verb}`,
+      `${failures.length} of ${targets.length} search ${unit}s failed to ${verb}`,
     );
   }
 }

--- a/packages/search-pipeline/src/search-index-writer.ts
+++ b/packages/search-pipeline/src/search-index-writer.ts
@@ -129,11 +129,13 @@ export function searchIndexWriter(
         throw error;
       }
 
-      // The components with at least one collection live, so `abort` never
-      // re-finalizes one: a committed blue/green rebuild’s abort would drop its
-      // now-live collection, and an uncommitted PEER’s abort would drop the
-      // collection that live one references. Tracked per component rather than
-      // per type because that is the unit the second hazard lives at.
+      // The collections that have gone live, so `abort` never re-finalizes one
+      // (a committed blue/green rebuild’s abort drops its now-live collection).
+      const committed = new Set<string>();
+      // The components with at least one collection live. Their UNCOMMITTED
+      // members are the ones whose build the live collection references, so
+      // they are abandoned rather than aborted. Tracked per component because
+      // that is the unit that hazard lives at.
       const live = new Set<readonly RootType[]>();
 
       return {
@@ -241,6 +243,7 @@ export function searchIndexWriter(
                   searchType.class,
                 ) as RunWriter<SearchDocument>;
                 await run.commit();
+                committed.add(searchType.class);
                 // Note the component as touched BEFORE the next member’s
                 // commit can throw, so the abort that follows knows this
                 // component has something live in it.
@@ -251,19 +254,22 @@ export function searchIndexWriter(
         },
 
         abort: async (error: unknown) => {
-          // Finalize only the collections that have not gone live – and, for a
-          // component that went PARTLY live, none of its members at all.
+          // Three outcomes, not two, because a join component makes “undo”
+          // destructive in a way it never was per collection:
           //
-          // Aborting a committed blue/green rebuild would drop its now-live
-          // collection; aborting an uncommitted member of a partly-committed
-          // component is the same mistake one edge out. Its half-built
-          // collection is precisely what the member that DID commit now
-          // references by concrete name, so dropping it leaves the live
-          // referrer with a dangling reference and every join through it
-          // failing – permanently, since the next run builds new collections
-          // rather than repairing that one. Leaving it costs an orphaned
-          // collection until an operator reclaims it; dropping it costs a
-          // broken live index, so the leak is the lesser evil.
+          // - a collection that WENT LIVE is left alone: aborting a committed
+          //   blue/green rebuild would drop its now-live collection;
+          // - a collection in a component that went PARTLY live is
+          //   `abandon`ed – finalized WITHOUT dropping what it built. Its
+          //   half-built collection is precisely what the member that did
+          //   commit now references by concrete name, so dropping it would
+          //   leave the live referrer with a dangling reference and every join
+          //   through it failing, permanently. Abandoning keeps the collection
+          //   (orphaned until a later run supersedes it) while still releasing
+          //   the cross-pod lock – skipping it entirely would hold that lock
+          //   for its whole TTL and fail the NEXT run before it starts;
+          // - everything else is aborted as before: nothing in its component is
+          //   live, so there is no reference to protect.
           //
           // Best-effort – cleanup failures must not mask the original error.
           const partlyLive = new Set(
@@ -273,8 +279,14 @@ export function searchIndexWriter(
           );
           await Promise.allSettled(
             [...runs]
-              .filter(([typeIri]) => !partlyLive.has(typeIri))
-              .map(([, run]) => run.abort(error)),
+              .filter(([typeIri]) => !committed.has(typeIri))
+              .map(([typeIri, run]) =>
+                partlyLive.has(typeIri)
+                  ? // A writer that does not implement `abandon` has an `abort`
+                    // that keeps what it built anyway – that is the contract.
+                    (run.abandon ?? run.abort).call(run, error)
+                  : run.abort(error),
+              ),
           );
         },
       };

--- a/packages/search-pipeline/src/search-index-writer.ts
+++ b/packages/search-pipeline/src/search-index-writer.ts
@@ -129,9 +129,12 @@ export function searchIndexWriter(
         throw error;
       }
 
-      // The collections that have gone live, so `abort` never re-finalizes one
-      // (a committed blue/green rebuild’s abort drops its now-live collection).
-      const committed = new Set<string>();
+      // The components with at least one collection live, so `abort` never
+      // re-finalizes one: a committed blue/green rebuild’s abort would drop its
+      // now-live collection, and an uncommitted PEER’s abort would drop the
+      // collection that live one references. Tracked per component rather than
+      // per type because that is the unit the second hazard lives at.
+      const live = new Set<readonly RootType[]>();
 
       return {
         write: async (
@@ -238,19 +241,39 @@ export function searchIndexWriter(
                   searchType.class,
                 ) as RunWriter<SearchDocument>;
                 await run.commit();
-                committed.add(searchType.class);
+                // Note the component as touched BEFORE the next member’s
+                // commit can throw, so the abort that follows knows this
+                // component has something live in it.
+                live.add(component);
               }
             },
           );
         },
 
         abort: async (error: unknown) => {
-          // Finalize only the collections that have not gone live: aborting a
-          // committed blue/green rebuild would drop its now-live collection.
+          // Finalize only the collections that have not gone live – and, for a
+          // component that went PARTLY live, none of its members at all.
+          //
+          // Aborting a committed blue/green rebuild would drop its now-live
+          // collection; aborting an uncommitted member of a partly-committed
+          // component is the same mistake one edge out. Its half-built
+          // collection is precisely what the member that DID commit now
+          // references by concrete name, so dropping it leaves the live
+          // referrer with a dangling reference and every join through it
+          // failing – permanently, since the next run builds new collections
+          // rather than repairing that one. Leaving it costs an orphaned
+          // collection until an operator reclaims it; dropping it costs a
+          // broken live index, so the leak is the lesser evil.
+          //
           // Best-effort – cleanup failures must not mask the original error.
+          const partlyLive = new Set(
+            [...live].flatMap((component) =>
+              component.map((searchType) => searchType.class),
+            ),
+          );
           await Promise.allSettled(
             [...runs]
-              .filter(([typeIri]) => !committed.has(typeIri))
+              .filter(([typeIri]) => !partlyLive.has(typeIri))
               .map(([, run]) => run.abort(error)),
           );
         },

--- a/packages/search-pipeline/test/fixtures/joins-sample.ttl
+++ b/packages/search-pipeline/test/fixtures/joins-sample.ttl
@@ -1,0 +1,31 @@
+@prefix schema: <https://schema.org/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+# The Linked Open Limburg shape the join feature exists for:
+# CreativeWork → Dataset → Publisher, two hops of joinable references.
+# Declared with CreativeWork FIRST, so the indexer writes the referring
+# documents before the referents they point at – the ordering an
+# `async_reference` must back-fill.
+
+<https://ex/cw/1> a schema:CreativeWork ;
+  schema:name "Het meisje met de parel"@nl ;
+  dcterms:isPartOf <https://ex/ds/limburg> .
+
+<https://ex/cw/2> a schema:CreativeWork ;
+  schema:name "De nachtwacht"@nl ;
+  dcterms:isPartOf <https://ex/ds/amsterdam> .
+
+<https://ex/ds/limburg> a dcat:Dataset ;
+  dcterms:title "Collectie Limburg"@nl ;
+  dcterms:publisher <https://ex/pub/limburg> .
+
+<https://ex/ds/amsterdam> a dcat:Dataset ;
+  dcterms:title "Collectie Amsterdam"@nl ;
+  dcterms:publisher <https://ex/pub/amsterdam> .
+
+<https://ex/pub/limburg> a schema:Organization ;
+  schema:name "Limburgs Museum"@nl .
+
+<https://ex/pub/amsterdam> a schema:Organization ;
+  schema:name "Rijksmuseum"@nl .

--- a/packages/search-pipeline/test/joins.integration.test.ts
+++ b/packages/search-pipeline/test/joins.integration.test.ts
@@ -1,0 +1,229 @@
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'typesense';
+import { Dataset, Distribution } from '@lde/dataset';
+import {
+  ProbedDistributions,
+  ResolvedDistribution,
+  type DistributionResolver,
+  type ProgressReporter,
+} from '@lde/pipeline';
+import { defineSearchType, searchSchema, type RootType } from '@lde/search';
+import {
+  createTypesenseSearchEngine,
+  InPlaceRebuild,
+} from '@lde/search-typesense';
+import {
+  startSparqlEndpoint,
+  teardownSparqlEndpoint,
+} from '@lde/local-sparql-endpoint';
+import { searchIndexerPipeline } from '../src/search-indexer-pipeline.js';
+import { TypesenseContainer } from './typesense-container.js';
+
+const SCHEMA = 'https://schema.org/';
+const DCTERMS = 'http://purl.org/dc/terms/';
+
+/** The `label` every label source must serve, so a reference can resolve one
+ *  – and so a joinable reference has a target at all. */
+const label = (path: string) =>
+  ({
+    name: 'label',
+    kind: 'text',
+    path: `<${path}>`,
+    locales: ['nl'],
+    output: true,
+    searchable: { weight: 5 },
+  }) as const;
+
+const publisher = defineSearchType({
+  name: 'Publisher',
+  class: `${SCHEMA}Organization`,
+  fields: [label(`${SCHEMA}name`)],
+});
+
+const dataset = defineSearchType({
+  name: 'Dataset',
+  class: 'http://www.w3.org/ns/dcat#Dataset',
+  fields: [
+    label(`${DCTERMS}title`),
+    {
+      name: 'publisher',
+      kind: 'reference',
+      path: `<${DCTERMS}publisher>`,
+      filterable: true,
+      output: true,
+      labelSource: 'Publisher',
+      joinable: true,
+      ref: { typeName: 'PublisherRef', strategy: 'labelOnly' },
+    },
+  ],
+});
+
+const creativeWork = defineSearchType({
+  name: 'CreativeWork',
+  class: `${SCHEMA}CreativeWork`,
+  fields: [
+    label(`${SCHEMA}name`),
+    {
+      name: 'dataset',
+      kind: 'reference',
+      path: `<${DCTERMS}isPartOf>`,
+      filterable: true,
+      output: true,
+      labelSource: 'Dataset',
+      joinable: true,
+      ref: { typeName: 'DatasetRef', strategy: 'labelOnly' },
+    },
+  ],
+});
+
+// Declared referrer-first ON PURPOSE. The stage order follows the declaration,
+// so `creative_works` documents are imported before the `datasets` they
+// reference and before the `publishers` behind those – the out-of-order arrival
+// `async_reference` has to back-fill, and the assumption most likely to regress
+// on a Typesense upgrade.
+const schema = searchSchema(creativeWork, dataset, publisher);
+
+describe('filtering across collections through declared joins', () => {
+  const container = new TypesenseContainer();
+  const port = 3010;
+  const distribution = Distribution.sparql(
+    new URL(`http://localhost:${port}/sparql`),
+  );
+  const source = new Dataset({
+    iri: new URL('http://example.org/dataset/limburg'),
+    distributions: [distribution],
+  });
+  // Resolve straight to the local endpoint: probing and importing are the
+  // resolver’s own concern, tested with @lde/pipeline – here it is a seam.
+  const resolver: DistributionResolver = {
+    probe: async () => new ProbedDistributions(source, [], null),
+    resolve: async () => new ResolvedDistribution(distribution, []),
+  };
+  let client: Client;
+
+  /**
+   * The ids of the CreativeWorks matching `iri` through `on` – the join path –
+   * or on the reference field itself when the path is empty.
+   */
+  const hits = async (
+    on: readonly string[],
+    iri: string,
+  ): Promise<string[]> => {
+    const engine = createTypesenseSearchEngine(client, schema);
+    const result = await engine.search(creativeWork, {
+      where: [
+        {
+          or: [
+            on.length === 0
+              ? { field: 'dataset', in: [iri] }
+              : { on, field: 'id', in: [iri] },
+          ],
+        },
+      ],
+      orderBy: [],
+      limit: 10,
+      offset: 0,
+      facets: [],
+      locale: 'nl',
+    });
+    return result.hits.map((hit) => hit.id);
+  };
+
+  beforeAll(async () => {
+    client = await container.start();
+    await startSparqlEndpoint(
+      port,
+      fileURLToPath(new URL('./fixtures/joins-sample.ttl', import.meta.url)),
+    );
+
+    const stageFailures: Error[] = [];
+    const reporter: ProgressReporter = {
+      stageFailed: (_stage, error) => {
+        stageFailures.push(error);
+      },
+    };
+    const index = async () =>
+      searchIndexerPipeline({
+        schema,
+        datasets: [source],
+        distributionResolver: resolver,
+        writerFor: (searchType: RootType, mounted) =>
+          new InPlaceRebuild(client, searchType, { schema: mounted }),
+        reporter,
+      }).run();
+    // TWICE, deliberately. Per-type stages import into the referring and the
+    // referenced collection CONCURRENTLY, and Typesense 30.2 permanently loses
+    // a reference written in that window (see the ADR’s limitations). A second
+    // run meets referents that already exist, so every reference resolves at
+    // write time. Once the engine fixes the race, one run will do.
+    await index();
+    await index();
+    expect(stageFailures).toEqual([]);
+  }, 240_000);
+
+  afterAll(async () => {
+    await teardownSparqlEndpoint();
+    await container.stop();
+  });
+
+  it('declares each joinable reference as a Typesense reference field', async () => {
+    const works = await client.collections('creative_works').retrieve();
+    expect(
+      works.fields.find((field) => field.name === 'dataset'),
+    ).toMatchObject({
+      reference: 'datasets.id',
+      async_reference: true,
+      cascade_delete: false,
+    });
+  });
+
+  it('resolves the references a referrer-first indexing run left dangling', async () => {
+    // The declaration puts `CreativeWork` first, so its documents are imported
+    // before the `datasets` and `publishers` they point at and every reference
+    // dangles at import time. `async_reference` is what makes the engine ACCEPT
+    // them rather than 400 (which, under `throwOnFail: false`, would drop the
+    // documents in silence) – so the run before this one left an index whose
+    // values are all present, and the run after it resolved the references. See
+    // the reference-back-fill test in `@lde/search-typesense` for the engine
+    // guarantee itself, and the ADR for why one run is not yet enough.
+    expect(
+      await hits(['dataset', 'publisher'], 'https://ex/pub/limburg'),
+    ).toEqual(['https://ex/cw/1']);
+  });
+
+  it('answers the two-hop motivating query in one round-trip', async () => {
+    // “Every object published by institution X”: one query, one round-trip,
+    // with a correct total – instead of listing the institution’s datasets and
+    // then querying the works of each.
+    expect(
+      await hits(['dataset', 'publisher'], 'https://ex/pub/amsterdam'),
+    ).toEqual(['https://ex/cw/2']);
+  });
+
+  it('filters one hop out, and by the ids the field itself holds', async () => {
+    // One hop: a condition on the referent.
+    expect(await hits(['dataset'], 'https://ex/ds/amsterdam')).toEqual([
+      'https://ex/cw/2',
+    ]);
+    // No hop: the ids the reference field itself holds. Unchanged by
+    // `joinable` – and here, the same answer by a different route.
+    expect(await hits([], 'https://ex/ds/amsterdam')).toEqual([
+      'https://ex/cw/2',
+    ]);
+  });
+
+  it('rejects a path the schema does not declare, before dispatching it', async () => {
+    const engine = createTypesenseSearchEngine(client, schema);
+    await expect(
+      engine.search(creativeWork, {
+        where: [{ or: [{ on: ['label'], field: 'id', in: ['x'] }] }],
+        orderBy: [],
+        limit: 10,
+        offset: 0,
+        facets: [],
+        locale: 'nl',
+      }),
+    ).rejects.toThrow(/“label.id” \(unknown-join\)/);
+  });
+});

--- a/packages/search-pipeline/test/multi-collection.integration.test.ts
+++ b/packages/search-pipeline/test/multi-collection.integration.test.ts
@@ -130,7 +130,7 @@ function blueGreenFor(
 ): (searchType: RootType) => Writer<SearchDocument> {
   return (searchType) =>
     new BlueGreenRebuild(client, searchType, {
-      name: COLLECTION[searchType.class],
+      collectionNameFor: (type) => COLLECTION[type.class as string],
     });
 }
 

--- a/packages/search-pipeline/test/search-index-writer.test.ts
+++ b/packages/search-pipeline/test/search-index-writer.test.ts
@@ -543,4 +543,106 @@ describe('searchIndexWriter', () => {
     expect(contexts).toHaveLength(2);
     expect(contexts.every((seen) => seen === context)).toBe(true);
   });
+
+  describe('with a join component', () => {
+    // work → dataset → publisher: three types that reference one another, so
+    // they come into existence and go live together.
+    const label = {
+      name: 'label',
+      kind: 'text',
+      locales: ['nl'],
+      output: true,
+      searchable: { weight: 5 },
+    } as const;
+    const joinable = (name: string, source: string) =>
+      ({
+        name,
+        kind: 'reference',
+        filterable: true,
+        labelSource: source,
+        joinable: true,
+      }) as const;
+    const joined = searchSchema(
+      { name: 'Work', class: WORK, fields: [label, joinable('in', 'Set')] },
+      {
+        name: 'Set',
+        class: 'https://example.org/Set',
+        fields: [label, joinable('by', 'Publisher')],
+      },
+      {
+        name: 'Publisher',
+        class: 'https://example.org/Publisher',
+        fields: [label],
+      },
+      // Outside the component: unaffected by any of it.
+      { name: 'Loose', class: PERSON, fields: [label] },
+    );
+
+    /** The order lifecycle calls reached the per-type writers. */
+    function orderRecorder(failOn?: string) {
+      const opened: string[] = [];
+      const committed: string[] = [];
+      const writerFor = (searchType: RootType): Writer<SearchDocument> => ({
+        openRun: async () => {
+          opened.push(searchType.name);
+          return {
+            write: () => Promise.resolve(),
+            commit: () => {
+              if (searchType.name === failOn) {
+                return Promise.reject(new Error(`no commit for ${failOn}`));
+              }
+              committed.push(searchType.name);
+              return Promise.resolve();
+            },
+            abort: () => Promise.resolve(),
+          };
+        },
+      });
+      return { opened, committed, writerFor };
+    }
+
+    it('opens referenced collections first', async () => {
+      // An engine cannot create a collection whose reference names one that
+      // does not exist yet.
+      const { opened, writerFor } = orderRecorder();
+
+      await searchIndexWriter({ schema: joined, writerFor }).openRun(
+        makeRunContext(),
+      );
+
+      expect(opened.indexOf('Publisher')).toBeLessThan(opened.indexOf('Set'));
+      expect(opened.indexOf('Set')).toBeLessThan(opened.indexOf('Work'));
+      expect(opened).toContain('Loose');
+    });
+
+    it('commits referrers first, so a superseded referent is dropped last', async () => {
+      const { committed, writerFor } = orderRecorder();
+
+      const run = await searchIndexWriter({
+        schema: joined,
+        writerFor,
+      }).openRun(makeRunContext());
+      await run.commit();
+
+      expect(committed.indexOf('Work')).toBeLessThan(committed.indexOf('Set'));
+      expect(committed.indexOf('Set')).toBeLessThan(
+        committed.indexOf('Publisher'),
+      );
+    });
+
+    it('stops a component at its first failed commit, leaving others alone', async () => {
+      // The component is the unit: `Set` failing must not let `Publisher` swap
+      // and drop the collection the still-live `Set` documents point at. The
+      // unrelated singleton commits regardless.
+      const { committed, writerFor } = orderRecorder('Set');
+
+      const run = await searchIndexWriter({
+        schema: joined,
+        writerFor,
+      }).openRun(makeRunContext());
+
+      await expect(run.commit()).rejects.toThrow(AggregateError);
+      expect(committed).toEqual(['Work', 'Loose']);
+    });
+  });
 });

--- a/packages/search-pipeline/test/search-index-writer.test.ts
+++ b/packages/search-pipeline/test/search-index-writer.test.ts
@@ -582,6 +582,7 @@ describe('searchIndexWriter', () => {
     function orderRecorder(failOn?: string) {
       const opened: string[] = [];
       const committed: string[] = [];
+      const aborted: string[] = [];
       const writerFor = (searchType: RootType): Writer<SearchDocument> => ({
         openRun: async () => {
           opened.push(searchType.name);
@@ -594,11 +595,14 @@ describe('searchIndexWriter', () => {
               committed.push(searchType.name);
               return Promise.resolve();
             },
-            abort: () => Promise.resolve(),
+            abort: () => {
+              aborted.push(searchType.name);
+              return Promise.resolve();
+            },
           };
         },
       });
-      return { opened, committed, writerFor };
+      return { opened, committed, aborted, writerFor };
     }
 
     it('opens referenced collections first', async () => {
@@ -643,6 +647,42 @@ describe('searchIndexWriter', () => {
 
       await expect(run.commit()).rejects.toThrow(AggregateError);
       expect(committed).toEqual(['Work', 'Loose']);
+    });
+
+    it('never aborts a member of a partly-committed component', async () => {
+      // `Work` went live pointing at `Publisher`’s and `Set`’s FRESH
+      // collections by concrete name. Aborting those uncommitted peers would
+      // drop exactly the collections the live `Work` references, breaking
+      // every join through it permanently – the same mistake as aborting a
+      // committed rebuild, one edge out. An orphaned collection is the lesser
+      // evil, so the whole component is left alone.
+      const { committed, aborted, writerFor } = orderRecorder('Set');
+
+      const run = await searchIndexWriter({
+        schema: joined,
+        writerFor,
+      }).openRun(makeRunContext());
+      await expect(run.commit()).rejects.toThrow(AggregateError);
+      await run.abort(new Error('run failed'));
+
+      expect(committed).toEqual(['Work', 'Loose']);
+      expect(aborted).toEqual([]);
+    });
+
+    it('still aborts a component that committed nothing', async () => {
+      // Nothing in the component is live, so there is no reference to protect
+      // and the half-built collections must be dropped as before.
+      const { committed, aborted, writerFor } = orderRecorder('Work');
+
+      const run = await searchIndexWriter({
+        schema: joined,
+        writerFor,
+      }).openRun(makeRunContext());
+      await expect(run.commit()).rejects.toThrow(AggregateError);
+      await run.abort(new Error('run failed'));
+
+      expect(committed).toEqual(['Loose']);
+      expect(aborted.sort()).toEqual(['Publisher', 'Set', 'Work']);
     });
   });
 });

--- a/packages/search-pipeline/test/search-index-writer.test.ts
+++ b/packages/search-pipeline/test/search-index-writer.test.ts
@@ -579,10 +579,14 @@ describe('searchIndexWriter', () => {
     );
 
     /** The order lifecycle calls reached the per-type writers. */
-    function orderRecorder(failOn?: string) {
+    function orderRecorder(
+      failOn?: string,
+      options: { readonly withAbandon?: boolean } = { withAbandon: true },
+    ) {
       const opened: string[] = [];
       const committed: string[] = [];
       const aborted: string[] = [];
+      const abandoned: string[] = [];
       const writerFor = (searchType: RootType): Writer<SearchDocument> => ({
         openRun: async () => {
           opened.push(searchType.name);
@@ -599,10 +603,16 @@ describe('searchIndexWriter', () => {
               aborted.push(searchType.name);
               return Promise.resolve();
             },
+            ...(options.withAbandon === true && {
+              abandon: () => {
+                abandoned.push(searchType.name);
+                return Promise.resolve();
+              },
+            }),
           };
         },
       });
-      return { opened, committed, aborted, writerFor };
+      return { opened, committed, aborted, abandoned, writerFor };
     }
 
     it('opens referenced collections first', async () => {
@@ -649,14 +659,14 @@ describe('searchIndexWriter', () => {
       expect(committed).toEqual(['Work', 'Loose']);
     });
 
-    it('never aborts a member of a partly-committed component', async () => {
+    it('abandons – never aborts – the peers of a committed member', async () => {
       // `Work` went live pointing at `Publisher`’s and `Set`’s FRESH
       // collections by concrete name. Aborting those uncommitted peers would
       // drop exactly the collections the live `Work` references, breaking
-      // every join through it permanently – the same mistake as aborting a
-      // committed rebuild, one edge out. An orphaned collection is the lesser
-      // evil, so the whole component is left alone.
-      const { committed, aborted, writerFor } = orderRecorder('Set');
+      // every join through it permanently. Abandoning keeps them – and still
+      // releases their cross-pod locks, which skipping them entirely would
+      // hold for a full TTL and fail the next run before it starts.
+      const { committed, aborted, abandoned, writerFor } = orderRecorder('Set');
 
       const run = await searchIndexWriter({
         schema: joined,
@@ -666,7 +676,30 @@ describe('searchIndexWriter', () => {
       await run.abort(new Error('run failed'));
 
       expect(committed).toEqual(['Work', 'Loose']);
+      expect(abandoned.sort()).toEqual(['Publisher', 'Set']);
+      // Neither the live member nor its peers are aborted.
       expect(aborted).toEqual([]);
+    });
+
+    it('falls back to abort for a writer that implements no abandon', async () => {
+      // The contract: a writer without `abandon` has an `abort` that keeps
+      // what it built (an In-place rebuild releasing its lock), so the
+      // fallback is correct rather than merely tolerable.
+      const { committed, aborted, abandoned, writerFor } = orderRecorder(
+        'Set',
+        { withAbandon: false },
+      );
+
+      const run = await searchIndexWriter({
+        schema: joined,
+        writerFor,
+      }).openRun(makeRunContext());
+      await expect(run.commit()).rejects.toThrow(AggregateError);
+      await run.abort(new Error('run failed'));
+
+      expect(committed).toEqual(['Work', 'Loose']);
+      expect(abandoned).toEqual([]);
+      expect(aborted.sort()).toEqual(['Publisher', 'Set']);
     });
 
     it('still aborts a component that committed nothing', async () => {

--- a/packages/search-typesense/src/blue-green-rebuild.ts
+++ b/packages/search-typesense/src/blue-green-rebuild.ts
@@ -199,6 +199,16 @@ export class BlueGreenRebuild<
             .catch(() => undefined);
           await releaseLock(this.client, name);
         },
+
+        abandon: async () => {
+          // Everything `abort` does EXCEPT the drop. Asked for when a peer
+          // whose documents reference this collection by concrete name has
+          // already gone live: dropping it would break that live collection’s
+          // joins, so the collection is kept for a later run to supersede.
+          // Releasing the lock is the whole point – without it the index stays
+          // locked for its full TTL and the next run cannot rebuild it.
+          await releaseLock(this.client, name);
+        },
       };
     });
   }

--- a/packages/search-typesense/src/blue-green-rebuild.ts
+++ b/packages/search-typesense/src/blue-green-rebuild.ts
@@ -89,7 +89,8 @@ export class BlueGreenRebuild<
     assertSweepableProvenanceField(searchType, { requireFacetable: false });
     this.sourceField = provenanceField(searchType);
     this.resolved = resolveRebuildOptions(searchType, options);
-    this.collectionName = this.resolved.definitionOptions.name;
+    this.collectionName =
+      this.resolved.definitionOptions.collectionNameFor(searchType);
   }
 
   async openRun(context: RunContext): Promise<RunWriter<TDocument>> {
@@ -101,15 +102,26 @@ export class BlueGreenRebuild<
       // Create the fresh (blue) collection up front, so a failure surfaces
       // before any dataset is processed. startedAt orders the versioned names;
       // concurrent same-name runs are excluded by the lock.
-      const collection = `${name}_${Date.parse(context.startedAt)}`;
+      //
+      // The SAME versioning applies to every peer this type joins to, so an
+      // emitted reference field names the peer’s FRESH collection rather than
+      // its live one – Typesense resolves an alias to a concrete collection at
+      // create time and keeps the concrete name, so referencing the alias would
+      // pin the new build to the collection the peer is about to supersede. No
+      // coordinator is needed: every writer in the run gets the same
+      // `RunContext`, so `startedAt` – and therefore every derived name – is
+      // identical across them.
+      const version = Date.parse(context.startedAt);
+      const versioned = (searchType: SearchType) =>
+        `${definitionOptions.collectionNameFor(searchType)}_${version}`;
+      const collection = versioned(this.searchType);
       const previous = await this.aliasTarget(name);
-      const definition = buildCollectionDefinition(
-        this.searchType,
-        definitionOptions,
-      );
+      const definition = buildCollectionDefinition(this.searchType, {
+        ...definitionOptions,
+        collectionNameFor: versioned,
+      });
       await this.client.collections().create({
         ...definition,
-        name: collection,
         // The private `source` only when the type declares no dataset field of
         // its own; a declared one is already in the definition and carries the
         // same IRI.

--- a/packages/search-typesense/src/collection-definition.ts
+++ b/packages/search-typesense/src/collection-definition.ts
@@ -8,8 +8,10 @@ import {
 } from '@lde/search';
 import {
   displayFieldPattern,
+  ID_FIELD,
   isInlineReference,
   isInternalField,
+  joinGraph,
   nestedFieldName,
   nestedReferenceType,
   physicalFields,
@@ -18,17 +20,30 @@ import { deriveCollectionName } from './collection-name.js';
 
 /** Deployment-specific options the generic field model does not carry. */
 export interface CollectionDefinitionOptions {
-  /** The Typesense collection (or alias) name. Omit to derive it from the
-   *  type’s `name` ({@link deriveCollectionName}); supply one to override that
-   *  (an env prefix, a multi-tenant name, an existing collection). */
-  readonly name?: string;
   /**
-   * The Search Schema the type belongs to – required only when the type
-   * surfaces an inline reference, whose nested fields are declared from the
-   * {@link ReferenceType} the schema resolves. A type without one needs no
-   * schema, so a caller that declares no nesting passes none; a type that does
-   * fails here rather than building a collection that silently omits the
-   * nesting.
+   * How a search type is named in Typesense – for **this** type and, where it
+   * declares a {@link ReferenceField.joinable} reference, for the peer type
+   * that reference points at. Omit to derive every name from the type’s own
+   * `name` ({@link deriveCollectionName}); supply one to override that (an env
+   * prefix, a multi-tenant name, an existing collection).
+   *
+   * A function of the type rather than a bare name, because an emitted
+   * reference field must name the peer’s **concrete** collection: a
+   * blue/green writer therefore hands in a function that appends the run’s
+   * version to every name in the component, so a fresh build references its
+   * peer’s fresh collection rather than the live one. No coordinator is
+   * needed – every writer in a run receives the same `RunContext`, so they
+   * derive identical names.
+   */
+  readonly collectionNameFor?: (searchType: SearchType) => string;
+  /**
+   * The Search Schema the type belongs to – required when the type surfaces an
+   * inline reference (whose nested fields are declared from the
+   * {@link ReferenceType} the schema resolves) or declares a joinable
+   * reference (whose target collection the schema’s {@link joinGraph}
+   * resolves). A type doing neither needs no schema, so a caller passes none;
+   * a type that does fails here rather than building a collection that
+   * silently omits the nesting or the reference.
    */
   readonly schema?: SearchSchema;
   /** Snowball stemming locale for non-localized searchable fields (e.g. `en`).
@@ -54,9 +69,15 @@ export interface CollectionDefinitionOptions {
  * stems in `defaultLocale` when one is set, and is left unstemmed (folded
  * only) otherwise.
  *
- * The collection `name` is optional: omitted, it is derived from the type’s own
- * `name` ({@link deriveCollectionName}), so a caller that has no naming opinion
- * states none.
+ * Collection naming is optional: omitted, every name – this type’s and the peer
+ * types its joins point at – is derived from the type’s own `name`
+ * ({@link deriveCollectionName}), so a caller that has no naming opinion states
+ * none.
+ *
+ * A {@link ReferenceField.joinable} reference is emitted as a Typesense
+ * **reference field** pointing at its target collection’s `id`, so a query can
+ * filter this type by a condition on the referent
+ * ({@link referenceDeclaration}).
  *
  * Memory lever: Typesense holds the index in RAM (with a raw copy of each
  * document on disk), so RAM tracks the *indexed* surface – roughly 2–3× the
@@ -84,9 +105,9 @@ export function buildCollectionDefinition(
   searchType: SearchType,
   options: CollectionDefinitionOptions = {},
 ): CollectionCreateSchema {
-  const { defaultLocale } = options;
+  const { defaultLocale, collectionNameFor = deriveCollectionName } = options;
   const collection: CollectionCreateSchema = {
-    name: options.name ?? deriveCollectionName(searchType),
+    name: collectionNameFor(searchType),
     fields: searchType.fields.flatMap((field) =>
       typesenseFields(
         searchType,
@@ -94,6 +115,7 @@ export function buildCollectionDefinition(
         defaultLocale,
         options.defaultSortingField,
         options.schema,
+        collectionNameFor,
       ),
     ),
   };
@@ -135,6 +157,54 @@ function nestedTypeOf(
   return nested;
 }
 
+/**
+ * The Typesense reference declaration a {@link ReferenceField.joinable} field
+ * carries, or `undefined` for every other field. All three keys are forced,
+ * none is a knob:
+ *
+ * - **`reference` always targets `.id`.** A reference match hitting more than
+ *   one document is a 400, and `id` is the only field the schema guarantees
+ *   unique.
+ * - **`async_reference: true`.** Without it, a document whose referent is not
+ *   indexed yet is rejected with a 400 – and the batch import runs
+ *   `throwOnFail: false`, so those would be silently dropped documents.
+ *   Documents stream per dataset ([ADR 13](../../../docs/decisions/0013-project-inside-the-batch-per-root-type.md)),
+ *   so out-of-order arrival is normal rather than exceptional; the engine
+ *   back-fills the reference when the referent lands.
+ * - **`cascade_delete: false`.** It defaults to `true`, so a sweep removing a
+ *   departed source’s referent documents would delete other sources’ referring
+ *   documents with them. Disabling it requires `async_reference`, so the two
+ *   travel together.
+ *
+ * Throws when the type declares a joinable reference the caller gave no schema
+ * to resolve the target of – the collection would otherwise come into existence
+ * without its reference and 400 on every join query.
+ */
+function referenceDeclaration(
+  searchType: SearchType,
+  field: SearchField,
+  schema: SearchSchema | undefined,
+  collectionNameFor: (searchType: SearchType) => string,
+): Record<string, unknown> | undefined {
+  if (field.kind !== 'reference' || field.joinable !== true) {
+    return undefined;
+  }
+  const target =
+    schema === undefined
+      ? undefined
+      : joinGraph(schema).resolve(searchType, [field.name]);
+  if (target === undefined) {
+    throw new Error(
+      `Building the collection for “${searchType.name}” needs the search schema its joinable reference “${field.name}” resolves against; pass it as the collection-definition option “schema”.`,
+    );
+  }
+  return {
+    reference: `${collectionNameFor(target)}.${ID_FIELD}`,
+    async_reference: true,
+    cascade_delete: false,
+  };
+}
+
 /** The physical Typesense fields one declaration produces. */
 function typesenseFields(
   searchType: SearchType,
@@ -142,6 +212,7 @@ function typesenseFields(
   defaultLocale: string | undefined,
   defaultSortingField: string | undefined,
   schema: SearchSchema | undefined,
+  collectionNameFor: (searchType: SearchType) => string,
 ): CollectionFieldSchema[] {
   // An internal field (no role) is projected as a reading device for the
   // derives and pruned before the writer, so the collection stores nothing for
@@ -207,6 +278,7 @@ function typesenseFields(
       // A `required` field is non-optional; so is the `default_sorting_field`,
       // which Typesense requires to be present. Everything else may be absent.
       optional: field.required !== true && field.name !== defaultSortingField,
+      ...referenceDeclaration(searchType, field, schema, collectionNameFor),
     },
   ];
   // `names.search` is non-empty exactly when the field projects a folded

--- a/packages/search-typesense/src/collection-definition.ts
+++ b/packages/search-typesense/src/collection-definition.ts
@@ -189,13 +189,21 @@ function referenceDeclaration(
   if (field.kind !== 'reference' || field.joinable !== true) {
     return undefined;
   }
-  const target =
-    schema === undefined
-      ? undefined
-      : joinGraph(schema).resolve(searchType, [field.name]);
-  if (target === undefined) {
+  if (schema === undefined) {
     throw new Error(
       `Building the collection for “${searchType.name}” needs the search schema its joinable reference “${field.name}” resolves against; pass it as the collection-definition option “schema”.`,
+    );
+  }
+  const target = joinGraph(schema).resolve(searchType, [field.name]);
+  if (target === undefined) {
+    // A schema WAS given and the edge still does not resolve. The rules that
+    // would reject the declaration itself all ran when the schema was built, so
+    // what is left is identity: `joinGraph` resolves from the exact declaration
+    // object the schema holds, and this is a lookalike – a re-declared type, or
+    // one belonging to another schema. Saying “pass the schema” here would send
+    // a caller to do the thing they already did.
+    throw new Error(
+      `Building the collection for “${searchType.name}” cannot resolve its joinable reference “${field.name}”: the given search schema does not declare this exact type. Pass the declaration the schema was built from, not a copy of it.`,
     );
   }
   return {

--- a/packages/search-typesense/src/in-place-rebuild.ts
+++ b/packages/search-typesense/src/in-place-rebuild.ts
@@ -74,7 +74,10 @@ export interface InPlaceRebuildOptions extends RebuildOptions {
  * `openRun` takes the single-flight cross-pod lock (throwing
  * `RebuildAlreadyRunning` when another rebuild holds it) and creates
  * the collection on demand from the {@link SearchType} plus the two
- * bookkeeping fields.
+ * bookkeeping fields. A collection that already exists is used as it is, with
+ * one exception: it must carry every reference field the declaration asks for,
+ * or the run fails with the drop-and-rebuild that fixes it
+ * ({@link assertReferencesPresent}).
  *
  * Document ids must be unique per (source, entity) – the caller keys them –
  * or documents from different sources overwrite each other.
@@ -114,7 +117,8 @@ export class InPlaceRebuild<
     } = options;
     this.maxSweepableSources = maxSweepableSources;
     this.resolved = resolveRebuildOptions(searchType, rebuildOptions);
-    this.collectionName = this.resolved.definitionOptions.name;
+    this.collectionName =
+      this.resolved.definitionOptions.collectionNameFor(searchType);
   }
 
   async openRun(context: RunContext): Promise<RunWriter<TDocument>> {
@@ -129,11 +133,12 @@ export class InPlaceRebuild<
       // field of its own; when it does, that declared field already carries the
       // IRI (and its own `facet: true`), and a second column would be the same
       // value twice, free to drift.
-      await ensureCollectionExists(this.client, name, () => {
-        const definition = buildCollectionDefinition(
-          this.searchType,
-          definitionOptions,
-        );
+      const definition = buildCollectionDefinition(
+        this.searchType,
+        definitionOptions,
+      );
+      const declaredFields = definition.fields ?? [];
+      const created = await ensureCollectionExists(this.client, name, () => {
         const bookkeeping: CollectionFieldSchema[] = [
           ...(sourceField === SOURCE_FIELD
             ? [{ name: SOURCE_FIELD, type: 'string', facet: true } as const]
@@ -142,9 +147,14 @@ export class InPlaceRebuild<
         ];
         return {
           ...definition,
-          fields: [...(definition.fields ?? []), ...bookkeeping],
+          fields: [...declaredFields, ...bookkeeping],
         };
       });
+      // A collection this run did NOT create may predate a `joinable` being
+      // declared, and a reference cannot be added to it here.
+      if (!created) {
+        await assertReferencesPresent(this.client, name, declaredFields);
+      }
 
       const importer = new BatchImporter<TDocument & Record<string, string>>(
         this.client,
@@ -258,5 +268,52 @@ export class InPlaceRebuild<
       );
     }
     return counts.map((count) => count.value);
+  }
+}
+
+/**
+ * Fail loudly when an EXISTING collection does not carry every reference field
+ * the declaration asks for, naming the drop-and-rebuild that fixes it. Never
+ * alters: an In-place rebuild creates a collection on demand and otherwise
+ * leaves its shape alone, and a reference field is the one difference that is
+ * not self-correcting.
+ *
+ * Without this a deployment that added `joinable` to an existing schema would
+ * index and commit perfectly happily, and then 400 on every join query – the
+ * collection has the *values*, it just has no reference to join through.
+ * Failing here keeps the invariant a component-scoped rebuild rests on: a
+ * component’s collections come into existence WITH their references, and never
+ * acquire them later.
+ *
+ * Deliberately scoped to reference fields only. Every other schema difference
+ * is self-correcting (a new plain field simply starts being written) or
+ * harmless, and general drift detection is a feature of its own.
+ */
+async function assertReferencesPresent(
+  client: Client,
+  name: string,
+  fields: readonly CollectionFieldSchema[],
+): Promise<void> {
+  const declared = fields.filter((field) => field.reference !== undefined);
+  if (declared.length === 0) {
+    return;
+  }
+  const existing = new Map(
+    (await client.collections(name).retrieve()).fields.map((field) => [
+      field.name,
+      field.reference,
+    ]),
+  );
+  const missing = declared.filter(
+    (field) => existing.get(field.name) !== field.reference,
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Typesense collection “${name}” exists without the reference field(s) ${missing
+        .map((field) => `“${field.name}” → “${field.reference as string}”`)
+        .join(
+          ', ',
+        )} its search type declares. A reference cannot be added to a live collection here: drop “${name}” (and the collections that join to it) and let the next run rebuild them.`,
+    );
   }
 }

--- a/packages/search-typesense/src/index.ts
+++ b/packages/search-typesense/src/index.ts
@@ -13,7 +13,7 @@ export { buildCollectionDefinition } from './collection-definition.js';
 export type { CollectionDefinitionOptions } from './collection-definition.js';
 export { deriveCollectionName } from './collection-name.js';
 export { buildSearchParams } from './query-compiler.js';
-export type { BuildSearchParamsOptions } from './query-compiler.js';
+export type { BuildSearchParamsOptions, JoinTarget } from './query-compiler.js';
 export { createTypesenseSearchEngine, parseSearchResponse } from './search.js';
 export type {
   TypesenseSearchEngine,

--- a/packages/search-typesense/src/lock.ts
+++ b/packages/search-typesense/src/lock.ts
@@ -97,15 +97,20 @@ export async function releaseLock(client: Client, name: string): Promise<void> {
 /**
  * Create a collection on demand: retrieve it, and only on a 404 create it
  * from the lazily built `schema`, tolerating a concurrent creator (409).
+ *
+ * Returns whether the collection was **brought into existence** by this call –
+ * which is what tells a caller that everything the definition declares is
+ * actually in the collection. An existing one may predate a declaration
+ * change, and some of those differences an engine cannot correct in place.
  */
 export async function ensureCollectionExists(
   client: Client,
   name: string,
   schema: () => CollectionCreateSchema,
-): Promise<void> {
+): Promise<boolean> {
   try {
     await client.collections(name).retrieve();
-    return;
+    return false;
   } catch (error) {
     if (httpStatus(error) !== 404) {
       throw error;
@@ -113,10 +118,13 @@ export async function ensureCollectionExists(
   }
   try {
     await client.collections().create(schema());
+    return true;
   } catch (error) {
     if (httpStatus(error) !== 409) {
       throw error;
     }
+    // A concurrent caller won the race; the collection exists, but not by us.
+    return false;
   }
 }
 
@@ -133,7 +141,7 @@ async function reclaimIfStale(
       .documents(name)
       .retrieve()) as { acquired_at: number };
   } catch (error) {
-    // Released between our create and this read — leave it for the next try.
+    // Released between our create and this read – leave it for the next try.
     if (httpStatus(error) === 404) {
       return false;
     }

--- a/packages/search-typesense/src/query-compiler.ts
+++ b/packages/search-typesense/src/query-compiler.ts
@@ -4,6 +4,7 @@ import {
   type Criterion,
   type FacetRange,
   type Filter,
+  type RootType,
   type SearchField,
   type SearchQuery,
   type SearchType,
@@ -21,12 +22,40 @@ import {
   searchableFields,
 } from '@lde/search/adapter';
 
+/** One hop of a join path, resolved: the Root Type it reaches and the
+ *  Typesense collection that type is stored in. */
+export interface JoinTarget {
+  readonly searchType: RootType;
+  readonly collection: string;
+}
+
 /**
  * Options for {@link buildSearchParams} – the query half of the engine
  * adapter. {@link TypesenseSearchEngineOptions} extends this, so each knob is
  * declared once and the engine forwards its options wholesale.
  */
 export interface BuildSearchParamsOptions {
+  /**
+   * Resolves a criterion’s {@link CriterionBase.on} join path to the collection
+   * it constrains – the one thing the engine-neutral {@link JoinGraph}
+   * deliberately does not answer, because collection naming is engine- and
+   * deployment-specific.
+   *
+   * Called once per **prefix** of a path, so a two-hop
+   * `['dataset', 'publisher']` yields the collection of each hop and compiles
+   * to the nested `$datasets($publishers(…))`. The declaration comes back with
+   * it, because the leaf term is compiled against the *target* type’s field
+   * (its kind, its facet flag), not the searched one.
+   *
+   * Left unset – or returning `undefined` for a path – a joined criterion
+   * compiles to nothing and drops out of its clause. Through the engine it can
+   * never get that far: `assertValidQuery` rejects an unresolvable path up
+   * front.
+   */
+  readonly joinTargetFor?: (
+    from: SearchType,
+    path: readonly string[],
+  ) => JoinTarget | undefined;
   /**
    * Cap on the number of buckets returned per facet (`max_facet_values`). Left
    * unset, Typesense defaults to 10 – too few for high-cardinality facets
@@ -53,6 +82,11 @@ export interface BuildSearchParamsOptions {
  * so the mapping is asserted directly in unit tests. Field names come from
  * {@link physicalFields}, the same convention the projection and the collection
  * schema use, so a query can never reference a field the index does not carry.
+ *
+ * A criterion carrying a {@link CriterionBase.on} join path compiles to a
+ * nested `$collection(…)` clause – one per hop – which is why the compiler
+ * takes {@link BuildSearchParamsOptions.joinTargetFor}: the join graph names
+ * the type, the deployment names the collection.
  */
 export function buildSearchParams(
   query: SearchQuery,
@@ -64,11 +98,7 @@ export function buildSearchParams(
       ? fold(query.text)
       : undefined;
   const { names, weights } = queryFields(searchType, query.locale);
-  const filterBy = compileFilterBy(
-    query.where,
-    searchType,
-    options.onIgnoredFilter,
-  );
+  const filterBy = compileFilterBy(query.where, searchType, options);
   const sortBy = query.orderBy
     .map((sort) => compileSort(sort, searchType, query.locale))
     .join(',');
@@ -170,13 +200,13 @@ function queryFields(
 function compileFilterBy(
   where: readonly Filter[],
   searchType: SearchType,
-  onIgnoredFilter: ((filter: Filter) => void) | undefined,
+  options: BuildSearchParamsOptions,
 ): string {
   return where
     .map((filter) => {
-      const clause = compileFilter(filter, searchType);
+      const clause = compileFilter(filter, searchType, options);
       if (clause === undefined) {
-        onIgnoredFilter?.(filter);
+        options.onIgnoredFilter?.(filter);
       }
       return clause;
     })
@@ -210,10 +240,11 @@ function compileFilterBy(
 function compileFilter(
   filter: Filter,
   searchType: SearchType,
+  options: BuildSearchParamsOptions,
 ): string | undefined {
   const terms: string[] = [];
   for (const criterion of filter.or) {
-    const outcome = compileCriterion(criterion, searchType);
+    const outcome = compileCriterion(criterion, searchType, options);
     if (outcome === VACUOUS) {
       return undefined;
     }
@@ -239,6 +270,47 @@ const UNUSABLE = Symbol('unusable');
  * re-derived by a second pass over the same rules.
  */
 function compileCriterion(
+  criterion: Criterion,
+  searchType: SearchType,
+  options: BuildSearchParamsOptions,
+): string | typeof VACUOUS | typeof UNUSABLE {
+  const on = criterion.on ?? [];
+  if (on.length === 0) {
+    return compileLeaf(criterion, searchType);
+  }
+  // A joined criterion constrains a document in ANOTHER collection, so the leaf
+  // is compiled against the type that path reaches and then wrapped, one
+  // `$collection(…)` per hop, outermost hop first:
+  // `['dataset', 'publisher']` → `$datasets($publishers(id:=…))`.
+  const collections: string[] = [];
+  let target = searchType;
+  for (let hop = 1; hop <= on.length; hop++) {
+    const resolved = options.joinTargetFor?.(searchType, on.slice(0, hop));
+    if (resolved === undefined) {
+      // An unresolvable path is a criterion that cannot be compiled at all –
+      // false, so it drops out and its siblings still stand. Through the
+      // engine, `assertValidQuery` has already rejected it.
+      return UNUSABLE;
+    }
+    collections.push(resolved.collection);
+    target = resolved.searchType;
+  }
+  const leaf = compileLeaf(criterion, target);
+  // A vacuous leaf states no constraint on the referent, so the join as a whole
+  // states none either – the reading, and so the outcome, passes straight
+  // through the hops.
+  if (leaf === VACUOUS || leaf === UNUSABLE) {
+    return leaf;
+  }
+  return collections.reduceRight(
+    (inner, collection) => `$${collection}(${inner})`,
+    leaf,
+  );
+}
+
+/** The criterion’s own term, against the type it actually constrains – the
+ *  searched type, or the one its join path reaches. */
+function compileLeaf(
   criterion: Criterion,
   searchType: SearchType,
 ): string | typeof VACUOUS | typeof UNUSABLE {

--- a/packages/search-typesense/src/rebuild-support.ts
+++ b/packages/search-typesense/src/rebuild-support.ts
@@ -25,26 +25,28 @@ export interface RebuildOptions extends CollectionDefinitionOptions {
 export interface ResolvedRebuildOptions {
   readonly batchSize: number;
   readonly lockTtlMs: number;
-  /** The collection-definition options with the `name` resolved – the one place
-   *  the resolved name lives, so the collection a writer talks to and the
-   *  definition it creates cannot say different things. */
+  /** The collection-definition options with `collectionNameFor` resolved to a
+   *  total function – the one place the naming convention lives, so the
+   *  collection a writer talks to, the definition it creates and the peer
+   *  collections its references name cannot say different things. */
   readonly definitionOptions: CollectionDefinitionOptions & {
-    readonly name: string;
+    readonly collectionNameFor: (searchType: SearchType) => string;
   };
 }
 
 /**
  * Apply the shared defaults, once, so neither writer restates them – including
- * the collection name, derived from the type ({@link deriveCollectionName})
+ * the collection naming, derived from each type ({@link deriveCollectionName})
  * when the deployment supplies none.
  *
  * Writers resolve at construction rather than per run, so an underivable name
  * throws when the writer is built, not on the first rebuild. The collection
  * definition is built here and discarded for the same reason: every way a
  * declaration can fail to describe a collection – an unresolvable surfaced
- * inline reference, whose nesting needs the schema – then fails at construction
- * rather than inside the first run, after a lock is held and a whole extraction
- * has been paid for.
+ * inline reference, whose nesting needs the schema, or a joinable reference
+ * whose target it resolves the same way – then fails at construction rather
+ * than inside the first run, after a lock is held and a whole extraction has
+ * been paid for.
  */
 export function resolveRebuildOptions(
   searchType: SearchType,
@@ -60,7 +62,8 @@ export function resolveRebuildOptions(
     lockTtlMs,
     definitionOptions: {
       ...definitionOptions,
-      name: definitionOptions.name ?? deriveCollectionName(searchType),
+      collectionNameFor:
+        definitionOptions.collectionNameFor ?? deriveCollectionName,
     },
   };
   buildCollectionDefinition(searchType, resolved.definitionOptions);

--- a/packages/search-typesense/src/rebuild-support.ts
+++ b/packages/search-typesense/src/rebuild-support.ts
@@ -1,6 +1,11 @@
 import type { Client } from 'typesense';
 import type { SearchType } from '@lde/search';
-import { datasetField, isInternalField } from '@lde/search/adapter';
+import {
+  datasetField,
+  isInternalField,
+  joinGraph,
+  referenceFields,
+} from '@lde/search/adapter';
 import {
   buildCollectionDefinition,
   type CollectionDefinitionOptions,
@@ -66,8 +71,45 @@ export function resolveRebuildOptions(
         definitionOptions.collectionNameFor ?? deriveCollectionName,
     },
   };
+  assertDistinctJoinTargetNames(searchType, resolved.definitionOptions);
   buildCollectionDefinition(searchType, resolved.definitionOptions);
   return resolved;
+}
+
+/**
+ * Reject a `collectionNameFor` that gives a join target the same name as the
+ * type doing the joining.
+ *
+ * The trap is the obvious migration from the `name` option this replaced:
+ * `name: 'staging_works'` reads as `collectionNameFor: () => 'staging_works'`,
+ * a constant function – which now also names every peer, so the emitted
+ * reference points the collection at ITSELF. Nothing downstream complains:
+ * Typesense accepts the self-reference and every join through it then answers
+ * nothing.
+ *
+ * Only the (type, target) pairs this type actually joins to are checked, so a
+ * deployment deliberately sharing one collection between unrelated types – the
+ * several-label-sources-in-one-`labels` case – stays allowed.
+ */
+function assertDistinctJoinTargetNames(
+  searchType: SearchType,
+  options: CollectionDefinitionOptions & {
+    readonly collectionNameFor: (searchType: SearchType) => string;
+  },
+): void {
+  const { schema, collectionNameFor } = options;
+  if (schema === undefined) {
+    return;
+  }
+  const own = collectionNameFor(searchType);
+  for (const field of referenceFields(searchType)) {
+    const target = joinGraph(schema).resolve(searchType, [field.name]);
+    if (target !== undefined && collectionNameFor(target) === own) {
+      throw new Error(
+        `The collection naming for “${searchType.name}” gives its join target “${target.name}” the same collection “${own}”, so the reference on “${field.name}” would point the collection at itself and every join through it would answer nothing. A constant “collectionNameFor” does this – derive the name from the type it is given (e.g. \`(type) => \`prefix_\${deriveCollectionName(type)}\`\`).`,
+      );
+    }
+  }
 }
 
 /**

--- a/packages/search-typesense/src/search.ts
+++ b/packages/search-typesense/src/search.ts
@@ -29,6 +29,7 @@ import {
   isInlineReference,
   isRangeFacet,
   isUnsatisfiable,
+  joinGraph,
   labelFieldOf,
   nestedReferenceType,
   outputFields,
@@ -49,7 +50,10 @@ import { deriveCollectionName } from './collection-name.js';
  *  just another type, so it is named the same way. */
 export interface TypesenseSearchEngineOptions<
   TypeName extends string = string,
-> extends BuildSearchParamsOptions {
+  // `joinTargetFor` is not a deployment knob: the engine already knows both
+  // halves of it – the schema’s join graph and every type’s collection – so it
+  // supplies the mapping itself rather than asking for it twice.
+> extends Omit<BuildSearchParamsOptions, 'joinTargetFor'> {
   /**
    * Overrides the collection (or alias) a search type reads, keyed by the
    * type’s `name`. Every type not named here reads the collection derived from
@@ -154,6 +158,25 @@ export function createTypesenseSearchEngine<
       collection,
     ]),
   );
+  // The schema's join graph, built once (it is cached per schema anyway), plus
+  // the collection half the graph deliberately leaves to the adapter. Together
+  // they are what lets a `where` criterion carry an `on` path: validation
+  // resolves the path to a type, the compiler turns each hop into
+  // `$collection(…)`.
+  const joins = joinGraph(schema);
+  const searchParamsOptions: BuildSearchParamsOptions = {
+    ...options,
+    joinTargetFor: (from, path) => {
+      // Both lookups always hit: `assertValidQuery` runs first and rejects
+      // every path this could not resolve, and each type resolved a collection
+      // above.
+      const target = joins.resolve(from, path) as RootType;
+      return {
+        searchType: target,
+        collection: collections.get(target.class) as string,
+      };
+    },
+  };
   // Resolve every reference field's label source ONCE at construction. The
   // schema already guarantees the named type exists and serves labels
   // (`searchSchema`/`labelFieldOf`), and every type resolved a collection
@@ -344,14 +367,14 @@ export function createTypesenseSearchEngine<
       // invalid query (unknown field, wrong operator, unknown facet) are both
       // rejected up front, for EVERY caller.
       assertTypeInSchema(schema, searchType);
-      assertValidQuery(query, searchType);
+      assertValidQuery(query, searchType, joins);
       // Asks for no document (an empty `id` membership): answer it without a
       // round-trip rather than dispatching a query whose only filter compiles
       // away, which would hand back the whole collection.
       if (isUnsatisfiable(query)) {
         return { total: 0, hits: [], facets: {} };
       }
-      const params = buildSearchParams(query, searchType, options);
+      const params = buildSearchParams(query, searchType, searchParamsOptions);
       const cachedLabelsPromise = startCachedLabels(searchType);
       // ONE search, but through `multi_search` (POST) like the facet batch and
       // the label lookup: `documents().search()` is a GET, so a long
@@ -379,7 +402,7 @@ export function createTypesenseSearchEngine<
     ): Promise<readonly FacetsOutcome[]> {
       assertTypeInSchema(schema, searchType);
       for (const query of queries) {
-        assertValidQuery(query, searchType);
+        assertValidQuery(query, searchType, joins);
       }
       if (queries.length === 0) {
         return [];
@@ -407,7 +430,7 @@ export function createTypesenseSearchEngine<
           ...buildSearchParams(
             { ...query, orderBy: [], limit: 0, offset: 0 },
             searchType,
-            options,
+            searchParamsOptions,
           ),
         })),
       })) as {

--- a/packages/search-typesense/test/blue-green-rebuild.test.ts
+++ b/packages/search-typesense/test/blue-green-rebuild.test.ts
@@ -201,6 +201,43 @@ describe('BlueGreenRebuild', () => {
     expect(await aliasTarget(client)).not.toBe(live);
   });
 
+  it('abandon keeps the half-built collection but still releases the lock', async () => {
+    // The half-way house between commit and abort, for the one case where
+    // undoing is the more destructive choice: a peer that already went live
+    // references this fresh collection by its concrete name, so dropping it
+    // would break that peer’s joins. The lock must still go, or the next run
+    // cannot rebuild the index at all (ADR 19).
+    const writer = new BlueGreenRebuild(client, datasetType, {
+      collectionNameFor: () => NAME,
+    });
+
+    const first = await writer.openRun(makeRunContext());
+    await first.write(
+      dataset,
+      stream([{ id: 'a', title: 'Live', year: 2024 }]),
+    );
+    await first.commit();
+    const live = await aliasTarget(client);
+    const collectionCount = (await client.collections().retrieve()).length;
+
+    const second = await writer.openRun(makeRunContext());
+    await second.write(dataset, stream([{ id: 'b', title: 'B', year: 2025 }]));
+    await second.abandon?.(new Error('a peer went live already'));
+
+    // The alias never moved, and – unlike abort – the fresh collection stays.
+    expect(await aliasTarget(client)).toBe(live);
+    expect((await client.collections().retrieve()).length).toBe(
+      collectionCount + 1,
+    );
+
+    // And the lock was released, so the next run proceeds rather than
+    // throwing RebuildAlreadyRunning for the whole TTL.
+    const third = await writer.openRun(makeRunContext());
+    await third.write(dataset, stream([{ id: 'c', title: 'C', year: 2026 }]));
+    await third.commit();
+    expect(await aliasTarget(client)).not.toBe(live);
+  });
+
   it('surfaces per-document import failures from write', async () => {
     const writer = new BlueGreenRebuild(client, datasetType, {
       collectionNameFor: () => NAME,

--- a/packages/search-typesense/test/blue-green-rebuild.test.ts
+++ b/packages/search-typesense/test/blue-green-rebuild.test.ts
@@ -68,7 +68,9 @@ describe('BlueGreenRebuild', () => {
   });
 
   it('publishes a versioned collection and points the index alias at it on commit', async () => {
-    const writer = new BlueGreenRebuild(client, datasetType, { name: NAME });
+    const writer = new BlueGreenRebuild(client, datasetType, {
+      collectionNameFor: () => NAME,
+    });
 
     const run = await writer.openRun(makeRunContext());
     await run.write(
@@ -87,7 +89,9 @@ describe('BlueGreenRebuild', () => {
   });
 
   it('keeps the live collection unswapped until commit', async () => {
-    const writer = new BlueGreenRebuild(client, datasetType, { name: NAME });
+    const writer = new BlueGreenRebuild(client, datasetType, {
+      collectionNameFor: () => NAME,
+    });
 
     const run = await writer.openRun(makeRunContext());
     await run.write(dataset, stream([{ id: 'a', title: 'A', year: 2024 }]));
@@ -99,7 +103,9 @@ describe('BlueGreenRebuild', () => {
   });
 
   it('swaps the alias to the new collection and drops the previous one', async () => {
-    const writer = new BlueGreenRebuild(client, datasetType, { name: NAME });
+    const writer = new BlueGreenRebuild(client, datasetType, {
+      collectionNameFor: () => NAME,
+    });
 
     const first = await writer.openRun(makeRunContext());
     await first.write(dataset, stream([{ id: 'a', title: 'Old', year: 2023 }]));
@@ -122,7 +128,7 @@ describe('BlueGreenRebuild', () => {
 
   it('batches documents within and across write calls', async () => {
     const writer = new BlueGreenRebuild(client, datasetType, {
-      name: NAME,
+      collectionNameFor: () => NAME,
       batchSize: 2,
     });
 
@@ -140,7 +146,9 @@ describe('BlueGreenRebuild', () => {
 
   it('refuses to open a run while another rebuild holds the index lock', async () => {
     await seedLock(client, NAME, Date.now());
-    const writer = new BlueGreenRebuild(client, datasetType, { name: NAME });
+    const writer = new BlueGreenRebuild(client, datasetType, {
+      collectionNameFor: () => NAME,
+    });
 
     await expect(writer.openRun(makeRunContext())).rejects.toThrow(
       RebuildAlreadyRunning,
@@ -151,7 +159,7 @@ describe('BlueGreenRebuild', () => {
   it('reclaims a stale lock and rebuilds', async () => {
     await seedLock(client, NAME, Date.now() - 10_000);
     const writer = new BlueGreenRebuild(client, datasetType, {
-      name: NAME,
+      collectionNameFor: () => NAME,
       lockTtlMs: 1_000,
     });
 
@@ -163,7 +171,9 @@ describe('BlueGreenRebuild', () => {
   });
 
   it('abort drops the half-built collection and leaves the live alias intact', async () => {
-    const writer = new BlueGreenRebuild(client, datasetType, { name: NAME });
+    const writer = new BlueGreenRebuild(client, datasetType, {
+      collectionNameFor: () => NAME,
+    });
 
     const first = await writer.openRun(makeRunContext());
     await first.write(
@@ -192,7 +202,9 @@ describe('BlueGreenRebuild', () => {
   });
 
   it('surfaces per-document import failures from write', async () => {
-    const writer = new BlueGreenRebuild(client, datasetType, { name: NAME });
+    const writer = new BlueGreenRebuild(client, datasetType, {
+      collectionNameFor: () => NAME,
+    });
 
     const run = await writer.openRun(makeRunContext());
     // `year` must be an int; a string is a hard validation failure.
@@ -211,7 +223,9 @@ describe('BlueGreenRebuild', () => {
   });
 
   it('publishes an empty collection for an empty run', async () => {
-    const writer = new BlueGreenRebuild(client, datasetType, { name: NAME });
+    const writer = new BlueGreenRebuild(client, datasetType, {
+      collectionNameFor: () => NAME,
+    });
 
     const run = await writer.openRun(makeRunContext());
     await run.commit();
@@ -220,7 +234,9 @@ describe('BlueGreenRebuild', () => {
   });
 
   it('rolls a failed dataset out of the collection so the swap never ships it', async () => {
-    const writer = new BlueGreenRebuild(client, datasetType, { name: NAME });
+    const writer = new BlueGreenRebuild(client, datasetType, {
+      collectionNameFor: () => NAME,
+    });
     const datasetB = new Dataset({
       iri: new URL('http://example.org/dataset/2'),
       distributions: [],
@@ -247,7 +263,9 @@ describe('BlueGreenRebuild', () => {
   });
 
   it('reset discards a dataset’s documents before a re-run', async () => {
-    const writer = new BlueGreenRebuild(client, datasetType, { name: NAME });
+    const writer = new BlueGreenRebuild(client, datasetType, {
+      collectionNameFor: () => NAME,
+    });
 
     const run = await writer.openRun(makeRunContext());
     // First pass (e.g. endpoint-sourced) writes a3 that the re-run will drop.
@@ -284,7 +302,7 @@ describe('BlueGreenRebuild', () => {
             class: 'https://example.org/Dataset',
             fields: [{ name: 'source', kind: 'keyword' }],
           },
-          { name: NAME },
+          { collectionNameFor: () => NAME },
         ),
     ).toThrow(/source/);
   });
@@ -309,7 +327,7 @@ describe('BlueGreenRebuild', () => {
     const writer = new BlueGreenRebuild<{ id: string; title: string }>(
       client,
       withDataset,
-      { name: NAME },
+      { collectionNameFor: () => NAME },
     );
 
     const failing = new Dataset({

--- a/packages/search-typesense/test/collection-definition.test.ts
+++ b/packages/search-typesense/test/collection-definition.test.ts
@@ -65,7 +65,7 @@ const schema: SearchType = {
 
 describe('buildCollectionDefinition', () => {
   const collection = buildCollectionDefinition(schema, {
-    name: 'datasets',
+    collectionNameFor: () => 'datasets',
     defaultLocale: 'nl',
     defaultSortingField: 'statusRank',
     synonymSets: ['dataset-synonyms'],
@@ -191,7 +191,7 @@ describe('buildCollectionDefinition', () => {
 
   it('assumes no language: without defaultLocale the companion is folded but unstemmed', () => {
     const withoutLocale = buildCollectionDefinition(schema, {
-      name: 'datasets',
+      collectionNameFor: () => 'datasets',
     });
     expect(withoutLocale.fields).toContainEqual({
       name: 'keyword_search',
@@ -222,7 +222,7 @@ describe('und-locale text', () => {
           },
         ],
       },
-      { name: 'docs', defaultLocale: 'en' },
+      { collectionNameFor: () => 'docs', defaultLocale: 'en' },
     );
     expect(schema.fields).toEqual([
       { name: 'summary_[^_]+', type: 'string', index: false, optional: true },
@@ -251,7 +251,7 @@ describe('und-locale text', () => {
           },
         ],
       },
-      { name: 'docs' },
+      { collectionNameFor: () => 'docs' },
     );
     // Display is gated on `output`; a search-only field emits only its folded
     // search companion, no `${name}_<lang>` regex field.
@@ -282,7 +282,7 @@ describe('internal fields', () => {
           { name: 'note', path: 'urn:ex:note', kind: 'text', locales: ['nl'] },
         ],
       },
-      { name: 'docs' },
+      { collectionNameFor: () => 'docs' },
     );
     // Every field declares no role, so it is internal – a projection-time
     // reading device, pruned before the writer. The collection stores nothing
@@ -305,7 +305,7 @@ describe('internal fields', () => {
           },
         ],
       },
-      { name: 'docs' },
+      { collectionNameFor: () => 'docs' },
     );
     // Only the field carrying a role reaches the collection.
     expect(collection.fields).toEqual([
@@ -368,7 +368,7 @@ describe('surfaced inline references', () => {
   const definitionFor = (media: Record<string, unknown>) => {
     const creativeWork = creativeWorkWith(media);
     return buildCollectionDefinition(creativeWork, {
-      name: 'works',
+      collectionNameFor: () => 'works',
       schema: searchSchema(creativeWork, mediaObject),
     });
   };
@@ -452,7 +452,7 @@ describe('surfaced inline references', () => {
     });
     const creativeWork = creativeWorkWith({});
     const collection = buildCollectionDefinition(creativeWork, {
-      name: 'works',
+      collectionNameFor: () => 'works',
       schema: searchSchema(creativeWork, media, thumbnail),
     });
     expect(collection.fields).toEqual([
@@ -477,7 +477,9 @@ describe('surfaced inline references', () => {
     // the reference as a string the projection never writes, and every document
     // would fail to import. Fail where the collection is built instead.
     expect(() =>
-      buildCollectionDefinition(creativeWorkWith({}), { name: 'works' }),
+      buildCollectionDefinition(creativeWorkWith({}), {
+        collectionNameFor: () => 'works',
+      }),
     ).toThrow(/needs the search schema.*“media”/);
   });
 
@@ -497,7 +499,7 @@ describe('surfaced inline references', () => {
       ],
     });
     const collection = buildCollectionDefinition(creativeWork, {
-      name: 'works',
+      collectionNameFor: () => 'works',
       schema: searchSchema(creativeWork, mediaObject),
     });
     expect(collection.fields).toEqual([]);

--- a/packages/search-typesense/test/collection-name.test.ts
+++ b/packages/search-typesense/test/collection-name.test.ts
@@ -76,7 +76,7 @@ describe('buildCollectionDefinition', () => {
 
   it('lets an explicit name override the derived one', () => {
     const definition = buildCollectionDefinition(typeNamed('CreativeWork'), {
-      name: 'staging_creative_works',
+      collectionNameFor: () => 'staging_creative_works',
     });
     expect(definition.name).toBe('staging_creative_works');
   });
@@ -105,7 +105,7 @@ describe('the writers and the engine agree on a type’s collection', () => {
     const engine = createTypesenseSearchEngine(noClient, schema, {
       collections: { CreativeWork: 'staging_works' },
     });
-    const options = { name: 'staging_works' };
+    const options = { collectionNameFor: () => 'staging_works' };
 
     expect(
       new InPlaceRebuild(noClient, creativeWork, options).collectionName,

--- a/packages/search-typesense/test/generator-stability.test.ts
+++ b/packages/search-typesense/test/generator-stability.test.ts
@@ -55,7 +55,7 @@ describe('collection-definition generator stability', () => {
   it('derives a stable Typesense collection for a representative schema', () => {
     expect(
       buildCollectionDefinition(THING, {
-        name: 'things',
+        collectionNameFor: () => 'things',
         defaultSortingField: 'size',
         defaultLocale: 'nl',
         synonymSets: ['things-synonyms'],

--- a/packages/search-typesense/test/in-place-rebuild.test.ts
+++ b/packages/search-typesense/test/in-place-rebuild.test.ts
@@ -77,7 +77,7 @@ describe('InPlaceRebuild', () => {
     const writer = new InPlaceRebuild<{ id: string; title: string }>(
       client,
       objectType,
-      { name: NAME },
+      { collectionNameFor: () => NAME },
     );
 
     const run = await writer.openRun(makeRunContext([datasetA.iri.toString()]));
@@ -100,7 +100,7 @@ describe('InPlaceRebuild', () => {
     const writer = new InPlaceRebuild<{ id: string; title: string }>(
       client,
       objectType,
-      { name: NAME },
+      { collectionNameFor: () => NAME },
     );
     await seed(
       writer,
@@ -137,7 +137,7 @@ describe('InPlaceRebuild', () => {
     const writer = new InPlaceRebuild<{ id: string; title: string }>(
       client,
       objectType,
-      { name: NAME },
+      { collectionNameFor: () => NAME },
     );
     await seed(
       writer,
@@ -167,7 +167,7 @@ describe('InPlaceRebuild', () => {
     const writer = new InPlaceRebuild<{ id: string; title: string }>(
       client,
       objectType,
-      { name: NAME },
+      { collectionNameFor: () => NAME },
     );
     await seed(
       writer,
@@ -190,7 +190,7 @@ describe('InPlaceRebuild', () => {
     const writer = new InPlaceRebuild<{ id: string; title: string }>(
       client,
       objectType,
-      { name: NAME },
+      { collectionNameFor: () => NAME },
     );
     await seed(
       writer,
@@ -217,7 +217,7 @@ describe('InPlaceRebuild', () => {
     const writer = new InPlaceRebuild<{ id: string; title: string }>(
       client,
       objectType,
-      { name: NAME },
+      { collectionNameFor: () => NAME },
     );
 
     await expect(
@@ -231,7 +231,7 @@ describe('InPlaceRebuild', () => {
     const writer = new InPlaceRebuild<{ id: string; title: string }>(
       client,
       objectType,
-      { name: NAME, batchSize: 1 },
+      { collectionNameFor: () => NAME, batchSize: 1 },
     );
     await seed(writer, new Map([[datasetA, [{ id: 'a1', title: 'One' }]]]));
 
@@ -262,7 +262,7 @@ describe('InPlaceRebuild', () => {
     const writer = new InPlaceRebuild<{ id: string; title: string }>(
       client,
       objectType,
-      { name: NAME, batchSize: 1 },
+      { collectionNameFor: () => NAME, batchSize: 1 },
     );
     await seed(
       writer,
@@ -312,9 +312,10 @@ describe('InPlaceRebuild', () => {
       fields: [{ name: 'source', kind: 'keyword' }],
     };
 
-    expect(() => new InPlaceRebuild(client, clashing, { name: NAME })).toThrow(
-      /source/,
-    );
+    expect(
+      () =>
+        new InPlaceRebuild(client, clashing, { collectionNameFor: () => NAME }),
+    ).toThrow(/source/);
   });
 
   describe('a type declaring the indexed dataset', () => {
@@ -339,7 +340,7 @@ describe('InPlaceRebuild', () => {
       const writer = new InPlaceRebuild<{ id: string; title: string }>(
         client,
         withDataset,
-        { name: NAME },
+        { collectionNameFor: () => NAME },
       );
 
       const run = await writer.openRun(
@@ -366,7 +367,7 @@ describe('InPlaceRebuild', () => {
       const writer = new InPlaceRebuild<{ id: string; title: string }>(
         client,
         withDataset,
-        { name: NAME },
+        { collectionNameFor: () => NAME },
       );
       await seed(
         writer,
@@ -404,7 +405,10 @@ describe('InPlaceRebuild', () => {
       };
 
       expect(
-        () => new InPlaceRebuild(client, notFacetable, { name: NAME }),
+        () =>
+          new InPlaceRebuild(client, notFacetable, {
+            collectionNameFor: () => NAME,
+          }),
       ).toThrow(/facetable/);
     });
   });

--- a/packages/search-typesense/test/joins.test.ts
+++ b/packages/search-typesense/test/joins.test.ts
@@ -264,6 +264,30 @@ describe('buildCollectionDefinition over a joinable reference', () => {
     );
   });
 
+  it('refuses a naming that gives a join target this type’s own collection', () => {
+    // The trap in migrating off the old `name` option: `name: 'staging_works'`
+    // reads as a CONSTANT function, which now also names every peer – so the
+    // reference would point the collection at itself, Typesense would accept
+    // it, and every join through it would answer nothing.
+    expect(
+      () =>
+        new InPlaceRebuild(undefined as never, DATASET, {
+          schema: SCHEMA,
+          collectionNameFor: () => 'staging_datasets',
+        }),
+    ).toThrow(
+      /gives its join target “Publisher” the same collection “staging_datasets”/,
+    );
+    // Derived from the type it is given, the same prefix is fine.
+    expect(
+      () =>
+        new InPlaceRebuild(undefined as never, DATASET, {
+          schema: SCHEMA,
+          collectionNameFor: (type) => `staging_${deriveCollectionName(type)}`,
+        }),
+    ).not.toThrow();
+  });
+
   it('refuses to build a joinable reference with no schema to resolve it', () => {
     // Silently omitting it would build a collection that indexes and commits
     // happily and then 400s on every join query.

--- a/packages/search-typesense/test/joins.test.ts
+++ b/packages/search-typesense/test/joins.test.ts
@@ -1,0 +1,434 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Client } from 'typesense';
+import {
+  defineSearchType,
+  joinGraph,
+  searchSchema,
+  type ReferenceField,
+  type SearchQuery,
+  type SearchType,
+} from '@lde/search';
+import { buildCollectionDefinition } from '../src/collection-definition.js';
+import { buildSearchParams, type JoinTarget } from '../src/query-compiler.js';
+import { deriveCollectionName } from '../src/collection-name.js';
+import { BlueGreenRebuild } from '../src/blue-green-rebuild.js';
+import { InPlaceRebuild } from '../src/in-place-rebuild.js';
+import { createTypesenseSearchEngine } from '../src/search.js';
+import { fakeTypesenseClient } from './fake-typesense-client.js';
+import { makeRunContext, typesenseError } from './helpers.js';
+
+/** A label-source-shaped root type: indexed, and serving a `label`. */
+function labelSource(name: string, fields: SearchType['fields'] = []) {
+  return defineSearchType({
+    name,
+    class: `https://example.org/${name}`,
+    fields: [
+      {
+        name: 'label',
+        path: 'http://www.w3.org/2000/01/rdf-schema#label',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+      { name: 'country', kind: 'keyword', filterable: true, facetable: true },
+      { name: 'founded', kind: 'date', filterable: true },
+      ...fields,
+    ],
+  });
+}
+
+const joinable = (name: string, source: string): ReferenceField => ({
+  name,
+  path: `https://example.org/${name}`,
+  kind: 'reference',
+  filterable: true,
+  labelSource: source,
+  joinable: true,
+});
+
+const PUBLISHER = labelSource('Publisher');
+const DATASET = labelSource('Dataset', [joinable('publisher', 'Publisher')]);
+const CREATIVE_WORK = labelSource('CreativeWork', [
+  joinable('dataset', 'Dataset'),
+  // A reference to the same target that is NOT joinable: labels and id
+  // filtering, no engine-level join.
+  {
+    name: 'sponsor',
+    path: 'https://example.org/sponsor',
+    kind: 'reference',
+    filterable: true,
+    labelSource: 'Publisher',
+  },
+]);
+const SCHEMA = searchSchema(PUBLISHER, DATASET, CREATIVE_WORK);
+const JOINS = joinGraph(SCHEMA);
+
+/** What the engine composes: the join graph names the type, the deployment
+ *  names the collection. */
+const joinTargetFor = (
+  from: SearchType,
+  path: readonly string[],
+): JoinTarget | undefined => {
+  const target = JOINS.resolve(from, path);
+  return target === undefined
+    ? undefined
+    : { searchType: target, collection: deriveCollectionName(target) };
+};
+
+const base: SearchQuery = {
+  where: [],
+  orderBy: [],
+  limit: 20,
+  offset: 0,
+  facets: [],
+  locale: 'nl',
+};
+
+const filterFor = (query: Partial<SearchQuery>) =>
+  buildSearchParams({ ...base, ...query }, CREATIVE_WORK, { joinTargetFor })
+    .filter_by;
+
+describe('buildSearchParams over a join path', () => {
+  it('wraps the leaf in one $collection(…) per hop', () => {
+    expect(
+      filterFor({
+        where: [
+          {
+            or: [
+              {
+                on: ['dataset', 'publisher'],
+                field: 'id',
+                in: ['https://example.org/X'],
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe('$datasets($publishers(id:=[`https://example.org/X`]))');
+  });
+
+  it('compiles the leaf against the TARGET type’s declaration', () => {
+    // `country` is facetable on Publisher, so it takes the loose `:`
+    // membership; `founded` is a date, so its ISO bounds become Unix seconds –
+    // both read off the joined type, never off CreativeWork.
+    expect(
+      filterFor({
+        where: [
+          {
+            or: [
+              { on: ['dataset', 'publisher'], field: 'country', in: ['NL'] },
+            ],
+          },
+          {
+            or: [
+              {
+                on: ['dataset'],
+                field: 'founded',
+                range: { min: '1970-01-01T00:00:00Z' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe('$datasets($publishers(country:[`NL`])) && $datasets(founded:>=0)');
+  });
+
+  it('mixes a joined criterion with a local one in one disjunction', () => {
+    // The reason `on` sits on the CRITERION and not on the clause: a
+    // Filter-level path would scope the whole disjunction and make this
+    // inexpressible.
+    expect(
+      filterFor({
+        where: [
+          {
+            or: [
+              { on: ['dataset'], field: 'country', in: ['NL'] },
+              { field: 'country', in: ['BE'] },
+            ],
+          },
+        ],
+      }),
+    ).toBe('($datasets(country:[`NL`]) || country:[`BE`])');
+  });
+
+  it('passes the vacuous and unusable readings straight through the hops', () => {
+    // A joined criterion stating no constraint on the referent states none at
+    // all, so the whole clause is skipped – exactly as an unjoined one is.
+    expect(
+      filterFor({
+        where: [
+          {
+            or: [
+              { on: ['dataset'], field: 'country', in: [] },
+              { field: 'country', in: ['BE'] },
+            ],
+          },
+        ],
+      }),
+    ).toBeUndefined();
+    // A joined identity membership over no ids enumerates no referent, so it
+    // is false and drops out, leaving its sibling standing.
+    expect(
+      filterFor({
+        where: [
+          {
+            or: [
+              { on: ['dataset'], field: 'id', in: [] },
+              { field: 'country', in: ['BE'] },
+            ],
+          },
+        ],
+      }),
+    ).toBe('country:[`BE`]');
+  });
+
+  it('drops a criterion whose path does not resolve', () => {
+    // `sponsor` is a reference, but not a joinable one, so it names no
+    // collection to join through. Through the engine `assertValidQuery` has
+    // already rejected this; the compiler still must not emit garbage.
+    expect(
+      filterFor({
+        where: [
+          {
+            or: [
+              { on: ['sponsor'], field: 'country', in: ['NL'] },
+              { field: 'country', in: ['BE'] },
+            ],
+          },
+        ],
+      }),
+    ).toBe('country:[`BE`]');
+    // And with no resolver supplied at all.
+    expect(
+      buildSearchParams(
+        {
+          ...base,
+          where: [{ or: [{ on: ['dataset'], field: 'country', in: ['NL'] }] }],
+        },
+        CREATIVE_WORK,
+      ).filter_by,
+    ).toBeUndefined();
+  });
+});
+
+describe('buildCollectionDefinition over a joinable reference', () => {
+  const fieldNamed = (
+    definition: { fields?: readonly { name: string }[] },
+    name: string,
+  ) => definition.fields?.find((field) => field.name === name);
+
+  it('emits a reference to the target collection’s id, async and non-cascading', () => {
+    const definition = buildCollectionDefinition(DATASET, { schema: SCHEMA });
+    expect(fieldNamed(definition, 'publisher')).toEqual({
+      name: 'publisher',
+      type: 'string',
+      facet: false,
+      sort: false,
+      optional: true,
+      // Always `.id`: a reference matching more than one document is a 400, and
+      // `id` is the only field the schema guarantees unique.
+      reference: 'publishers.id',
+      // Documents stream per dataset, so a referent indexed after its referrer
+      // is normal; without this the referrer would be rejected and – with
+      // `throwOnFail: false` – silently dropped.
+      async_reference: true,
+      // Left at its `true` default, a sweep of departed Publisher documents
+      // would delete other sources’ Dataset documents with them.
+      cascade_delete: false,
+    });
+  });
+
+  it('leaves a non-joinable reference a plain string field', () => {
+    const definition = buildCollectionDefinition(CREATIVE_WORK, {
+      schema: SCHEMA,
+    });
+    expect(fieldNamed(definition, 'sponsor')).not.toHaveProperty('reference');
+    expect(fieldNamed(definition, 'dataset')).toHaveProperty(
+      'reference',
+      'datasets.id',
+    );
+  });
+
+  it('names the peer collection the same way it names its own', () => {
+    // What a blue/green writer needs: the fresh build must reference its
+    // peer’s FRESH collection, so one naming function covers both.
+    const definition = buildCollectionDefinition(DATASET, {
+      schema: SCHEMA,
+      collectionNameFor: (type) => `${deriveCollectionName(type)}_17`,
+    });
+    expect(definition.name).toBe('datasets_17');
+    expect(fieldNamed(definition, 'publisher')).toHaveProperty(
+      'reference',
+      'publishers_17.id',
+    );
+  });
+
+  it('refuses to build a joinable reference with no schema to resolve it', () => {
+    // Silently omitting it would build a collection that indexes and commits
+    // happily and then 400s on every join query.
+    expect(() => buildCollectionDefinition(DATASET)).toThrow(
+      /needs the search schema its joinable reference “publisher” resolves against/,
+    );
+  });
+});
+
+/**
+ * A client whose data collection either does not exist (404, so the writer
+ * creates it) or comes back with the given fields.
+ */
+function fakeClient(existingFields?: readonly Record<string, unknown>[]) {
+  const created = vi.fn().mockResolvedValue({});
+  const client = {
+    aliases: () => ({
+      retrieve: () => Promise.reject(typesenseError(404)),
+      upsert: () => Promise.resolve({}),
+    }),
+    collections: (name?: string) => {
+      if (name === undefined) {
+        return {
+          create: (definition: { name: string }) =>
+            definition.name === 'rebuild_locks'
+              ? Promise.resolve({})
+              : created(definition),
+        };
+      }
+      if (name === 'rebuild_locks') {
+        return {
+          retrieve: () => Promise.resolve({}),
+          documents: (id?: string) =>
+            id === undefined
+              ? { create: () => Promise.resolve({}) }
+              : { delete: () => Promise.resolve({}) },
+        };
+      }
+      return {
+        retrieve: () =>
+          existingFields === undefined
+            ? Promise.reject(typesenseError(404))
+            : Promise.resolve({ fields: existingFields }),
+      };
+    },
+  } as unknown as Client;
+  return { client, created };
+}
+
+describe('BlueGreenRebuild across a component', () => {
+  it('points its reference at the peer’s fresh collection, not the live alias', async () => {
+    // Decision 9 in one assertion: Typesense resolves an alias to a concrete
+    // collection at create time and keeps the concrete name, so referencing
+    // `publishers` would pin this build to the collection the peer is about to
+    // supersede. `startedAt` is shared by every writer in the run, so both
+    // sides derive the same version with no coordinator.
+    const { client, created } = fakeClient();
+    const context = makeRunContext();
+    const writer = new BlueGreenRebuild(client, DATASET, { schema: SCHEMA });
+
+    await writer.openRun(context);
+
+    const version = Date.parse(context.startedAt);
+    expect(created).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: `datasets_${version}`,
+        fields: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'publisher',
+            reference: `publishers_${version}.id`,
+          }),
+        ]),
+      }),
+    );
+    // The alias the writer keeps pointed at its newest build is unversioned.
+    expect(writer.collectionName).toBe('datasets');
+  });
+});
+
+describe('the engine compiling a join', () => {
+  it('resolves each hop to the collection that type reads', async () => {
+    const { client, performs } = fakeTypesenseClient({
+      searchResponse: { found: 0, hits: [] },
+    });
+    const engine = createTypesenseSearchEngine(client, SCHEMA, {
+      // A deployment naming a collection its own way is named that way in the
+      // join too – the graph names the type, the deployment the collection.
+      collections: { Publisher: 'orgs' },
+    });
+
+    await engine.search(CREATIVE_WORK, {
+      where: [
+        {
+          or: [
+            {
+              on: ['dataset', 'publisher'],
+              field: 'id',
+              in: ['https://example.org/X'],
+            },
+          ],
+        },
+      ],
+      orderBy: [],
+      limit: 10,
+      offset: 0,
+      facets: [],
+      locale: 'nl',
+    });
+
+    expect(performs[0][0].filter_by).toBe(
+      '$datasets($orgs(id:=[`https://example.org/X`]))',
+    );
+  });
+});
+
+describe('InPlaceRebuild against an existing collection', () => {
+  const options = { schema: SCHEMA };
+
+  it('creates the collection with its reference field when it is absent', async () => {
+    const { client, created } = fakeClient();
+    const writer = new InPlaceRebuild(client, DATASET, options);
+
+    await writer.openRun(makeRunContext());
+
+    expect(created).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'datasets',
+        fields: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'publisher',
+            reference: 'publishers.id',
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('accepts an existing collection that already carries the reference', async () => {
+    const { client } = fakeClient([
+      { name: 'publisher', reference: 'publishers.id' },
+    ]);
+    const writer = new InPlaceRebuild(client, DATASET, options);
+
+    await expect(writer.openRun(makeRunContext())).resolves.toBeDefined();
+  });
+
+  it('fails loudly on an existing collection with no reference field', async () => {
+    // Without this the run would index and commit perfectly happily, and only
+    // then 400 on every join query: the values are there, the reference is
+    // not. `ensureCollectionExists` only creates on a 404, so nothing else
+    // would ever notice.
+    const { client } = fakeClient([{ name: 'publisher' }]);
+    const writer = new InPlaceRebuild(client, DATASET, options);
+
+    await expect(writer.openRun(makeRunContext())).rejects.toThrow(
+      /exists without the reference field\(s\) “publisher” → “publishers.id”.*drop “datasets”/s,
+    );
+  });
+
+  it('leaves a reference-free type alone', async () => {
+    // Scoped to reference fields only: every other schema difference is
+    // self-correcting, and general drift detection is a feature of its own.
+    const { client } = fakeClient([{ name: 'label_nl' }]);
+    const writer = new InPlaceRebuild(client, PUBLISHER, options);
+
+    await expect(writer.openRun(makeRunContext())).resolves.toBeDefined();
+  });
+});

--- a/packages/search-typesense/test/joins.test.ts
+++ b/packages/search-typesense/test/joins.test.ts
@@ -288,6 +288,40 @@ describe('buildCollectionDefinition over a joinable reference', () => {
     ).not.toThrow();
   });
 
+  it('stores a joinable reference that declares no other role', () => {
+    // `joinable` IS a role: an engine can only join through a value it stores,
+    // so the field must not be pruned as an Internal Field. Otherwise the edge
+    // resolves, the query validates and the compiler emits `$publishers(…)`
+    // against a collection that never had the column.
+    const joinOnly = labelSource('JoinOnly', [
+      {
+        name: 'publisher',
+        path: 'https://example.org/publisher',
+        kind: 'reference',
+        labelSource: 'Publisher',
+        joinable: true,
+      },
+    ]);
+    const definition = buildCollectionDefinition(joinOnly, {
+      schema: searchSchema(PUBLISHER, joinOnly),
+    });
+    expect(
+      definition.fields?.find((field) => field.name === 'publisher'),
+    ).toMatchObject({ reference: 'publishers.id' });
+  });
+
+  it('tells a lookalike type apart from a missing schema', () => {
+    // A schema WAS passed; what is wrong is that this is not the declaration
+    // the schema was built from. Repeating “pass the schema” would send the
+    // caller to do what they already did.
+    expect(() =>
+      buildCollectionDefinition(
+        { ...DATASET, fields: [...DATASET.fields] },
+        { schema: SCHEMA },
+      ),
+    ).toThrow(/does not declare this exact type/);
+  });
+
   it('refuses to build a joinable reference with no schema to resolve it', () => {
     // Silently omitting it would build a collection that indexes and commits
     // happily and then 400s on every join query.

--- a/packages/search-typesense/test/rebuild-error-paths.test.ts
+++ b/packages/search-typesense/test/rebuild-error-paths.test.ts
@@ -81,7 +81,7 @@ describe('BlueGreenRebuild error paths', () => {
       createDataCollection: () => Promise.reject(typesenseError(500)),
     });
     const writer = new BlueGreenRebuild(client, searchType, {
-      name: 'datasets',
+      collectionNameFor: () => 'datasets',
     });
 
     await expect(writer.openRun(makeRunContext())).rejects.toThrow('HTTP 500');
@@ -94,7 +94,7 @@ describe('BlueGreenRebuild error paths', () => {
     // post-swap lock release then fails.
     releasedLocks.mockRejectedValue(typesenseError(500));
     const writer = new BlueGreenRebuild(client, searchType, {
-      name: 'datasets',
+      collectionNameFor: () => 'datasets',
     });
 
     const run = await writer.openRun(makeRunContext());
@@ -111,7 +111,9 @@ describe('InPlaceRebuild error paths', () => {
     const { client, releasedLocks } = fakeClient({
       retrieveDataCollection: () => Promise.reject(typesenseError(500)),
     });
-    const writer = new InPlaceRebuild(client, searchType, { name: 'objects' });
+    const writer = new InPlaceRebuild(client, searchType, {
+      collectionNameFor: () => 'objects',
+    });
 
     await expect(writer.openRun(makeRunContext())).rejects.toThrow('HTTP 500');
     expect(releasedLocks).toHaveBeenCalledOnce();
@@ -130,7 +132,7 @@ describe('InPlaceRebuild error paths', () => {
   it('sweeps when the source count is exactly the cap (not truncated)', async () => {
     const { client, deletedFilters } = fakeClient({ facetCounts: sources(2) });
     const writer = new InPlaceRebuild(client, searchType, {
-      name: 'objects',
+      collectionNameFor: () => 'objects',
       maxSweepableSources: 2,
     });
 
@@ -143,7 +145,7 @@ describe('InPlaceRebuild error paths', () => {
   it('refuses a membership sweep when the facet is truncated (one over the cap)', async () => {
     const { client, deletedFilters } = fakeClient({ facetCounts: sources(3) });
     const writer = new InPlaceRebuild(client, searchType, {
-      name: 'objects',
+      collectionNameFor: () => 'objects',
       maxSweepableSources: 2,
     });
 

--- a/packages/search-typesense/test/rebuild-support.test.ts
+++ b/packages/search-typesense/test/rebuild-support.test.ts
@@ -28,21 +28,21 @@ describe('resolveRebuildOptions', () => {
 
   it('applies the shared defaults and keeps the residual schema options', () => {
     const resolved = resolveRebuildOptions(OBJECT, {
-      name: 'objects',
+      collectionNameFor: () => 'objects',
       defaultSortingField: 'rank',
     });
 
     expect(resolved.batchSize).toBe(1000);
     expect(resolved.lockTtlMs).toBe(600_000);
-    expect(resolved.definitionOptions).toEqual({
-      name: 'objects',
-      defaultSortingField: 'rank',
-    });
+    expect(resolved.definitionOptions.defaultSortingField).toBe('rank');
+    expect(resolved.definitionOptions.collectionNameFor(OBJECT)).toBe(
+      'objects',
+    );
   });
 
   it('honours explicit overrides', () => {
     const resolved = resolveRebuildOptions(OBJECT, {
-      name: 'objects',
+      collectionNameFor: () => 'objects',
       batchSize: 50,
       lockTtlMs: 1_000,
     });
@@ -56,11 +56,20 @@ describe('resolveRebuildOptions', () => {
     });
 
     // The definition must be built for the very collection the writer talks
-    // to, so the derived name is resolved here rather than left undefined.
-    expect(resolved.definitionOptions).toEqual({
-      name: 'museum_objects',
-      defaultSortingField: 'rank',
-    });
+    // to, so the naming is resolved to a total function here rather than left
+    // undefined – and it names a PEER as readily as this type, which is what a
+    // join’s reference field needs.
+    expect(resolved.definitionOptions.defaultSortingField).toBe('rank');
+    expect(resolved.definitionOptions.collectionNameFor(OBJECT)).toBe(
+      'museum_objects',
+    );
+    expect(
+      resolved.definitionOptions.collectionNameFor({
+        name: 'Publisher',
+        class: 'https://example.org/Publisher',
+        fields: [],
+      }),
+    ).toBe('publishers');
   });
 });
 

--- a/packages/search-typesense/test/reference-backfill.integration.test.ts
+++ b/packages/search-typesense/test/reference-backfill.integration.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from 'typesense';
+import { TypesenseContainer } from './typesense-container.js';
+
+/**
+ * The engine guarantee the whole join feature rests on, pinned against a real
+ * Typesense: a reference written before its referent exists is **accepted** and
+ * later **resolved**, rather than rejected with a 400.
+ *
+ * It has to be checked here rather than reasoned about, because it is not ours
+ * to fix and it is the assumption most likely to move on an engine upgrade –
+ * documents stream per dataset, so a referrer arriving first is normal. Without
+ * `async_reference` the import would fail, and `throwOnFail: false` would turn
+ * that into silently dropped documents.
+ *
+ * The concurrency caveat is deliberately NOT asserted here: when the referring
+ * and the referenced collection are imported at the same time, 30.2 can lose a
+ * reference permanently, which is why an indexing run does not yet make a
+ * one-run guarantee. See ADR 19.
+ */
+describe('async_reference back-fill', () => {
+  const container = new TypesenseContainer();
+  let client: Client;
+
+  beforeAll(async () => {
+    client = await container.start();
+  }, 120_000);
+
+  afterAll(async () => {
+    await container.stop();
+  });
+
+  it('accepts a dangling reference and resolves it when the referent lands', async () => {
+    await client.collections().create({
+      name: 'people',
+      fields: [{ name: 'name', type: 'string' }],
+    });
+    await client.collections().create({
+      name: 'books',
+      fields: [
+        { name: 'name', type: 'string' },
+        {
+          name: 'author',
+          type: 'string',
+          reference: 'people.id',
+          async_reference: true,
+          cascade_delete: false,
+        },
+      ],
+    });
+
+    // Referrer first: at this moment `p1` does not exist. Without
+    // `async_reference` this import is a 400.
+    const [outcome] = await client
+      .collections('books')
+      .documents()
+      .import([{ id: 'b1', name: 'Book', author: 'p1' }], { action: 'upsert' });
+    expect(outcome).toMatchObject({ success: true });
+
+    await client
+      .collections('people')
+      .documents()
+      .import([{ id: 'p1', name: 'Ann' }], { action: 'upsert' });
+
+    const { results } = (await client.multiSearch.perform({
+      searches: [
+        {
+          collection: 'books',
+          q: '*',
+          query_by: 'name',
+          filter_by: '$people(name:=`Ann`)',
+        },
+      ],
+    })) as { results: { found?: number }[] };
+    expect(results[0]?.found).toBe(1);
+  }, 60_000);
+});

--- a/packages/search-typesense/test/search-engine.test.ts
+++ b/packages/search-typesense/test/search-engine.test.ts
@@ -193,18 +193,18 @@ describe('createTypesenseSearchEngine (integration)', () => {
     // Typesense accepts the generated schema (stemming, locales, int64, …).
     await client.collections().create(
       buildCollectionDefinition(datasetSchema, {
-        name: 'datasets',
+        collectionNameFor: () => 'datasets',
         defaultSortingField: 'statusRank',
         defaultLocale: 'nl',
         schema: fullSchema,
       }),
     );
     // The label source's collection comes from the same declarative source.
-    await client
-      .collections()
-      .create(
-        buildCollectionDefinition(organizationSchema, { name: 'labels' }),
-      );
+    await client.collections().create(
+      buildCollectionDefinition(organizationSchema, {
+        collectionNameFor: () => 'labels',
+      }),
+    );
     await client
       .collections('datasets')
       .documents()

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these – see AGENTS.md.
-          functions: 98.79,
-          lines: 99.17,
-          branches: 95.18,
-          statements: 99.19,
+          functions: 98.86,
+          lines: 99.22,
+          branches: 95.46,
+          statements: 99.24,
         },
       },
     },

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -21,7 +21,7 @@ export default mergeConfig(
           functions: 98.87,
           lines: 99.24,
           branches: 95.53,
-          statements: 99.25,
+          statements: 99.26,
         },
       },
     },

--- a/packages/search-typesense/vite.config.ts
+++ b/packages/search-typesense/vite.config.ts
@@ -18,10 +18,10 @@ export default mergeConfig(
         thresholds: {
           // Honest full-suite baseline (autoUpdate raises it from here); a
           // partial vitest run must never rewrite these – see AGENTS.md.
-          functions: 98.86,
-          lines: 99.22,
-          branches: 95.46,
-          statements: 99.24,
+          functions: 98.87,
+          lines: 99.24,
+          branches: 95.53,
+          statements: 99.25,
         },
       },
     },

--- a/packages/search/src/adapter.ts
+++ b/packages/search/src/adapter.ts
@@ -40,6 +40,8 @@ export {
 } from './schema.js';
 export type { PhysicalFields } from './schema.js';
 export { physicalNameTokens } from './physical-name.js';
+export { joinGraph, MAX_JOIN_DEPTH } from './join-graph.js';
+export type { JoinGraph } from './join-graph.js';
 export {
   filterOperatorFor,
   filterOperator,

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -46,13 +46,25 @@ export type {
   ProjectionValue,
 } from './schema.js';
 
+// The declared join edges between root types: which types a query can filter
+// across, and which collections must be rebuilt together. Built eagerly by
+// `searchSchema`, so declaring a schema is what validates the joins.
+export { joinGraph, MAX_JOIN_DEPTH } from './join-graph.js';
+export type { JoinGraph } from './join-graph.js';
+
 // Engine- and protocol-neutral query IR (what a `queryDefaults` policy or an
 // in-process caller writes).
 // `filterOn` builds the ordinary one-criterion clause – the shape a consumer
 // policy (`queryDefaults`) appends to `where`, so it belongs on the authoring
 // surface and not only on the adapter one.
 export { filterOn } from './query.js';
-export type { SearchQuery, Filter, Criterion, Sort } from './query.js';
+export type {
+  SearchQuery,
+  Filter,
+  Criterion,
+  CriterionBase,
+  Sort,
+} from './query.js';
 
 // Engine port + the logical result document returned across it. An engine is
 // bound to the whole SearchSchema at construction by its adapter factory.

--- a/packages/search/src/join-graph.ts
+++ b/packages/search/src/join-graph.ts
@@ -1,0 +1,283 @@
+import {
+  referenceFields,
+  type ReferenceField,
+  type RootType,
+  type SearchSchema,
+  type SearchType,
+} from './schema.js';
+
+/**
+ * The deepest `on` path a query may state: `dataset → publisher → country` is
+ * three hops. Fixed rather than configurable, and enforced in the query IR
+ * ({@link validateQuery}) rather than in an adapter, so a later REST surface
+ * inherits the same ceiling. Typesense imposes no limit of its own, and the
+ * GraphQL max-depth guard counts selection sets rather than input nesting, so
+ * without this a `where` could nest a join arbitrarily deep and each hop is an
+ * extra collection scan.
+ */
+export const MAX_JOIN_DEPTH = 3;
+
+/**
+ * The declared join edges of a {@link SearchSchema}: which Root Types are
+ * reachable from which through {@link ReferenceField.joinable} references, and
+ * which of them must be rebuilt together.
+ *
+ * Two members, because a consumer needs exactly two answers. A **query**
+ * compiler asks *what does this path of field names reach* ({@link
+ * JoinGraph.resolve}); a **writer** asks *which collections come into existence
+ * together* ({@link JoinGraph.components}). Everything else – deriving the
+ * edges from `joinable` + `labelSource`, the one-edge-per-target rule, cycle
+ * rejection, the depth cap, and the asymmetry between undirected membership and
+ * directed creation order – is hidden here, so no consumer restates it.
+ *
+ * `resolve` returns a {@link RootType}, never a collection name: how a type is
+ * named in an engine is engine- and deployment-specific and stays in the
+ * adapter.
+ */
+export interface JoinGraph {
+  /**
+   * The **join components**: groups of Root Types that reference one another,
+   * directly or transitively, and therefore share a rebuild
+   * ([ADR 19](../../docs/decisions/0019-filter-across-collections-through-declared-joins.md)).
+   * Every Root Type appears in exactly one; a type with no joinable edge is a
+   * singleton and keeps per-collection isolation exactly as before.
+   *
+   * Membership is the **undirected** connected component – a referrer and its
+   * referent must rebuild together whichever way the edge points – while the
+   * order **within** a component is the **directed** topological sort,
+   * referenced first. That asymmetry is load-bearing: an engine cannot create a
+   * collection whose reference names a collection that does not exist yet, so
+   * the referent’s collection must be opened first.
+   */
+  readonly components: readonly (readonly RootType[])[];
+  /**
+   * The Root Type a path of joinable field names reaches from `from`, or
+   * `undefined` when the path does not resolve – an unknown field name, a
+   * reference that is not `joinable`, or a path deeper than
+   * {@link MAX_JOIN_DEPTH}. An empty path resolves to `from` itself only when
+   * `from` is a Root Type; a Reference Type has no collection to join to.
+   */
+  resolve(from: SearchType, path: readonly string[]): RootType | undefined;
+}
+
+/**
+ * The join graph of a {@link SearchSchema}, built once per schema and cached:
+ * {@link searchSchema} builds it eagerly, so a schema whose joins do not hold
+ * up – two joinable fields at one target, a cycle – fails at startup rather
+ * than on the first query or the first rebuild.
+ *
+ * Calling it again for the same schema returns the same graph.
+ */
+export function joinGraph(schema: SearchSchema): JoinGraph {
+  const cached = graphsBySchema.get(schema);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const built = buildJoinGraph(schema);
+  graphsBySchema.set(schema, built);
+  return built;
+}
+
+/** One graph per schema, held beside it rather than on it, so a
+ *  {@link SearchSchema} stays a plain branded `Map`. */
+const graphsBySchema = new WeakMap<SearchSchema, JoinGraph>();
+
+/** One declared join edge: the field it is declared on and the Root Type it
+ *  points at. */
+interface JoinEdge {
+  readonly field: ReferenceField;
+  readonly target: RootType;
+}
+
+/** Every Root Type’s outgoing edges, keyed by class IRI then by field name. */
+type EdgeIndex = ReadonlyMap<string, ReadonlyMap<string, JoinEdge>>;
+
+/** The edges leaving one Root Type, keyed by field name. Total by
+ *  construction: the index is built with an entry for EVERY Root Type, an empty
+ *  map where a type declares none, so no caller needs a fallback it can never
+ *  take. */
+function edgesOf(
+  edges: EdgeIndex,
+  searchType: RootType,
+): ReadonlyMap<string, JoinEdge> {
+  return edges.get(searchType.class) as ReadonlyMap<string, JoinEdge>;
+}
+
+/** The edges leaving one Root Type, in declaration order. */
+function edgesFrom(edges: EdgeIndex, searchType: RootType): Iterable<JoinEdge> {
+  return edgesOf(edges, searchType).values();
+}
+
+/**
+ * Derive, validate and index the edges. Throws – rather than reporting issues –
+ * because it is called from {@link searchSchema}, whose contract is that an
+ * invalid declaration fails at startup.
+ */
+function buildJoinGraph(schema: SearchSchema): JoinGraph {
+  const rootTypes = [...schema.values()];
+  const byName = new Map(rootTypes.map((type) => [type.name, type]));
+  const edges = new Map<string, ReadonlyMap<string, JoinEdge>>();
+  for (const searchType of rootTypes) {
+    edges.set(searchType.class, declaredEdges(searchType, byName));
+  }
+  assertAcyclic(rootTypes, edges);
+  return {
+    components: componentsOf(rootTypes, edges),
+    resolve(from: SearchType, path: readonly string[]) {
+      if (path.length > MAX_JOIN_DEPTH) {
+        return undefined;
+      }
+      // A Reference Type is never indexed, so it has no collection to join
+      // from; only a member of this schema’s class map can start a path.
+      const start =
+        from.class === undefined ? undefined : schema.get(from.class);
+      if (start === undefined || start !== from) {
+        return undefined;
+      }
+      let current: RootType = start;
+      for (const name of path) {
+        const edge: JoinEdge | undefined = edgesOf(edges, current).get(name);
+        if (edge === undefined) {
+          return undefined;
+        }
+        current = edge.target;
+      }
+      return current;
+    },
+  };
+}
+
+/**
+ * The joinable edges one Root Type declares, keyed by field name.
+ *
+ * Enforces the **one edge per (type, target)** rule here rather than in a
+ * consumer: a Typesense join addresses the referent by *collection*, not by
+ * field, so a second reference to the same collection is accepted, indexed and
+ * then unreachable – the engine resolves every join through the first field
+ * that matched and silently ignores the rest
+ * ({@link https://github.com/typesense/typesense/issues/3021}). `publisher` and
+ * `creator` both resolving to `Organization` is the ordinary case, so it must
+ * be a declaration error naming both fields rather than a surprise at query
+ * time.
+ */
+function declaredEdges(
+  searchType: RootType,
+  byName: ReadonlyMap<string, RootType>,
+): ReadonlyMap<string, JoinEdge> {
+  const edges = new Map<string, JoinEdge>();
+  const claimedBy = new Map<string, string>();
+  for (const field of referenceFields(searchType)) {
+    if (field.joinable !== true) {
+      continue;
+    }
+    // Both lookups always hit: `validateSearchType` rejects `joinable` without
+    // a `labelSource`, and a label source is always an indexed Root Type – it
+    // must declare a `searchable` `label` field, which a Reference Type cannot
+    // carry (a nested field is `output` only). So a joinable edge always has a
+    // collection at the far end without a rule of its own.
+    const target = byName.get(field.labelSource as string) as RootType;
+    const claimed = claimedBy.get(target.name);
+    if (claimed !== undefined) {
+      throw new Error(
+        `Search type “${searchType.name}” declares two joinable references to “${target.name}” (“${claimed}” and “${field.name}”); an engine addresses a join by collection, not by field, so only one reference per target can be joinable. Drop “joinable” from one of them – it keeps its labels, facets and id filtering.`,
+      );
+    }
+    claimedBy.set(target.name, field.name);
+    edges.set(field.name, { field, target });
+  }
+  return edges;
+}
+
+/**
+ * Reject a cycle in the **directed** join graph. A cycle would make the
+ * topological creation order below undefinable – there is no collection to
+ * create first – and, with the component as the unit of rebuild, no order in
+ * which a component’s collections could come into existence at all.
+ */
+function assertAcyclic(
+  rootTypes: readonly RootType[],
+  edges: ReadonlyMap<string, ReadonlyMap<string, JoinEdge>>,
+): void {
+  const done = new Set<string>();
+  const visit = (searchType: RootType, onPath: readonly RootType[]): void => {
+    if (onPath.some((ancestor) => ancestor.class === searchType.class)) {
+      const cycle = [...onPath, searchType]
+        .map((type) => `“${type.name}”`)
+        .join(' → ');
+      throw new Error(
+        `Join cycle ${cycle}; the joinable references between search types must be acyclic, so a component’s collections have an order to be created in.`,
+      );
+    }
+    if (done.has(searchType.class)) {
+      return;
+    }
+    const extended = [...onPath, searchType];
+    for (const edge of edgesFrom(edges, searchType)) {
+      visit(edge.target, extended);
+    }
+    done.add(searchType.class);
+  };
+  for (const searchType of rootTypes) {
+    visit(searchType, []);
+  }
+}
+
+/**
+ * Partition the Root Types into join components, each topologically ordered.
+ *
+ * Membership is the undirected connected component (union-find over the
+ * edges); the order within one is a depth-first topological sort over the
+ * directed edges, so a type is emitted only after everything it references.
+ * Components come out in declaration order of their first member, so a schema’s
+ * rebuild order is stable across runs.
+ */
+function componentsOf(
+  rootTypes: readonly RootType[],
+  edges: ReadonlyMap<string, ReadonlyMap<string, JoinEdge>>,
+): readonly (readonly RootType[])[] {
+  const parent = new Map(rootTypes.map((type) => [type.class, type.class]));
+  const find = (iri: string): string => {
+    let root = iri;
+    while (parent.get(root) !== root) {
+      root = parent.get(root) as string;
+    }
+    return root;
+  };
+  for (const searchType of rootTypes) {
+    for (const edge of edgesFrom(edges, searchType)) {
+      parent.set(find(searchType.class), find(edge.target.class));
+    }
+  }
+  const members = new Map<string, RootType[]>();
+  for (const searchType of rootTypes) {
+    const root = find(searchType.class);
+    members.set(root, [...(members.get(root) ?? []), searchType]);
+  }
+  return [...members.values()].map((component) =>
+    topologicallyOrdered(component, edges),
+  );
+}
+
+/** One component’s members, everything a type references before the type
+ *  itself. Terminates because {@link assertAcyclic} ran first. */
+function topologicallyOrdered(
+  component: readonly RootType[],
+  edges: ReadonlyMap<string, ReadonlyMap<string, JoinEdge>>,
+): readonly RootType[] {
+  const ordered: RootType[] = [];
+  const emitted = new Set<string>();
+  const visit = (searchType: RootType): void => {
+    if (emitted.has(searchType.class)) {
+      return;
+    }
+    emitted.add(searchType.class);
+    for (const edge of edgesFrom(edges, searchType)) {
+      visit(edge.target);
+    }
+    ordered.push(searchType);
+  };
+  for (const searchType of component) {
+    visit(searchType);
+  }
+  return ordered;
+}

--- a/packages/search/src/query.ts
+++ b/packages/search/src/query.ts
@@ -4,6 +4,7 @@ import {
   ID_FIELD,
   type SearchType,
 } from './schema.js';
+import { MAX_JOIN_DEPTH, type JoinGraph } from './join-graph.js';
 
 /**
  * The engine- and protocol-neutral query IR. Every API surface compiles its
@@ -28,6 +29,36 @@ export interface SearchQuery {
 }
 
 /**
+ * What every {@link Criterion} carries, whatever its operator: the field it
+ * constrains, and – for a criterion that constrains a *joined* document rather
+ * than this one – the path of joinable references to walk to reach it.
+ */
+export interface CriterionBase {
+  /** The logical field name, on the type the {@link CriterionBase.on} path
+   *  reaches (or on the searched type when there is none). */
+  readonly field: string;
+  /**
+   * A **join path**: the names of the {@link ReferenceField.joinable}
+   * references to follow, in order, to the type this criterion constrains.
+   * `['dataset', 'publisher']` on a `CreativeWork` criterion means *the
+   * publisher of the dataset this work belongs to*. Omitted (or empty) for the
+   * ordinary case: the criterion constrains the searched type itself.
+   *
+   * A path, deliberately, and not boolean structure – so the criterion stays an
+   * **atom** and `where` stays the flat conjunction of disjunctions
+   * [ADR 18](../../docs/decisions/0018-filter-across-several-fields-with-one-clause.md)
+   * made it. `on` sits on the criterion rather than on the {@link Filter} for
+   * the same reason a criterion carries its own operator: a `Filter`-level
+   * `on` would scope the whole disjunction and make
+   * `“published by X, or titled Y”` inexpressible.
+   *
+   * Capped at {@link MAX_JOIN_DEPTH} hops and resolved by
+   * {@link validateQuery} against the schema’s {@link JoinGraph}.
+   */
+  readonly on?: readonly string[];
+}
+
+/**
  * One criterion on one field. The operator is fixed by that field’s
  * {@link FieldKind} ({@link filterOperatorFor}): keyword/reference use `in` (OR
  * within the value list), the numeric/date kinds use an inclusive `range`,
@@ -36,18 +67,19 @@ export interface SearchQuery {
  * Criteria are the atoms a {@link Filter} is built from, so each carries its own
  * field AND its own operator: one clause may range over a `reference` and a
  * `keyword` field at once, and each field is constrained the way its kind
- * allows.
+ * allows. Each equally carries its own {@link CriterionBase.on} join path, so
+ * one clause may mix a condition on this document with one on a joined
+ * document.
  */
 export type Criterion =
-  | { readonly field: string; readonly in: readonly string[] }
-  | {
-      readonly field: string;
+  | (CriterionBase & { readonly in: readonly string[] })
+  | (CriterionBase & {
       readonly range: {
         readonly min?: number | string;
         readonly max?: number | string;
       };
-    }
-  | { readonly field: string; readonly is: boolean };
+    })
+  | (CriterionBase & { readonly is: boolean });
 
 /**
  * One `where` clause: a disjunction, matching a document that satisfies **any**
@@ -109,6 +141,10 @@ export function filterOn(criterion: Criterion): Filter {
  * is a disjunction that happens to include identity, not an enumeration of
  * wanted documents, so it stays the vacuous no-op every other empty `in` is.
  *
+ * A joined identity clause (`{ on: […], field: 'id', in: [] }`) reads the same
+ * way one hop out: it enumerates the *referents* wanted, and no referent means
+ * no document can match through that edge.
+ *
  * An adapter MUST answer an unsatisfiable query with an empty result rather
  * than dispatching it.
  */
@@ -138,7 +174,23 @@ export interface QueryIssue {
   readonly part: 'where' | 'facets' | 'orderBy';
   readonly field: string;
   readonly reason:
-    'unknown-field' | 'not-filterable' | 'operator-mismatch' | 'not-facetable';
+    | 'unknown-field'
+    | 'not-filterable'
+    | 'operator-mismatch'
+    | 'not-facetable'
+    /** The criterion’s `on` path is longer than {@link MAX_JOIN_DEPTH}. */
+    | 'join-too-deep'
+    /** The `on` path does not resolve: a name that is not a field, a reference
+     *  that is not `joinable`, or no join graph to resolve it against. */
+    | 'unknown-join';
+}
+
+/** The `field` a joined issue is reported under: the path and the leaf name
+ *  together, so a message says which hop and which field, not just which
+ *  field. `dataset.publisher.id` reads the way the criterion was written. */
+function issueField(criterion: Criterion): string {
+  const on = criterion.on ?? [];
+  return on.length === 0 ? criterion.field : [...on, criterion.field].join('.');
 }
 
 /**
@@ -152,6 +204,15 @@ export interface QueryIssue {
  * checks declaration only, not the `sortable` flag: that flag means *publicly
  * selectable*, and a deployment policy may sort on a private tie-break field.
  *
+ * A criterion carrying an {@link CriterionBase.on} join path is checked against
+ * the type that path reaches instead: the path must be at most
+ * {@link MAX_JOIN_DEPTH} hops (`join-too-deep`) and must resolve through
+ * `joins` (`unknown-join`), and the leaf field must then be filterable on the
+ * *target* type. The cap lives here, in the IR, rather than in an adapter or a
+ * surface, so every surface inherits it. `joins` is optional because a query
+ * with no join path needs none; a joined criterion validated without one is an
+ * `unknown-join`, never a silently unchecked filter.
+ *
  * This is the port’s always-on guard: every {@link SearchEngine} adapter MUST
  * reject a query with issues ({@link assertValidQuery}) instead of passing
  * garbage to its engine, so validation holds for every caller – including
@@ -160,6 +221,7 @@ export interface QueryIssue {
 export function validateQuery(
   query: SearchQuery,
   searchType: SearchType,
+  joins?: JoinGraph,
 ): readonly QueryIssue[] {
   const issues: QueryIssue[] = [];
   for (const filter of query.where) {
@@ -170,6 +232,25 @@ export function validateQuery(
     // a `reference` membership with a `date` range without either being wrong.
     for (const criterion of filter.or) {
       const name = criterion.field;
+      const field = issueField(criterion);
+      // A criterion may constrain a JOINED document, and then every rule below
+      // is about the type its `on` path reaches, not about the searched one.
+      // Resolving the path needs the schema’s join graph, so a caller that
+      // supplied none cannot serve a joined criterion at all.
+      const on = criterion.on ?? [];
+      let constrained = searchType;
+      if (on.length > 0) {
+        if (on.length > MAX_JOIN_DEPTH) {
+          issues.push({ part: 'where', field, reason: 'join-too-deep' });
+          continue;
+        }
+        const target = joins?.resolve(searchType, on);
+        if (target === undefined) {
+          issues.push({ part: 'where', field, reason: 'unknown-join' });
+          continue;
+        }
+        constrained = target;
+      }
       // `id` is filterable on every type without being declared by any: it is
       // the document’s IRI, so the lookup exists wherever documents do.
       // Membership only – an IRI has no range and no truth value.
@@ -177,21 +258,23 @@ export function validateQuery(
         if (filterOperator(criterion) !== 'in') {
           issues.push({
             part: 'where',
-            field: name,
+            field,
             reason: 'operator-mismatch',
           });
         }
         continue;
       }
-      const field = fieldNamed(searchType, name);
-      if (field === undefined) {
-        issues.push({ part: 'where', field: name, reason: 'unknown-field' });
-      } else if (field.filterable !== true) {
-        issues.push({ part: 'where', field: name, reason: 'not-filterable' });
-      } else if (filterOperatorFor(field.kind) !== filterOperator(criterion)) {
+      const declared = fieldNamed(constrained, name);
+      if (declared === undefined) {
+        issues.push({ part: 'where', field, reason: 'unknown-field' });
+      } else if (declared.filterable !== true) {
+        issues.push({ part: 'where', field, reason: 'not-filterable' });
+      } else if (
+        filterOperatorFor(declared.kind) !== filterOperator(criterion)
+      ) {
         issues.push({
           part: 'where',
-          field: name,
+          field,
           reason: 'operator-mismatch',
         });
       }
@@ -225,8 +308,9 @@ export function validateQuery(
 export function assertValidQuery(
   query: SearchQuery,
   searchType: SearchType,
+  joins?: JoinGraph,
 ): void {
-  const issues = validateQuery(query, searchType);
+  const issues = validateQuery(query, searchType, joins);
   if (issues.length > 0) {
     const detail = issues
       .map((issue) => `${issue.part}: “${issue.field}” (${issue.reason})`)

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -1,4 +1,5 @@
 import type { ProjectedNode, ProjectionContext } from './project.js';
+import { joinGraph } from './join-graph.js';
 
 /**
  * The engine-neutral kind of a queryable field. It drives every downstream
@@ -216,6 +217,28 @@ export interface ReferenceField extends SearchFieldBase, Searchable {
    * resolution.
    */
   readonly labelSource?: string;
+  /**
+   * Turn this reference into an **engine-level join**, so a query can filter
+   * this type by a condition on the referent – `“every object published by
+   * institution X”` in one round-trip instead of two. Valid only alongside
+   * {@link ReferenceField.labelSource}, which already asserts that this
+   * field’s values are ids of documents in that type’s collection – exactly
+   * the fact a join needs.
+   *
+   * A capability flag in the vocabulary of `filterable`/`facetable`/`sortable`,
+   * and deliberately not derived from `labelSource`: an engine may refuse to
+   * index a mutual reference, so auto-deriving would make an existing schema
+   * silently lose a field. A `labelSource` added for display therefore costs
+   * nothing it does not cost today; only a `joinable` edge pays the
+   * component-scoped rebuild coupling.
+   *
+   * Never on an `inline` reference: that carries its referent as a nested
+   * object rather than as an id an engine can point a reference field at.
+   *
+   * At most ONE joinable field per (type, label source) – see
+   * {@link joinGraph}.
+   */
+  readonly joinable?: boolean;
   /**
    * The referenced entity’s shape and how much of it to carry. Required when
    * the field is `output` – the strategy is what decides the output shape, so
@@ -444,7 +467,8 @@ function isRootType(searchType: SearchType): searchType is RootType {
  *
  * Every declaration is validated ({@link assertValidSearchType}) – the
  * declaration-time counterpart of the port’s `assertValidQuery` – and the
- * schema-wide invariants are enforced: no two Root Types may share a `class` IRI
+ * schema-wide invariants are enforced – including the join rules, by building
+ * the {@link joinGraph} eagerly: no two Root Types may share a `class` IRI
  * (they would silently overwrite each other in the map) and no two types may
  * share a `name` (names key the API surfaces, across Root and Reference Types
  * alike). Every inline reference must resolve to a declared Reference Type, and
@@ -489,6 +513,12 @@ export function searchSchema<const Types extends readonly SearchType[]>(
       .map((searchType) => [searchType.class, searchType]),
   ) as unknown as SearchSchema<Types>;
   referenceTypesBySchema.set(schema, referenceTypes);
+  // Build the join graph eagerly and discard it: it is cached per schema, and
+  // building it is what enforces the schema-wide join rules (one joinable
+  // reference per target, every target an indexed Root Type, no cycles). A
+  // schema whose joins do not hold up therefore fails HERE, not on the first
+  // query or – worse – halfway through the first rebuild.
+  joinGraph(schema);
   return schema;
 }
 
@@ -815,6 +845,8 @@ export interface SearchTypeIssue {
     | 'duplicate-projection-value'
     | 'text-not-filterable'
     | 'text-not-facetable'
+    | 'joinable-not-allowed'
+    | 'joinable-without-label-source'
     | 'reserved-field-name';
 }
 
@@ -900,6 +932,11 @@ const LOCALE_PATTERN = /^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$/;
  *   reserved name↔locale separator);
  * - a `reference` field that is `output` declares `ref` (the API surfaces
  *   need the reference type name); `ref` on any other kind is meaningless;
+ * - `joinable` only on a `reference` field, and only alongside a `labelSource`
+ *   – the join addresses the referent’s collection, which is the one the label
+ *   source names, so without it the flag states an edge to nowhere. The
+ *   schema-wide half of the rule (at most one joinable field per (type, label
+ *   source), no cycles) is {@link joinGraph}’s;
  * - a `text` field declares at least one locale (`und` = untagged; projection and
  *   result reconstruction have no representation for unlocalized text – use
  *   `keyword` for untagged strings); `locales` on any other kind is
@@ -962,8 +999,18 @@ export function validateSearchType(
       if (field.output === true && field.ref === undefined) {
         issue('missing-ref');
       }
-    } else if (field.ref !== undefined) {
-      issue('ref-not-allowed');
+      // A join addresses the referent’s collection, which is the collection the
+      // label source names: without one the flag states an edge to nowhere.
+      if (field.joinable === true && field.labelSource === undefined) {
+        issue('joinable-without-label-source');
+      }
+    } else {
+      if (field.ref !== undefined) {
+        issue('ref-not-allowed');
+      }
+      if (field.joinable === true) {
+        issue('joinable-not-allowed');
+      }
     }
     if (field.kind === 'text') {
       if ((field.locales ?? []).length === 0) {
@@ -1056,6 +1103,8 @@ interface FlatField extends SearchFieldBase, Searchable, RangeFacetable {
   readonly ref?: ReferenceField['ref'];
   readonly transform?: (value: string) => string;
   readonly from?: ProjectionValue;
+  readonly labelSource?: string;
+  readonly joinable?: boolean;
 }
 
 /**

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -847,6 +847,7 @@ export interface SearchTypeIssue {
     | 'text-not-facetable'
     | 'joinable-not-allowed'
     | 'joinable-without-label-source'
+    | 'joinable-with-inline-ref'
     | 'reserved-field-name';
 }
 
@@ -934,9 +935,11 @@ const LOCALE_PATTERN = /^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$/;
  *   need the reference type name); `ref` on any other kind is meaningless;
  * - `joinable` only on a `reference` field, and only alongside a `labelSource`
  *   – the join addresses the referent’s collection, which is the one the label
- *   source names, so without it the flag states an edge to nowhere. The
- *   schema-wide half of the rule (at most one joinable field per (type, label
- *   source), no cycles) is {@link joinGraph}’s;
+ *   source names, so without it the flag states an edge to nowhere – and never
+ *   on an `inline` reference, which is stored as a nested object rather than as
+ *   an id a reference field can point at. The schema-wide half of the rule (at
+ *   most one joinable field per (type, label source), no cycles) is
+ *   {@link joinGraph}’s;
  * - a `text` field declares at least one locale (`und` = untagged; projection and
  *   result reconstruction have no representation for unlocalized text – use
  *   `keyword` for untagged strings); `locales` on any other kind is
@@ -1003,6 +1006,14 @@ export function validateSearchType(
       // label source names: without one the flag states an edge to nowhere.
       if (field.joinable === true && field.labelSource === undefined) {
         issue('joinable-without-label-source');
+      }
+      // An inline reference is stored as a NESTED OBJECT, not as an id an
+      // engine can point a reference field at, so the two cannot both hold:
+      // the collection definition would emit the nesting and silently drop the
+      // reference, leaving a schema whose joins validate, compile and then fail
+      // at the engine. Carry the referent inline or join to it, not both.
+      if (field.joinable === true && field.ref?.strategy === 'inline') {
+        issue('joinable-with-inline-ref');
       }
     } else {
       if (field.ref !== undefined) {

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -1264,11 +1264,20 @@ export function outputFields(searchType: SearchType): readonly SearchField[] {
 
 /**
  * Whether a field declares **no** role – none of `output`, `searchable`,
- * `filterable`, `facetable`, `sortable`. Such a field is an **internal field**:
- * the projection populates it (so a later {@link SearchFieldBase.derive} can
- * read it), then prunes it before the document reaches a writer, and the engine
- * collection definition omits it entirely – not stored, not indexed, no RAM.
- * Absence of a role declares that intent; there is no separate marker flag.
+ * `filterable`, `facetable`, `sortable`, `joinable`. Such a field is an
+ * **internal field**: the projection populates it (so a later
+ * {@link SearchFieldBase.derive} can read it), then prunes it before the
+ * document reaches a writer, and the engine collection definition omits it
+ * entirely – not stored, not indexed, no RAM. Absence of a role declares that
+ * intent; there is no separate marker flag.
+ *
+ * {@link ReferenceField.joinable} counts as a role for exactly the reason the
+ * others do: it is a promise about what the *engine* can do with the field, and
+ * an engine can only join through a value it actually stores. Leaving it out
+ * would let a joinable-but-otherwise-role-less reference declare an edge the
+ * schema resolves, the query validates and the compiler emits – against a
+ * collection that never stored the column, so every such query fails at the
+ * engine.
  *
  * The single predicate the projection and the collection definition share, so
  * they cannot disagree on what is internal. See the Search context’s load-bearing
@@ -1280,7 +1289,8 @@ export function isInternalField(field: SearchField): boolean {
     field.searchable === undefined &&
     field.filterable !== true &&
     field.facetable !== true &&
-    field.sortable !== true
+    field.sortable !== true &&
+    (field.kind !== 'reference' || field.joinable !== true)
   );
 }
 

--- a/packages/search/test/join-graph.test.ts
+++ b/packages/search/test/join-graph.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { joinGraph, MAX_JOIN_DEPTH } from '../src/join-graph.js';
+import {
+  defineSearchType,
+  searchSchema,
+  type ReferenceField,
+  type RootType,
+  type SearchType,
+} from '../src/schema.js';
+
+/** A label-source-shaped root type: an indexed type serving `label`. */
+function labelSource(name: string, fields: SearchType['fields'] = []) {
+  return defineSearchType({
+    name,
+    class: `https://example.org/${name}`,
+    fields: [
+      {
+        name: 'label',
+        path: 'http://www.w3.org/2000/01/rdf-schema#label',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+      ...fields,
+    ],
+  });
+}
+
+/** A joinable (or plain) reference declaration. */
+function reference(
+  name: string,
+  labelSourceName: string,
+  extra: Partial<ReferenceField> = {},
+): ReferenceField {
+  return {
+    name,
+    path: `https://example.org/${name}`,
+    kind: 'reference',
+    filterable: true,
+    labelSource: labelSourceName,
+    ...extra,
+  };
+}
+
+const PUBLISHER = labelSource('Publisher');
+const DATASET = labelSource('Dataset', [
+  reference('publisher', 'Publisher', { joinable: true }),
+]);
+const CREATIVE_WORK = labelSource('CreativeWork', [
+  reference('dataset', 'Dataset', { joinable: true }),
+]);
+
+const names = (types: readonly RootType[]) => types.map((type) => type.name);
+
+describe('joinGraph', () => {
+  it('is built once per schema and returned again on the next call', () => {
+    const schema = searchSchema(PUBLISHER, DATASET, CREATIVE_WORK);
+    expect(joinGraph(schema)).toBe(joinGraph(schema));
+  });
+
+  describe('resolve', () => {
+    const schema = searchSchema(PUBLISHER, DATASET, CREATIVE_WORK);
+    const joins = joinGraph(schema);
+
+    it('walks a path of joinable field names hop by hop', () => {
+      expect(joins.resolve(CREATIVE_WORK, ['dataset'])).toBe(DATASET);
+      expect(joins.resolve(CREATIVE_WORK, ['dataset', 'publisher'])).toBe(
+        PUBLISHER,
+      );
+    });
+
+    it('resolves the empty path to the type itself', () => {
+      expect(joins.resolve(CREATIVE_WORK, [])).toBe(CREATIVE_WORK);
+    });
+
+    it('does not resolve a field that is not a joinable reference', () => {
+      expect(joins.resolve(CREATIVE_WORK, ['label'])).toBeUndefined();
+      expect(joins.resolve(CREATIVE_WORK, ['nonesuch'])).toBeUndefined();
+      // A reference declaring no `joinable` keeps its labels and its id
+      // filtering, but states no edge.
+      const plain = labelSource('Plain', [reference('publisher', 'Publisher')]);
+      const other = searchSchema(PUBLISHER, plain);
+      expect(joinGraph(other).resolve(plain, ['publisher'])).toBeUndefined();
+    });
+
+    it('does not resolve a path deeper than the cap', () => {
+      const deep = ['dataset', 'publisher', 'publisher', 'publisher'];
+      expect(deep.length).toBeGreaterThan(MAX_JOIN_DEPTH);
+      expect(joins.resolve(CREATIVE_WORK, deep)).toBeUndefined();
+    });
+
+    it('does not resolve from a type outside this schema', () => {
+      // A Reference Type is never indexed, so it has no collection to join
+      // from; nor has a Root Type declared against another schema.
+      const referenceType = defineSearchType({ name: 'Loose', fields: [] });
+      expect(joins.resolve(referenceType, ['dataset'])).toBeUndefined();
+      expect(joins.resolve(labelSource('Dataset'), ['publisher'])).toBe(
+        undefined,
+      );
+    });
+  });
+
+  describe('components', () => {
+    it('groups every type that references another, transitively', () => {
+      const loose = labelSource('Loose');
+      const schema = searchSchema(PUBLISHER, DATASET, CREATIVE_WORK, loose);
+      const components = joinGraph(schema).components.map(names);
+      expect(components).toEqual([
+        // Referenced first: the order a writer may create the collections in.
+        ['Publisher', 'Dataset', 'CreativeWork'],
+        ['Loose'],
+      ]);
+    });
+
+    it('makes a type with no joinable edge a singleton component', () => {
+      const schema = searchSchema(PUBLISHER, labelSource('Other'));
+      expect(joinGraph(schema).components.map(names)).toEqual([
+        ['Publisher'],
+        ['Other'],
+      ]);
+    });
+
+    it('groups undirected but orders directed', () => {
+      // Two referrers, one referent: nobody references the referrers, yet all
+      // three rebuild together because the edges connect them.
+      const dataset = labelSource('Dataset', [
+        reference('publisher', 'Publisher', { joinable: true }),
+      ]);
+      const person = labelSource('Person', [
+        reference('affiliation', 'Publisher', { joinable: true }),
+      ]);
+      const schema = searchSchema(PUBLISHER, dataset, person);
+      const [component] = joinGraph(schema).components;
+      expect(names(component)).toEqual(['Publisher', 'Dataset', 'Person']);
+    });
+  });
+
+  describe('declaration rules', () => {
+    it('rejects a second joinable reference to the same target', () => {
+      const dataset = labelSource('Dataset', [
+        reference('publisher', 'Publisher', { joinable: true }),
+        reference('creator', 'Publisher', { joinable: true }),
+      ]);
+      expect(() => searchSchema(PUBLISHER, dataset)).toThrow(
+        /two joinable references to “Publisher” \(“publisher” and “creator”\)/,
+      );
+    });
+
+    it('allows a second, non-joinable reference to the same target', () => {
+      const dataset = labelSource('Dataset', [
+        reference('publisher', 'Publisher', { joinable: true }),
+        reference('creator', 'Publisher'),
+      ]);
+      expect(() => searchSchema(PUBLISHER, dataset)).not.toThrow();
+    });
+
+    it('rejects a cycle', () => {
+      const a = labelSource('A', [reference('b', 'B', { joinable: true })]);
+      const b = labelSource('B', [reference('a', 'A', { joinable: true })]);
+      expect(() => searchSchema(a, b)).toThrow(/Join cycle “A” → “B” → “A”/);
+    });
+
+    it('rejects a self-reference as a cycle', () => {
+      const a = labelSource('A', [
+        reference('parent', 'A', { joinable: true }),
+      ]);
+      expect(() => searchSchema(a)).toThrow(/Join cycle “A” → “A”/);
+    });
+  });
+});

--- a/packages/search/test/query.test.ts
+++ b/packages/search/test/query.test.ts
@@ -9,7 +9,12 @@ import {
   validateQuery,
   type SearchQuery,
 } from '../src/query.js';
-import type { SearchType } from '../src/schema.js';
+import { joinGraph, MAX_JOIN_DEPTH } from '../src/join-graph.js';
+import {
+  defineSearchType,
+  searchSchema,
+  type SearchType,
+} from '../src/schema.js';
 
 describe('filterOperator', () => {
   it('reads the operator off a criterion’s discriminating key', () => {
@@ -299,6 +304,165 @@ describe('validateQuery', () => {
     expect(validateQuery({ ...base, where: [{ or: [] }] }, searchType)).toEqual(
       [],
     );
+  });
+
+  describe('a criterion carrying a join path', () => {
+    // A three-type chain, so a path of every allowed depth is expressible.
+    const label = (name: string, fields: SearchType['fields'] = []) =>
+      defineSearchType({
+        name,
+        class: `https://example.org/${name}`,
+        fields: [
+          {
+            name: 'label',
+            kind: 'text',
+            locales: ['nl'],
+            output: true,
+            searchable: { weight: 5 },
+          },
+          { name: 'country', kind: 'keyword', filterable: true },
+          { name: 'note', kind: 'keyword' },
+          ...fields,
+        ],
+      });
+    const joinable = (name: string, source: string) =>
+      ({
+        name,
+        kind: 'reference',
+        filterable: true,
+        labelSource: source,
+        joinable: true,
+      }) as const;
+    const publisher = label('Publisher');
+    const dataset = label('Dataset', [joinable('publisher', 'Publisher')]);
+    const work = label('CreativeWork', [joinable('dataset', 'Dataset')]);
+    const joins = joinGraph(searchSchema(publisher, dataset, work));
+
+    it('validates the leaf against the type the path reaches', () => {
+      expect(
+        validateQuery(
+          {
+            ...base,
+            where: [
+              {
+                or: [
+                  { on: ['dataset', 'publisher'], field: 'id', in: ['urn:x'] },
+                  { on: ['dataset'], field: 'country', in: ['NL'] },
+                ],
+              },
+            ],
+          },
+          work,
+          joins,
+        ),
+      ).toEqual([]);
+    });
+
+    it('reports the leaf’s own issues under the full path', () => {
+      expect(
+        validateQuery(
+          {
+            ...base,
+            where: [
+              // `note` is declared on Publisher but opts into no role, and
+              // `country` is a keyword, so a range mismatches its kind.
+              { or: [{ on: ['dataset', 'publisher'], field: 'note', in: [] }] },
+              { or: [{ on: ['dataset'], field: 'country', range: {} }] },
+              { or: [{ on: ['dataset'], field: 'nonesuch', in: [] }] },
+            ],
+          },
+          work,
+          joins,
+        ),
+      ).toEqual([
+        {
+          part: 'where',
+          field: 'dataset.publisher.note',
+          reason: 'not-filterable',
+        },
+        {
+          part: 'where',
+          field: 'dataset.country',
+          reason: 'operator-mismatch',
+        },
+        { part: 'where', field: 'dataset.nonesuch', reason: 'unknown-field' },
+      ]);
+    });
+
+    it('rejects a path an `id` criterion uses with the wrong operator', () => {
+      expect(
+        validateQuery(
+          {
+            ...base,
+            where: [{ or: [{ on: ['dataset'], field: 'id', is: true }] }],
+          },
+          work,
+          joins,
+        ),
+      ).toEqual([
+        { part: 'where', field: 'dataset.id', reason: 'operator-mismatch' },
+      ]);
+    });
+
+    it('caps the depth, in the IR rather than in a surface', () => {
+      const tooDeep = Array.from(
+        { length: MAX_JOIN_DEPTH + 1 },
+        () => 'dataset',
+      );
+      expect(
+        validateQuery(
+          {
+            ...base,
+            where: [{ or: [{ on: tooDeep, field: 'id', in: ['x'] }] }],
+          },
+          work,
+          joins,
+        ),
+      ).toEqual([
+        {
+          part: 'where',
+          field: `${tooDeep.join('.')}.id`,
+          reason: 'join-too-deep',
+        },
+      ]);
+    });
+
+    it('rejects a path that does not resolve, and one with no graph to resolve it', () => {
+      expect(
+        validateQuery(
+          // `label` is a field, but not a joinable reference.
+          {
+            ...base,
+            where: [{ or: [{ on: ['label'], field: 'id', in: ['x'] }] }],
+          },
+          work,
+          joins,
+        ),
+      ).toEqual([{ part: 'where', field: 'label.id', reason: 'unknown-join' }]);
+      // A joined criterion validated without a join graph is an issue, never a
+      // silently unchecked filter.
+      expect(
+        validateQuery(
+          {
+            ...base,
+            where: [{ or: [{ on: ['dataset'], field: 'id', in: ['x'] }] }],
+          },
+          work,
+        ),
+      ).toEqual([
+        { part: 'where', field: 'dataset.id', reason: 'unknown-join' },
+      ]);
+    });
+
+    it('treats an empty path as no join at all', () => {
+      expect(
+        validateQuery(
+          { ...base, where: [{ or: [{ on: [], field: 'label', in: ['x'] }] }] },
+          work,
+          joins,
+        ),
+      ).toEqual([{ part: 'where', field: 'label', reason: 'not-filterable' }]);
+    });
   });
 
   it('assertValidQuery names the type and every issue', () => {

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -660,6 +660,41 @@ describe('validateSearchType', () => {
       ),
     ).toEqual([{ field: 'size', reason: 'transform-not-allowed' }]);
   });
+
+  it('allows joinable on a reference field that declares a label source', () => {
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'publisher',
+          kind: 'reference',
+          filterable: true,
+          labelSource: 'Organization',
+          joinable: true,
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('rejects joinable without a label source, and on a non-reference', () => {
+    // A join addresses the referent’s COLLECTION, which is the one the label
+    // source names; without one the flag states an edge to nowhere.
+    expect(
+      validateSearchType(
+        typeWith({ name: 'publisher', kind: 'reference', joinable: true }),
+      ),
+    ).toEqual([
+      { field: 'publisher', reason: 'joinable-without-label-source' },
+    ]);
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'format',
+          kind: 'keyword',
+          joinable: true,
+        } as never),
+      ),
+    ).toEqual([{ field: 'format', reason: 'joinable-not-allowed' }]);
+  });
 });
 
 describe('assertTypeInSchema', () => {

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -13,6 +13,7 @@ import {
   irAlias,
   isAbsoluteIri,
   isoToUnixSeconds,
+  isInternalField,
   isRangeFacet,
   nestedFieldName,
   nestedReferenceType,
@@ -694,6 +695,22 @@ describe('validateSearchType', () => {
         } as never),
       ),
     ).toEqual([{ field: 'format', reason: 'joinable-not-allowed' }]);
+  });
+
+  it('counts joinable as a role, so such a field is never internal', () => {
+    // An engine can only join through a value it stores, so a joinable
+    // reference must survive the Internal Field pruning even when it declares
+    // nothing else – otherwise the edge resolves and the query compiles
+    // against a column the collection never had.
+    const joinable: SearchField = {
+      name: 'publisher',
+      kind: 'reference',
+      labelSource: 'Publisher',
+      joinable: true,
+    };
+    expect(isInternalField(joinable)).toBe(false);
+    // Without it, the same declaration is the reading device it looks like.
+    expect(isInternalField({ ...joinable, joinable: false })).toBe(true);
   });
 
   it('rejects joinable on an inline reference', () => {

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -695,6 +695,25 @@ describe('validateSearchType', () => {
       ),
     ).toEqual([{ field: 'format', reason: 'joinable-not-allowed' }]);
   });
+
+  it('rejects joinable on an inline reference', () => {
+    // An inline reference is stored as a nested object, not as an id a
+    // reference field can point at: the collection definition would emit the
+    // nesting and silently drop the reference, so the join would validate,
+    // compile, and only then fail at the engine.
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'media',
+          kind: 'reference',
+          output: true,
+          labelSource: 'MediaObject',
+          joinable: true,
+          ref: { typeName: 'MediaObject', strategy: 'inline' },
+        }),
+      ),
+    ).toEqual([{ field: 'media', reason: 'joinable-with-inline-ref' }]);
+  });
 });
 
 describe('assertTypeInSchema', () => {

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 99.42,
+          branches: 99.49,
           statements: 100,
         },
       },


### PR DESCRIPTION
Gives the query model cross-collection filtering by declaring joins on the edges
the schema already describes, so “every object published by institution X”
becomes one query instead of two round trips.

```graphql
creativeWorks(where: {
  dataset: { where: { publisher: { where: { id: { in: [$institution] } } } } }
})
```

compiles to `filter_by: $datasets($publishers(id:=X))` – one engine round-trip,
with a correct `total`, ranking and facet counts.

Fix #712. Decisions and their reasoning: [ADR 19](docs/decisions/0019-filter-across-collections-through-declared-joins.md).

## What changed

**`@lde/search`** – `joinable: true` on a `reference` field, valid only
alongside `labelSource` (which already asserts its values are ids in that
type’s collection). `joinGraph(schema)` holds everything that follows: the
components a rebuild is scoped by, and what a query path resolves to. Built
eagerly by `searchSchema`, so the schema-wide rules – one joinable reference per
target, no cycles – fail at startup. A criterion gains an `on` path, capped at
three hops in the IR so a later REST surface inherits the cap; `where` stays the
flat conjunction of disjunctions ADR 18 made it.

**`@lde/search-typesense`** – a joinable reference is emitted as a reference
field targeting `.id`, with `async_reference: true` and `cascade_delete: false`
(all three forced, reasons in the ADR). An `on` path compiles to nested
`$collection(…)` clauses, the leaf compiled against the *target* type’s
declaration. `InPlaceRebuild` fails loudly when an existing collection lacks a
declared reference, naming the drop-and-rebuild – it would otherwise index and
commit happily and then 400 on every join.

**`@lde/search-pipeline`** – the join component is the unit of rebuild: runs
open referenced-first (a collection cannot reference one that does not exist
yet) and commit per component, referrers-first (a blue/green commit drops the
collection it supersedes). A type with no joinable edge is a singleton
component, so a schema without joins behaves exactly as before.

**`@lde/search-api-graphql`** – a joinable reference takes
`‹Target›ReferenceFilter @oneOf { in, where }`, one per target and shared by
every field pointing at it; a non-joinable one keeps `StringFilter`, so the
capability difference is visible in the schema rather than a runtime error.
Skip-own-filter is keyed by `(path, field)`.

## Found while testing: Typesense loses references under concurrent import

The integration test caught something the issue assumed was safe. Back-fill is
exact **sequentially** – a referrer imported before its referent is accepted and
resolves the moment the referent lands (pinned by a new test). But per-type
stages import into a referring and a referenced collection **concurrently**, and
30.2 can then lose a reference *permanently*: every document present, the join
finding nothing, and which edge loses varying per run. Reproduced 4 of 5 times
with two 500-document concurrent imports.

So a component built from scratch needs its indexer run **twice** before its
joins resolve; a second run meets referents that already exist and resolves
every reference at write time. Steady-state runs over a stable corpus are
unaffected. `async_reference` is still strictly right – without it those
documents would be rejected outright and, under `throwOnFail: false`, dropped in
silence.

This is documented as a limitation in the ADR and flagged in the
`search-typesense` reference; the end-to-end test indexes twice with a comment
saying why. Not ours to fix, and worth re-checking on every engine upgrade –
when it is fixed, the second run and the caveat both go.

## Gaps closed after a second review

- **`abort` held the rebuild lock.** The partly-live-component fix below stopped
  the only path that releases the cross-pod lock, so it stayed held for its full
  TTL and the *next* run failed wholesale with `RebuildAlreadyRunning` – a worse
  blast radius than the leak it avoided. `RunWriter` gains an optional
  **`abandon(error)`** (*finalize, release resources, keep what you built*),
  implemented on the blue/green rebuild as a lock release without the drop, and
  falling back to `abort` for writers whose abort discards nothing.
- **A join-only reference was pruned.** `joinable` with no other role failed
  `isInternalField`, so the collection never stored the column – while the edge
  still resolved and the query still compiled to `$publishers(…)`. `joinable`
  now counts as a Role, which is where it belongs: an engine can only join
  through a value it stores.
- **A lookalike search type** now gets its own error instead of being told to
  pass the schema it already passed.

## Gaps closed after the first review

Four issues a review of the first commit turned up, all fixed here:

- **`abort` broke a partly-committed component.** If a component's referrer
  committed and its referent then failed, `abort` dropped the referent's
  half-built collection – which is exactly what the now-live referrer
  references by concrete name, so every join through the live index broke
  permanently. Such collections are now abandoned rather than dropped (see
  above for the follow-up that got the lock handling right too).
- **`joinable` on an *inline* reference was silently dropped.** The collection
  definition emits the nesting and returns before the reference declaration, so
  the join validated, compiled, and only then 400'd at the engine. Now rejected
  in `validateSearchType` – an inline reference carries a nested object, not an
  id a reference can point at.
- **A constant `collectionNameFor` self-referenced.** The natural migration from
  `name: 'x'` is `collectionNameFor: () => 'x'`, which now also names every
  peer – pointing the collection's reference at itself. Rejected at writer
  construction with the derived form in the message.
- **An empty joined `where` inside an `or` crashed** on the missing clause
  rather than reporting anything; it now says what is wrong.

## API changes

`@lde/pipeline`'s `RunWriter` gains an optional `abandon(error)` – additive, and
falling back to `abort` when unimplemented, so no existing writer changes.

The Typesense rebuild and collection-definition options take
`collectionNameFor: (searchType) => string` instead of `name: string`. A writer
now names more than its own collection: an emitted reference names its *peer’s*,
and a blue/green build must name the peer’s fresh collection rather than its
live alias. Migration is mechanical – `name: 'x'` becomes
`collectionNameFor: () => 'x'`.

## Out of v1

Reverse joins, facets and sorting through a join, free text through a join, and
shadow collections – each with its reason in the ADR. The `(path, field)` facet
key already anticipates joined facets.
