### PR TITLE
feat(search): let a field carry a description to the API surface

### DIFF
--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -146,6 +146,11 @@ const gqlSchema = buildGraphQLSchema(searchSchema(DATASET, PERSON));
 
 ## What it builds (per root type)
 
+A field’s [`description`](./search#describing-a-field) is carried onto both the
+output field and the `where` key of the same name, so an explanation written on
+the declaration reaches a consumer in the playground, in introspection and in an
+editor.
+
 - **Output type** (the `SearchType`’s `name`): localized text → best-first `[LanguageString!]!`
   (`[0].language` is the language actually served); references → named per-shape
   types (`Organization`, `Term`) with an `id` and a `label` – the same word the

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -353,6 +353,41 @@ label }`), and on a reference facet’s bucket. One word, one meaning – so a
 collection reads the same whether you arrive at it directly or through a
 reference.
 
+### Describing a field
+
+A field may carry a `description`, which surfaces wherever an API has somewhere
+to put it – in GraphQL as the field’s description, so it reaches a consumer in
+the playground, in introspection and in an editor rather than in documentation
+they would have to know to look for. It appears on the output field and again on
+the `where` key of the same name, since a reader filtering by a field is the one
+most likely to need telling what it covers.
+
+```ts
+{
+  name: 'creatorName',
+  kind: 'text',
+  path: '<https://schema.org/creator>/<https://schema.org/name>',
+  locales: ['nl'],
+  output: true,
+  searchable: { weight: 3 },
+  description:
+    'Every creator’s name as published, including creators the source names ' +
+    'inline without a URI. Free text rather than a facet, and not always a ' +
+    'personal name.',
+}
+```
+
+Worth declaring wherever the name is not the whole story. The case it exists for
+is two fields over one property that differ in what they can see: a `creator`
+reference keyed by URI can be faceted but is empty where the source named a
+creator inline, while a `creatorName` read through the graph sees every creator
+but cannot be faceted. Neither is a superset of the other, and a consumer reading
+only the field names will reasonably conclude that one duplicates the other.
+
+The declaration is the only place to say so. The module a served API mounts is
+plain data, and there is no hook to annotate the built schema afterwards – so the
+sentence written here is the one that reaches the reader.
+
 ### Facet buckets
 
 A `FacetBucket` always carries its `value` and `count`; what else it carries is

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -312,7 +312,16 @@ export function buildGraphQLSchema(
     }
   }
 
+  /** A field's config, plus the declared {@link SearchFieldBase.description}
+   *  wherever the field surfaces – so one sentence written on the declaration
+   *  reaches the playground, introspection and an editor alike. */
   function outputFieldConfig(
+    field: SearchField,
+  ): GraphQLFieldConfig<Source, SearchContext> {
+    return { ...outputFieldType(field), description: field.description };
+  }
+
+  function outputFieldType(
     field: SearchField,
   ): GraphQLFieldConfig<Source, SearchContext> {
     switch (field.kind) {
@@ -419,7 +428,10 @@ export function buildGraphQLSchema(
         [ID_FIELD]: { type: stringFilter },
       };
       for (const field of filterable) {
-        fields[field.name] = { type: whereFieldType(field) };
+        fields[field.name] = {
+          type: whereFieldType(field),
+          description: field.description,
+        };
       }
       return fields;
     };

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -1225,3 +1225,81 @@ describe('nested inline references', () => {
     );
   });
 });
+
+describe('field descriptions', () => {
+  // A declaration is the only place a schema author can speak: the module is
+  // plain data, mounted, with no hook to decorate the built schema afterwards.
+  // So `description` has to reach every surface the field appears on, or it
+  // reaches the reader in some places and not others.
+  const described = {
+    name: 'CreativeWork',
+    class: 'https://schema.org/CreativeWork',
+    fields: [
+      {
+        name: 'creator',
+        kind: 'reference',
+        description:
+          'Creators identified by URI. Absent where the publisher named one inline; see creatorName.',
+        filterable: true,
+        output: true,
+        ref: { typeName: 'Person', strategy: 'labelOnly' },
+        labelSource: 'Person',
+      },
+      {
+        name: 'creatorName',
+        kind: 'text',
+        description:
+          'Every creator’s name as published, including those with no URI. Free text, not a facet.',
+        locales: ['nl'],
+        output: true,
+        searchable: { weight: 3 },
+      },
+      {
+        name: 'label',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+    ],
+  } satisfies SearchType;
+
+  // A label source must exist and expose an `output`, `searchable` `label`.
+  const person = {
+    name: 'Person',
+    class: 'https://schema.org/Person',
+    fields: [
+      {
+        name: 'label',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+    ],
+  } satisfies SearchType;
+
+  const sdl = () =>
+    printSchema(buildGraphQLSchema(searchSchema(described, person)));
+
+  it('describes an output field', () => {
+    expect(sdl()).toMatch(
+      /"""\s+Every creator’s name as published[^"]*"""\s+creatorName:/,
+    );
+  });
+
+  it('describes the same field where it is filtered on', () => {
+    // The `where` input names the field a second time; a reader filtering by it
+    // is the one most likely to need telling what it covers.
+    expect(sdl()).toMatch(
+      /"""\s+Creators identified by URI[^"]*"""\s+creator: StringFilter/,
+    );
+  });
+
+  it('leaves a field without one undescribed', () => {
+    // Not merely “the field is there”: assert no description block precedes it,
+    // or this would pass whether or not one had been emitted.
+    expect(sdl()).not.toMatch(/"""[^"]*"""\s+label: \[LanguageString/);
+    expect(sdl()).toMatch(/\n {2}label: \[LanguageString!\]!/);
+  });
+});

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -80,6 +80,18 @@ export interface SearchFieldBase {
   /** Logical API name; the physical fanout derives from it. Declare camelCase
    *  where it surfaces in GraphQL. */
   readonly name: string;
+  /**
+   * What this field means, for whoever queries it. Carried to every API surface
+   * with somewhere to put it – GraphQL renders it as the field’s description, so
+   * it reaches a consumer in the playground, in introspection and in an editor,
+   * rather than in documentation they would have to know to look for.
+   *
+   * Worth declaring wherever the name is not the whole story: two fields over
+   * one property that differ in what they can see, a value that is not what its
+   * name suggests, a facet that covers only part of a corpus. Prose, not a type
+   * – the shape is already in the declaration.
+   */
+  readonly description?: string;
   /** Framed-IR predicate IRI to project from. Omit for a field populated by
    *  {@link SearchFieldBase.derive} (or outside the projection entirely). */
   readonly path?: string;


### PR DESCRIPTION
A declaration is the only place a schema author can speak. The module a served API mounts is plain data, there is no hook to annotate the built `GraphQLSchema` afterwards, and `SearchTypeOptions` carries only `queryField` and `queryDefaults`. So nothing an author writes reaches the consumer reading the schema.

The generator meanwhile already emits descriptions for its own constructs — `CreativeWorkWhere`, `or`, `and`. That makes this an asymmetry rather than an absence: the library may explain itself, the author may not.

`description` on `SearchFieldBase` closes it. GraphQL renders it on the output field **and** on the `where` key of the same name, since a reader filtering by a field is the one most likely to need telling what it covers.

```ts
{
  name: 'creatorName',
  kind: 'text',
  path: '<https://schema.org/creator>/<https://schema.org/name>',
  output: true,
  searchable: { weight: 3 },
  description:
    'Every creator’s name as published, including creators the source names inline without a URI. Free text rather than a facet, and not always a personal name.',
}
```

## The case it exists for

Two fields over one property that differ in what they can see. In [limburg/lol](https://codeberg.org/limburg/lol), `creator` is a URI-keyed reference — faceted, filterable, and empty wherever the publisher named a creator inline. `creatorName` reads the name one hop through the graph — every creator, searchable, not faceted.

Measured over that corpus: 94 works have both, **288 have only `creatorName`**, and none has only `creator`. Neither field is a superset, and dropping either loses a population of works entirely. A consumer reading just the two names reasonably concludes one duplicates the other — which is what happened, and what prompted this.

## What it is not

Not a second way to document a schema: there was no first way. Not read-side options — the indexer mounts the same module, and a field's *meaning* is not read-side. Keying explanations off `types['CreativeWork'].fields['creatorName']` was the alternative I was tempted by, and I rejected it because nothing would validate those strings, so a rename silently orphans the text. On the declaration it sits beside the `path` it describes.

## Verified

- The three new tests cover output, `where`, and the absence of a description.
- **The negative case can fail**: adding a `description` to the undescribed field makes it fail, removing it restores green. A test that cannot fail would have been the easy mistake here.
- `nx affected -t lint test typecheck build` clean; the four lint warnings are pre-existing non-null assertions in files this does not touch.
- `npm run docs:build` passes, so the new `#describing-a-field` anchor resolves.

Docs go to `docs/reference/search.md` (where `labelSource` is described, since that is where the reader forms the expectation) and a pointer from `docs/reference/search-api-graphql.md`. No README changes — per ADR 17 those stay slim.

## Not included

`SearchType` gains no description. One optional field on a declaration is enough for the case in hand, and I would rather add the type-level one when something needs it than guess at its shape now.
