### PR TITLE
docs: rank architecture decision records lower in site search

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -213,6 +213,17 @@ export default withMermaid({
     ],
     search: {
       provider: 'local',
+      options: {
+        miniSearch: {
+          searchOptions: {
+            // Architecture decision records document how we got here, so they
+            // rank below the guide and reference pages that explain how to use
+            // the packages.
+            boostDocument: (documentId: string) =>
+              documentId.startsWith('/decisions/') ? 0.3 : 1,
+          },
+        },
+      },
     },
     editLink: {
       pattern: 'https://github.com/ldelements/lde/edit/main/docs/:path',


### PR DESCRIPTION
Architecture decision records explain how the project got where it is, not how to use it. In the docs site’s local search they compete on equal footing with the guide and reference pages, so a query like “pipeline” can surface an ADR above the page that actually documents the package.

VitePress’ local search is MiniSearch, which lets a document’s score be scaled at query time. Pages under `/decisions/` are now boosted by 0.3; everything else keeps its default weight. Field-level boosts (`title`, `text`, `titles`) are untouched, so a strong title match in an ADR can still rank – it just no longer outranks the usage docs by default.
