### PR TITLE
feat(search-indexer): add a transform without forking the composition

### DIFF
--- a/docs/reference/search-indexer.md
+++ b/docs/reference/search-indexer.md
@@ -14,9 +14,9 @@ that binds the engine-agnostic `searchIndexerPipeline` to the
 [`@lde/search-typesense`](./search-typesense) rebuild writers. Mount the
 **same schema module** into both images and point both at the same
 `TYPESENSE_*` coordinates, and the write and the read side cannot disagree
-about the schema. A deployment that needs more – a bespoke root selector,
-per-stage tuning, another engine – composes `searchStages`,
-`searchIndexWriter` and `Pipeline` directly instead.
+about the schema. A deployment that needs domain behaviour on top passes a
+[transform](#add-a-transform); one that needs a bespoke root selector, per-stage
+tuning or another engine [composes it yourself](#compose-it-yourself).
 
 ## Installation
 
@@ -77,6 +77,7 @@ images.
 | `TYPESENSE_API_KEY`   | **required**                | An admin key: the indexer creates, writes and swaps collections                                                                                       |
 | `REBUILD_MODE`        | `in-place`                  | `in-place` (update the live collection) or `blue-green` (swap on commit)                                                                              |
 | `COLLECTION_PREFIX`   | none                        | Prefix for every derived collection name (configure the read side to match)                                                                           |
+| `DEFAULT_LOCALE`      | none                        | Stemming language for untagged text, e.g. `nl`. Unset, untagged text is folded but **unstemmed** – `fietsen` will not match `fiets`                   |
 | `PROVENANCE_FILE`     | none                        | JSON file remembering per-dataset processing, to skip unchanged datasets                                                                              |
 | `PIPELINE_VERSION`    | none                        | Version keying the skip decisions; required with `PROVENANCE_FILE`                                                                                    |
 | `QLEVER_IMAGE`        | none                        | Enables the QLever import path (see below), e.g. `adfreiburg/qlever:latest`                                                                           |
@@ -203,3 +204,115 @@ The configuration types are exported too: `IndexerConfig` (what
 `configFromEnvironment` produces) and its parts `TypesenseConnection`,
 `ProvenanceConfig` (`PROVENANCE_FILE` + `PIPELINE_VERSION`) and `QleverConfig`
 (the QLever import path).
+
+## Add a transform
+
+The one thing configuration cannot express is domain behaviour: correcting the
+data a publisher ships, minting a quad it does not, dropping one it should not.
+Pass it as a `QuadTransform` per root type, keyed by the type’s `name`:
+
+```ts
+import {
+  configFromEnvironment,
+  createSearchIndexer,
+} from '@lde/search-indexer';
+
+const pipeline = await createSearchIndexer(configFromEnvironment(process.env), {
+  transforms: { Object: [dropSelfReferences] },
+});
+await pipeline.run();
+```
+
+That is the whole cost of adding behaviour. Dataset selection, the QLever
+import path, registry-sourced root types, collection naming, provenance and the
+console reporter stay wired, and the transform is attached to the type’s
+generated reader – so the reader’s subject variable and the stage’s root
+variable cannot fall out of step. A key the mounted schema does not declare
+throws at boot rather than attaching nothing and shipping an unenriched
+collection.
+
+One rule the type system cannot state: **a field a transform fills must still
+declare a `path`.** Projection skips a field with neither a `path` nor a
+`derive`, so a transform-minted IR Alias is otherwise never read and the field
+ships empty.
+
+## Compose it yourself
+
+Reach for this only when the deployment needs something `createSearchIndexer`
+has no answer for – a non-SPARQL reader, a root selector that is not by class,
+another engine – and compose `searchStages`, `searchIndexWriter` and `Pipeline`
+directly. Adding a transform is **not** such a case; that is `transforms` above.
+
+The three pieces `createSearchIndexer` composes are exported, so this route
+costs the bespoke part rather than a copy of the wiring:
+
+- `datasetSelectorFrom(config)` – the registry-backed dataset selection;
+- `distributionResolverFrom(config)` – the QLever import path when
+  `QLEVER_IMAGE` is set, `undefined` otherwise (the pipeline’s endpoint-only
+  default);
+- `writerFactoryFrom(client, config)` – the rebuild writer per root type, its
+  collection named and prefixed as configured and its untagged text stemmed in
+  `DEFAULT_LOCALE`.
+
+```ts
+import { Pipeline, SparqlConstructReader } from '@lde/pipeline';
+import { ConsoleReporter } from '@lde/pipeline-console-reporter';
+import { loadSchemaModule } from '@lde/search/module';
+import { searchIndexWriter, searchStages } from '@lde/search-pipeline';
+import {
+  configFromEnvironment,
+  datasetSelectorFrom,
+  distributionResolverFrom,
+  writerFactoryFrom,
+} from '@lde/search-indexer';
+import { Client } from 'typesense';
+
+const config = configFromEnvironment(process.env);
+const { schema } = await loadSchemaModule(config.schemaModulePath);
+const client = new Client({
+  nodes: [
+    {
+      host: config.typesense.host,
+      port: config.typesense.port,
+      protocol: config.typesense.protocol,
+    },
+  ],
+  apiKey: config.typesense.apiKey,
+});
+const objectType = schema.get('https://example.org/Object')!;
+
+const pipeline = new Pipeline({
+  datasetSelector: datasetSelectorFrom(config),
+  distributionResolver: distributionResolverFrom(config),
+  stages: searchStages({
+    schema,
+    types: [
+      {
+        searchType: objectType,
+        rootVariable: 'root',
+        itemSelector: myBespokeSelector,
+        // Own reader: attach transforms to it as data, `{ reader, transform }`.
+        readers: { reader: myNonSparqlReader, transform: [myTransform] },
+      },
+    ],
+  }),
+  writers: searchIndexWriter({
+    schema,
+    writerFor: writerFactoryFrom(client, config),
+  }),
+  // Composing by hand means restating these: they are wired by
+  // `searchIndexerPipeline`, which this route bypasses, and silently absent if
+  // forgotten.
+  reporter: new ConsoleReporter(),
+});
+await pipeline.run();
+```
+
+Note what the last argument buys back. `createSearchIndexer` also passes
+`registryTypes` (from `REGISTRY_ROOT_TYPES`), `provenanceStore` and
+`pipelineVersion` (from `PROVENANCE_FILE` + `PIPELINE_VERSION`) into
+`searchIndexerPipeline`. This route bypasses that function, so each is absent
+until restated – with no error, just a run that reports nothing, skips nothing
+and reads registry types from the wrong place. That is the cost of leaving the
+convenience, and the reason `transforms` exists rather than sending every
+deployment here.

--- a/docs/reference/search-pipeline.md
+++ b/docs/reference/search-pipeline.md
@@ -92,10 +92,30 @@ Each role in that wiring maps to a package:
 | Provenance (skip-unchanged)            | [`@lde/pipeline`](./pipeline) – `FileProvenanceStore`, or a triplestore-backed store                                                                                                                               |
 | Reporting                              | [`@lde/pipeline-console-reporter`](./pipeline-console-reporter) `ConsoleReporter`                                                                                                                                  |
 
+Domain behaviour on top of that wiring – correcting the data, minting a quad the
+source does not ship, dropping one it should not – is the `transforms` option,
+one or more `QuadTransform`s per root type keyed by the type’s `name`:
+
+```ts
+searchIndexerPipeline({
+  schema,
+  datasets,
+  writerFor,
+  transforms: { Object: [dropSelfReferences] },
+});
+```
+
+The transform is attached to the type’s generated reader, so the reader’s
+subject variable and the stage’s root variable stay in step; a key the schema
+does not declare throws at wiring time. Note that a field a transform fills must
+still declare a `path` – projection skips a field with neither a `path` nor a
+`derive`.
+
 A deployment that needs more – a bespoke root selector (where the entry point
 is a domain fact, not a class), per-stage tuning, non-SPARQL readers, or
-quad-level plugins – composes the parts directly, as below; the convenience
-owns no capability of its own.
+quad-level plugins – composes the parts directly, as below, restating the
+registry sourcing, provenance and reporting this convenience wires; beyond
+those it owns no capability of its own.
 
 ## Usage
 

--- a/packages/search-indexer/src/composition.ts
+++ b/packages/search-indexer/src/composition.ts
@@ -1,5 +1,6 @@
-// Internal composition pieces of createSearchIndexer, split out so each can
-// be tested without running a pipeline (Pipeline keeps its wiring private).
+// The composition pieces of createSearchIndexer, each usable on its own so a
+// deployment that needs one bespoke stage keeps the rest of the wiring
+// (Pipeline keeps its own wiring private).
 import { Client as RegistryClient } from '@lde/dataset-registry-client';
 import {
   ImportResolver,
@@ -31,7 +32,8 @@ export function datasetSelectorFrom(config: IndexerConfig): DatasetSelector {
  * The engine-writer factory the configuration describes: an
  * {@link InPlaceRebuild} or {@link BlueGreenRebuild} per root type, its
  * collection name derived from the type – prefixed when the deployment says
- * so, so the read side must be configured with the same prefix.
+ * so, so the read side must be configured with the same prefix – and its
+ * untagged text stemmed in the configured {@link IndexerConfig.defaultLocale}.
  *
  * The mounted schema the pipeline hands each call travels into the writer: a
  * type that surfaces an inline reference builds its collection from the
@@ -43,7 +45,8 @@ export function writerFactoryFrom(
   config: IndexerConfig,
 ): (searchType: RootType, schema: SearchSchema) => Writer<SearchDocument> {
   return (searchType, schema) => {
-    const options = {
+    const writerOptions = {
+      defaultLocale: config.defaultLocale,
       schema,
       ...(config.collectionPrefix
         ? {
@@ -52,8 +55,8 @@ export function writerFactoryFrom(
         : {}),
     };
     return config.rebuildMode === 'blue-green'
-      ? new BlueGreenRebuild(client, searchType, options)
-      : new InPlaceRebuild(client, searchType, options);
+      ? new BlueGreenRebuild(client, searchType, writerOptions)
+      : new InPlaceRebuild(client, searchType, writerOptions);
   };
 }
 

--- a/packages/search-indexer/src/config.ts
+++ b/packages/search-indexer/src/config.ts
@@ -33,6 +33,13 @@ export interface IndexerConfig {
   /** Prefix prepended to every derived collection name
    *  (`COLLECTION_PREFIX`), e.g. for a shared multi-tenant engine. */
   readonly collectionPrefix?: string;
+  /**
+   * Stemming language for text that carries no language tag (`DEFAULT_LOCALE`,
+   * e.g. `nl`). Unset, such text is folded but **unstemmed** – no language is
+   * ever assumed – so `fietsen` does not match `fiets`. Text declaring a real
+   * locale always stems in its own language, whatever this says.
+   */
+  readonly defaultLocale?: string;
   /** Per-dataset processing memory: skip unchanged datasets
    *  (`PROVENANCE_FILE` + `PIPELINE_VERSION`). */
   readonly provenance?: ProvenanceConfig;
@@ -164,6 +171,7 @@ export function configFromEnvironment(
     },
     rebuildMode: rebuildMode as 'in-place' | 'blue-green',
     collectionPrefix: environment['COLLECTION_PREFIX'],
+    defaultLocale: environment['DEFAULT_LOCALE'],
     provenance,
     qlever,
   };

--- a/packages/search-indexer/src/index.ts
+++ b/packages/search-indexer/src/index.ts
@@ -4,6 +4,18 @@
 // `search-indexer` bin (src/cli.ts) and the Docker image are thin wrappers
 // over these.
 export { createSearchIndexer } from './indexer.js';
+export type { SearchIndexerExtensions } from './indexer.js';
+// The pieces createSearchIndexer composes. Adding a transform does NOT need
+// these – that is `createSearchIndexer(config, { transforms })`. They are for
+// the genuinely bespoke deployment (a non-SPARQL reader, another engine, a root
+// selector that is not by class), which composes `searchStages`,
+// `searchIndexWriter` and `Pipeline` directly and would otherwise also re-derive
+// dataset selection, the QLever import path and collection naming.
+export {
+  datasetSelectorFrom,
+  distributionResolverFrom,
+  writerFactoryFrom,
+} from './composition.js';
 export { configFromEnvironment } from './config.js';
 export type {
   IndexerConfig,

--- a/packages/search-indexer/src/indexer.ts
+++ b/packages/search-indexer/src/indexer.ts
@@ -1,4 +1,9 @@
-import { FileProvenanceStore, type Pipeline } from '@lde/pipeline';
+import {
+  FileProvenanceStore,
+  type Pipeline,
+  type QuadTransform,
+  type ReaderContext,
+} from '@lde/pipeline';
 import { ConsoleReporter } from '@lde/pipeline-console-reporter';
 import { loadSchemaModule } from '@lde/search/module';
 import {
@@ -13,16 +18,46 @@ import {
 } from './composition.js';
 import type { IndexerConfig } from './config.js';
 
+/** What a deployment adds to the standard indexer – the domain behaviour no
+ *  configuration can express. */
+export interface SearchIndexerExtensions {
+  /**
+   * {@link QuadTransform}(s) per root type, keyed by `SearchType.name`: correct
+   * the data, mint a quad the source does not ship, drop one it should not.
+   * Attached to the type’s reader, so a transform sees each root’s quads before
+   * projection.
+   *
+   * This is the whole cost of adding behaviour – dataset selection, the QLever
+   * import path, registry-sourced types, collection naming, provenance and
+   * reporting stay wired. A name the schema does not declare throws at boot.
+   *
+   * A field a transform fills must still declare a `path`: projection skips a
+   * field with neither a `path` nor a `derive`.
+   */
+  readonly transforms?: Readonly<
+    Record<
+      string,
+      QuadTransform<ReaderContext> | QuadTransform<ReaderContext>[]
+    >
+  >;
+}
+
 /**
  * Compose the ready-to-run search indexer from an {@link IndexerConfig}: load
  * and validate the mounted schema module (the same file the served-API image
  * mounts), select datasets from the registry, bind the Typesense rebuild
  * writers, and wire the optional QLever import path and provenance store into
  * `searchIndexerPipeline`. Every misconfiguration – an invalid schema, an
- * underivable collection name – throws here, at boot, never mid-run.
+ * underivable collection name, a transform naming an undeclared type – throws
+ * here, at boot, never mid-run.
+ *
+ * `extensions` carries the domain behaviour a deployment adds on top
+ * ({@link SearchIndexerExtensions}); everything else about a deployment is
+ * configuration, so the bin and the Docker image need only the config.
  */
 export async function createSearchIndexer(
   config: IndexerConfig,
+  extensions: SearchIndexerExtensions = {},
 ): Promise<Pipeline<TypedSearchDocument>> {
   const { schema } = await loadSchemaModule(config.schemaModulePath);
   const client = new Client({
@@ -52,5 +87,6 @@ export async function createSearchIndexer(
       : undefined,
     pipelineVersion: config.provenance?.pipelineVersion,
     reporter: new ConsoleReporter(),
+    transforms: extensions.transforms,
   });
 }

--- a/packages/search-indexer/test/composition.test.ts
+++ b/packages/search-indexer/test/composition.test.ts
@@ -1,7 +1,13 @@
-import { ImportResolver, RegistrySelector } from '@lde/pipeline';
+import { ImportResolver, Pipeline, RegistrySelector } from '@lde/pipeline';
 import { searchSchema } from '@lde/search';
+import {
+  searchIndexWriter,
+  searchStages,
+  selectByClass,
+} from '@lde/search-pipeline';
 import { BlueGreenRebuild, InPlaceRebuild } from '@lde/search-typesense';
 import { Client } from 'typesense';
+import type { CollectionCreateSchema } from 'typesense/lib/Typesense/Collections.js';
 import { describe, expect, it } from 'vitest';
 import {
   datasetSelectorFrom,
@@ -27,6 +33,76 @@ const schema = searchSchema({
   fields: [{ name: 'title', kind: 'text', locales: ['en'], output: true }],
 });
 const datasetType = [...schema.values()][0]!;
+
+/** A type whose searchable text carries no language tag – the `und` locale
+ *  whose stemming `defaultLocale` decides. */
+const untaggedSchema = searchSchema({
+  name: 'Dataset',
+  class: 'http://www.w3.org/ns/dcat#Dataset',
+  fields: [
+    {
+      name: 'title',
+      kind: 'text',
+      // A field the projection reads needs a path even when a transform is what
+      // fills it: projection skips a field with neither a path nor a derive.
+      path: '<http://purl.org/dc/terms/title>',
+      locales: ['und'],
+      output: true,
+      searchable: { weight: 1 },
+    },
+  ],
+});
+const untaggedType = [...untaggedSchema.values()][0]!;
+
+/**
+ * A Typesense client that records the collections a writer creates: the lock
+ * is granted, the target collection is reported missing (404), and the
+ * definition the writer then creates is captured. Enough of the client for
+ * `openRun` to reach the create – the definition is what these tests assert.
+ */
+function recordingClient(): {
+  client: Client;
+  created: CollectionCreateSchema[];
+} {
+  const created: CollectionCreateSchema[] = [];
+  const notFound = Object.assign(new Error('HTTP 404'), { httpStatus: 404 });
+  const client = {
+    collections: (name?: string) =>
+      name === undefined
+        ? {
+            create: async (schema: CollectionCreateSchema) => {
+              created.push(schema);
+              return schema;
+            },
+          }
+        : {
+            retrieve: async () => {
+              throw notFound;
+            },
+            documents: () => ({ create: async () => ({}) }),
+          },
+  } as unknown as Client;
+  return { client, created };
+}
+
+/** The physical field a definition declares under `name`. */
+function field(
+  definition: CollectionCreateSchema,
+  name: string,
+): Record<string, unknown> {
+  const found = definition.fields?.find((each) => each.name === name);
+  expect(
+    found,
+    `no field “${name}” in the collection definition`,
+  ).toBeDefined();
+  return found as unknown as Record<string, unknown>;
+}
+
+const runContext = {
+  runId: 'run-1',
+  startedAt: '2026-07-06T12:00:00.000Z',
+  selectedSources: () => [],
+};
 
 describe('datasetSelectorFrom', () => {
   it('selects from the configured registry', () => {
@@ -63,6 +139,31 @@ describe('writerFactoryFrom', () => {
       'staging_datasets',
     );
   });
+
+  it('leaves untagged text unstemmed without DEFAULT_LOCALE', async () => {
+    const { client: recorder, created } = recordingClient();
+    const writerFor = writerFactoryFrom(
+      recorder,
+      configFromEnvironment(minimal),
+    );
+    await writerFor(untaggedType, untaggedSchema).openRun(runContext);
+    expect(field(created[0]!, 'title_search_und')).not.toHaveProperty('stem');
+  });
+
+  it('stems untagged text in the configured DEFAULT_LOCALE', async () => {
+    // Configuration, not code: the Docker image reaches this too, so a Dutch
+    // deployment does not fold-without-stemming (“fietsen” vs “fiets”).
+    const { client: recorder, created } = recordingClient();
+    const writerFor = writerFactoryFrom(
+      recorder,
+      configFromEnvironment({ ...minimal, DEFAULT_LOCALE: 'nl' }),
+    );
+    await writerFor(untaggedType, untaggedSchema).openRun(runContext);
+    expect(field(created[0]!, 'title_search_und')).toMatchObject({
+      stem: true,
+      locale: 'nl',
+    });
+  });
 });
 
 describe('distributionResolverFrom', () => {
@@ -95,5 +196,34 @@ describe('distributionResolverFrom', () => {
       }),
     );
     expect(resolver).toBeInstanceOf(ImportResolver);
+  });
+});
+
+describe('the composed route', () => {
+  it('wires the helpers into a Pipeline, as the reference documents', () => {
+    // The worked example in docs/reference/search-indexer.md, asserted here so
+    // it cannot rot while createSearchIndexer keeps passing: a deployment
+    // reaches SearchStageType.readers – its transform – while the helpers keep
+    // dataset selection, the import path and collection naming.
+    const config = configFromEnvironment(minimal);
+    const pipeline = new Pipeline({
+      datasetSelector: datasetSelectorFrom(config),
+      distributionResolver: distributionResolverFrom(config),
+      stages: searchStages({
+        schema: untaggedSchema,
+        types: [
+          {
+            searchType: untaggedType,
+            rootVariable: 'root',
+            itemSelector: selectByClass(untaggedType),
+          },
+        ],
+      }),
+      writers: searchIndexWriter({
+        schema: untaggedSchema,
+        writerFor: writerFactoryFrom(client, config),
+      }),
+    });
+    expect(pipeline).toBeInstanceOf(Pipeline);
   });
 });

--- a/packages/search-indexer/test/config.test.ts
+++ b/packages/search-indexer/test/config.test.ts
@@ -23,6 +23,7 @@ describe('configFromEnvironment', () => {
       },
       rebuildMode: 'in-place',
       collectionPrefix: undefined,
+      defaultLocale: undefined,
       provenance: undefined,
       qlever: undefined,
     });
@@ -36,6 +37,7 @@ describe('configFromEnvironment', () => {
       TYPESENSE_PROTOCOL: 'https',
       REBUILD_MODE: 'blue-green',
       COLLECTION_PREFIX: 'staging_',
+      DEFAULT_LOCALE: 'nl',
       REGISTRY_ROOT_TYPES: 'Dataset, Publisher',
       QLEVER_IMAGE: 'adfreiburg/qlever:latest',
       IMPORT_STRATEGY: 'import',
@@ -54,6 +56,7 @@ describe('configFromEnvironment', () => {
       },
       rebuildMode: 'blue-green',
       collectionPrefix: 'staging_',
+      defaultLocale: 'nl',
       provenance: undefined,
       qlever: {
         image: 'adfreiburg/qlever:latest',

--- a/packages/search-indexer/test/indexer.test.ts
+++ b/packages/search-indexer/test/indexer.test.ts
@@ -59,6 +59,46 @@ describe('createSearchIndexer', () => {
     ).rejects.toThrowError(/Unknown registry root type\(s\) “Publisher”/);
   });
 
+  it('attaches a deployment’s transform without giving up the wiring', async () => {
+    // The whole cost of adding behaviour: one option. Everything
+    // createSearchIndexer wires – provenance, the reporter, registry types,
+    // collection naming – stays wired, which hand-composing a Pipeline to reach
+    // the reader silently gives up.
+    const pipeline = await createSearchIndexer(
+      configFromEnvironment({
+        ...minimal,
+        SCHEMA_MODULE: fixture,
+        PROVENANCE_FILE: '/state/provenance.json',
+        PIPELINE_VERSION: '1',
+      }),
+      {
+        transforms: {
+          Dataset: async function* (quads) {
+            yield* quads;
+          },
+        },
+      },
+    );
+    expect(pipeline).toBeInstanceOf(Pipeline);
+  });
+
+  it('fails the boot on a transform naming a type the schema does not declare', async () => {
+    // At boot, not per dataset: the transform would otherwise attach to nothing
+    // and the collection would ship unenriched.
+    await expect(
+      createSearchIndexer(
+        configFromEnvironment({ ...minimal, SCHEMA_MODULE: fixture }),
+        {
+          transforms: {
+            Datasets: async function* (quads) {
+              yield* quads;
+            },
+          },
+        },
+      ),
+    ).rejects.toThrowError(/Unknown transform type\(s\) “Datasets”/);
+  });
+
   it('fails the boot on an unloadable schema module, naming the path', async () => {
     await expect(
       createSearchIndexer(

--- a/packages/search-pipeline/src/search-indexer-pipeline.ts
+++ b/packages/search-pipeline/src/search-indexer-pipeline.ts
@@ -6,6 +6,8 @@ import {
   type DistributionResolver,
   type ProgressReporter,
   type ProvenanceStore,
+  type QuadTransform,
+  type ReaderContext,
   type Writer,
 } from '@lde/pipeline';
 import type { RootType, SearchDocument, SearchSchema } from '@lde/search';
@@ -73,6 +75,26 @@ export interface SearchIndexerPipelineOptions {
     names: readonly string[];
   };
   /**
+   * {@link QuadTransform}(s) attached to a root type’s reader, keyed by
+   * {@link SearchType.name} – the extension point a deployment reaches for
+   * when the data needs correcting, enriching or pruning before projection.
+   *
+   * This is what keeps a deployment with one bespoke transform on this
+   * convenience instead of hand-composing a {@link Pipeline}: composing by hand
+   * to reach the reader means restating dataset selection, registry sourcing,
+   * provenance and reporting, and silently losing whichever is forgotten.
+   *
+   * Named by `name` rather than by class IRI, like {@link registryTypes}; a
+   * name the schema does not declare throws at wiring time rather than
+   * attaching nothing and shipping an unenriched collection.
+   */
+  transforms?: Readonly<
+    Record<
+      string,
+      QuadTransform<ReaderContext> | QuadTransform<ReaderContext>[]
+    >
+  >;
+  /**
    * Optional per-dataset processing memory: skip a dataset whose source
    * fingerprint and {@link pipelineVersion} both match the stored record.
    * Requires {@link pipelineVersion}.
@@ -118,17 +140,22 @@ export interface SearchIndexerPipelineOptions {
  * await pipeline.run();
  * ```
  *
+ * Domain behaviour on top of the standard wiring is {@link transforms}, so
+ * adding it costs the behaviour rather than this whole composition.
+ *
  * A deployment that needs more – a bespoke root selector (the entry point is a
  * domain fact, not a class), per-stage tuning (`batchSize`, `maxConcurrency`),
  * non-SPARQL readers, or quad-level plugins – composes {@link searchStages},
- * {@link searchIndexWriter} and {@link Pipeline} directly; this convenience
- * owns no capability of its own.
+ * {@link searchIndexWriter} and {@link Pipeline} directly, restating the
+ * registry sourcing, provenance and reporting this function wires; beyond
+ * those, this convenience owns no capability of its own.
  */
 export function searchIndexerPipeline(
   options: SearchIndexerPipelineOptions,
 ): Pipeline<TypedSearchDocument> {
-  const { schema, datasets, registryTypes } = options;
+  const { schema, datasets, registryTypes, transforms } = options;
   const fromRegistry = registryTypeNames(schema, registryTypes?.names);
+  assertDeclaredTypeNames(schema, Object.keys(transforms ?? {}), 'transform');
   const sourceFor =
     registryTypes === undefined
       ? undefined
@@ -145,6 +172,7 @@ export function searchIndexerPipeline(
         rootVariable: 'root',
         itemSelector: selectByClass(searchType),
         sourceFor: fromRegistry.has(searchType.name) ? sourceFor : undefined,
+        transform: transforms?.[searchType.name],
       })),
     }),
     writers: searchIndexWriter({ schema, writerFor: options.writerFor }),
@@ -165,18 +193,32 @@ function registryTypeNames(
   declaredNames: readonly string[] | undefined,
 ): ReadonlySet<string> {
   const names = new Set(declaredNames ?? []);
+  assertDeclaredTypeNames(schema, [...names], 'registry root');
+  return names;
+}
+
+/**
+ * Every name must be one the schema declares. Shared by the options that key
+ * behaviour by {@link SearchType.name}: naming a type the schema does not have
+ * is a configuration mistake whose only other symptom is an option that
+ * silently does nothing.
+ */
+function assertDeclaredTypeNames(
+  schema: SearchSchema,
+  names: readonly string[],
+  label: string,
+): void {
   const declared = new Set(
     [...schema.values()].map((searchType) => searchType.name),
   );
-  const unknown = [...names].filter((name) => !declared.has(name));
+  const unknown = names.filter((name) => !declared.has(name));
   if (unknown.length > 0) {
     throw new Error(
-      `Unknown registry root type(s) ${unknown
+      `Unknown ${label} type(s) ${unknown
         .map((name) => `“${name}”`)
         .join(', ')}; the schema declares ${[...declared]
         .map((name) => `“${name}”`)
         .join(', ')}.`,
     );
   }
-  return names;
 }

--- a/packages/search-pipeline/src/search-stages.ts
+++ b/packages/search-pipeline/src/search-stages.ts
@@ -3,7 +3,10 @@ import {
   SparqlConstructReader,
   SparqlItemSelector,
   Stage,
+  type AttachedReader,
   type ItemSelector,
+  type QuadTransform,
+  type ReaderContext,
   type StageOptions,
   type StageReaders,
 } from '@lde/pipeline';
@@ -40,10 +43,27 @@ export interface SearchStageType {
    * from `searchType` ({@link extractionQuery}), with `rootVariable` as the free
    * subject the batch’s roots bind to – the schema-derived reader the projection
    * is guaranteed to agree with (they share the {@link irAlias} convention).
-   * Supply your own only to read from a non-SPARQL source, merge several
-   * readers, or attach transforms.
+   * Supply your own only to read from a non-SPARQL source or merge several
+   * readers; to enrich the default reader’s quads, use {@link transform}.
    */
   readers?: StageReaders;
+  /**
+   * {@link QuadTransform}(s) attached to the **default** reader – the usual way
+   * to add behaviour to this stage: correct the data, mint a quad the source
+   * does not ship, drop one it should not.
+   *
+   * Attaching here rather than building the reader yourself is what keeps the
+   * reader’s `subjectVariable` and this stage’s {@link rootVariable} in
+   * agreement: nothing cross-checks them, and a mismatch extracts nothing.
+   * Mutually exclusive with {@link readers} – a caller supplying its own
+   * reader(s) attaches transforms to them directly ({@link AttachedReader}),
+   * since only that caller knows which of several readers each belongs to.
+   *
+   * A field a transform fills must still declare a `path`: projection skips a
+   * field with neither a `path` nor a `derive`, so a transform-minted IR Alias
+   * is otherwise never read.
+   */
+  transform?: QuadTransform<ReaderContext> | QuadTransform<ReaderContext>[];
   /**
    * Where this type’s stage reads, when that is not the dataset’s own
    * distribution – see {@link StageOptions.sourceFor}. {@link registrySource}
@@ -107,16 +127,28 @@ export function searchStages(
       );
     }
     const { rootVariable } = type;
+    if (type.readers !== undefined && type.transform !== undefined) {
+      // Which of the caller’s readers the transform belongs to is knowable only
+      // to that caller, so guessing (all of them? the first?) would be a silent
+      // wrong answer. Attach it as an AttachedReader instead.
+      throw new Error(
+        `Search type “${searchType.name}”: “transform” attaches to the default reader, so it cannot be combined with “readers” – attach the transform to your own reader instead ({ reader, transform }).`,
+      );
+    }
     // Default to the Extraction CONSTRUCT generated from the schema, its subject
     // left free for the batch’s VALUES injection. The reader and the projection
-    // then agree by construction: both key off the same IR Aliases.
-    const readers =
+    // then agree by construction: both key off the same IR Aliases – which is
+    // also why an attached transform never has to restate the subject variable.
+    const readers: StageReaders =
       type.readers ??
-      new SparqlConstructReader({
-        query: extractionQueryString(searchType, schema, {
-          subjectVariable: rootVariable,
+      ({
+        reader: new SparqlConstructReader({
+          query: extractionQueryString(searchType, schema, {
+            subjectVariable: rootVariable,
+          }),
         }),
-      });
+        transform: type.transform,
+      } satisfies AttachedReader);
     return new Stage<TypedSearchDocument>({
       name: searchType.name,
       readers,

--- a/packages/search-pipeline/test/search-indexer-pipeline.test.ts
+++ b/packages/search-pipeline/test/search-indexer-pipeline.test.ts
@@ -8,6 +8,7 @@ import {
   type Writer,
 } from '@lde/pipeline';
 import { searchSchema, type RootType, type SearchDocument } from '@lde/search';
+import type { Quad } from '@rdfjs/types';
 import { searchIndexerPipeline } from '../src/search-indexer-pipeline.js';
 
 const DATASET = 'https://example.org/Dataset';
@@ -184,6 +185,88 @@ describe('searchIndexerPipeline', () => {
           registryTypes: { ...registry, names: ['Datasets'] },
         }),
       ).toThrow(/Unknown registry root type\(s\) “Datasets”/);
+    });
+  });
+
+  describe('transforms', () => {
+    it('attaches a transform to the named type’s reader only', async () => {
+      // End to end: the transform sees the type’s extracted quads, and the
+      // other type’s stage runs untouched – so a deployment adds behaviour
+      // without hand-composing a Pipeline and losing everything else this
+      // convenience wires.
+      const seen: { stage: string; subjects: string[] }[] = [];
+      const transform = async function* (
+        quads: AsyncIterable<Quad>,
+        context: { stage: string },
+      ) {
+        const subjects: string[] = [];
+        for await (const quad of quads) {
+          subjects.push(quad.subject.value);
+          yield quad;
+        }
+        seen.push({ stage: context.stage, subjects });
+      };
+
+      nock('http://data.example.org')
+        .post('/sparql')
+        .times(10)
+        .reply((_uri, body) => {
+          const query = decodeURIComponent(String(body).replace(/\+/g, ' '));
+          if (query.includes('CONSTRUCT')) {
+            return [
+              200,
+              '<http://example.org/org/1> <https://example.org/name> "ACME" .\n',
+              { 'Content-Type': 'application/n-triples' },
+            ];
+          }
+          // One root per type, so each stage forms a batch and runs its reader.
+          return [
+            200,
+            {
+              head: { vars: ['root'] },
+              results: {
+                bindings: [
+                  { root: { type: 'uri', value: 'http://example.org/org/1' } },
+                ],
+              },
+            },
+            { 'Content-Type': 'application/sparql-results+json' },
+          ];
+        });
+
+      await searchIndexerPipeline({
+        schema,
+        datasets: [
+          new Dataset({
+            iri: new URL('http://example.org/dataset/1'),
+            distributions: [
+              Distribution.sparql(new URL('http://data.example.org/sparql')),
+            ],
+          }),
+        ],
+        writerFor: () => engineWriter,
+        transforms: { Organization: transform },
+      }).run();
+
+      expect(seen.map((each) => each.stage)).toEqual(['Organization']);
+      expect(seen[0]?.subjects).toContain('http://example.org/org/1');
+    });
+
+    it('rejects a name the schema does not declare', () => {
+      // Otherwise silent: the transform would attach to nothing and the
+      // collection would ship unenriched.
+      expect(() =>
+        searchIndexerPipeline({
+          schema,
+          datasets: [],
+          writerFor: () => engineWriter,
+          transforms: {
+            Organisation: async function* (quads) {
+              yield* quads;
+            },
+          },
+        }),
+      ).toThrow(/Unknown transform type\(s\) “Organisation”/);
     });
   });
 });

--- a/packages/search-pipeline/test/search-stages.test.ts
+++ b/packages/search-pipeline/test/search-stages.test.ts
@@ -225,6 +225,27 @@ describe('searchStages', () => {
     ).toThrow(/not in the schema/);
   });
 
+  it('refuses a transform alongside the caller’s own readers', () => {
+    // Which of several readers the transform belongs to is knowable only to the
+    // caller, so this is a mistake to name rather than a default to guess.
+    expect(() =>
+      searchStages({
+        schema,
+        types: [
+          {
+            searchType: person,
+            rootVariable: 'root',
+            itemSelector: rootsSelector([]),
+            readers: nameReader,
+            transform: async function* (quads) {
+              yield* quads;
+            },
+          },
+        ],
+      }),
+    ).toThrow(/cannot be combined with “readers”/);
+  });
+
   it('fails clearly when the selector does not bind the stage’s rootVariable', async () => {
     // The stage reads ?subject, but `rootsSelector` binds ?root – a config
     // mismatch. The batch deref must throw a named error, not an opaque


### PR DESCRIPTION
`@lde/search-indexer` calls itself the composition layer but exported only
`createSearchIndexer` and `configFromEnvironment`. A Deployment that needs one
transform had to take the documented route – `searchStages` + `searchIndexWriter`
+ `Pipeline` – and give up everything else with it.

The issue proposed exporting the three composition helpers so that route costs
less. This does that, but not only that: exporting them leaves the common case –
attach one transform – paying eleven things to learn in order to hide three, and
silently losing capability on the way.

## What the composed route actually costs

`createSearchIndexer` passes `registryTypes`, `provenanceStore`,
`pipelineVersion` and a `ConsoleReporter` into `searchIndexerPipeline`. Composing
a `Pipeline` by hand bypasses that function, so all four are absent until
restated – with no error. A Deployment that followed the documented route to add
a transform would silently stop skipping unchanged datasets, stop reporting, and
read registry-sourced types from the wrong place.

So the transform gets a first-class hook instead:

```ts
const pipeline = await createSearchIndexer(config, {
  transforms: { Object: [dropSelfReferences] },
});
```

One option. Dataset selection, the QLever import path, registry types, collection
naming, provenance and reporting stay wired. The transform attaches to the
type’s generated reader, so the reader’s `subjectVariable` and the stage’s
`rootVariable` cannot fall out of step – the trap is removed rather than
documented. A key the schema does not declare throws at boot, as
`registryTypes` already does.

Underneath, `SearchIndexerPipelineOptions.transforms` and
`SearchStageType.transform` carry it. `transform` is mutually exclusive with a
caller’s own `readers`: which of several readers it belongs to is knowable only
to that caller, so it is a mistake to name rather than a default to guess.

## `DEFAULT_LOCALE`

`writerFactoryFrom` built `{ schema, name? }`, while `defaultLocale` is what
decides whether untagged text stems (`collection-definition.ts`:
`locales[index] === 'und' ? defaultLocale : locales[index]`). No `IndexerConfig`
field carried it and no environment variable set it, so **the Docker image could
not stem untagged text at all** – a Dutch index folds but never stems, and
`fietsen` does not match `fiets`.

It is deployment configuration rather than code, so it lands as `DEFAULT_LOCALE`
in `IndexerConfig`. The plain image gets it too, and no caller passes it in code.

## The helpers, still exported

`datasetSelectorFrom`, `distributionResolverFrom` and `writerFactoryFrom` are
exported as the issue asked, for the deployment that genuinely leaves the
convenience – a non-SPARQL reader, another engine, a root selector that is not by
class. That route is documented with what it costs, rather than as the answer for
adding behaviour.

## Tests

- the transform is asserted end to end: it sees the named type’s extracted quads
  and the other type’s stage runs untouched;
- an undeclared type name throws, at the pipeline layer and at boot;
- `transform` combined with the caller’s own `readers` throws;
- `DEFAULT_LOCALE` reaches the collection definition (`{ stem: true, locale:
  'nl' }` on `title_search_und`, absent when unset), driving a writer’s
  `openRun` against a recording Typesense client;
- one test composes the helpers as the reference documents, so that route cannot
  rot while `createSearchIndexer` passes.

Both packages stay at 100% coverage.

Fix #691
