### PR TITLE
feat(search)!: type a filter by what its field keys on

### DIFF
--- a/docs/decisions/0004-search-api-graphql-surface.md
+++ b/docs/decisions/0004-search-api-graphql-surface.md
@@ -16,8 +16,17 @@ Amended 2026-08-13: that word is the label source’s own – its
 `labelField`, `label` by default (see
 [ADR 8](./0008-resolve-reference-labels-from-per-reference-label-sources.md)),
 so a source declaring `labelField: 'name'` is served as `{ id, name }`. A
-`ValueBucket`’s `label` is unchanged: it is per-facet-field, and a per-type name
-would make the bucket type non-uniform.
+bucket’s `label` is unchanged: it is per-facet-field, and a per-type name would
+make the bucket type non-uniform.
+
+Amended by [ADR 19](./0019-type-a-filter-by-what-its-field-keys-on.md): the
+single `StringFilter` is replaced by filter inputs typed by what the field keys
+on (`KeywordFilter`, `IRIFilter`, `‹Target›Filter` over a new `IRI` scalar),
+`id` is filtered per type, and `idOnly` is implemented – so a reference surfaces
+as a bare `IRI` rather than being forward-declared. A reference facet’s bucket
+is `IriBucket`, whose `value` is an `IRI`, so the round trip from bucket to
+filter is typed end to end. The `StringFilter`, `ValueBucket` and `idOnly` rows
+below are historical.
 
 ## Context
 

--- a/docs/decisions/0018-filter-across-several-fields-with-one-clause.md
+++ b/docs/decisions/0018-filter-across-several-fields-with-one-clause.md
@@ -6,6 +6,13 @@ Date: 2026-08-07
 
 Accepted
 
+Amended by [ADR 19](./0019-type-a-filter-by-what-its-field-keys-on.md), which
+answers the question this ADR left to the client – _which_ fields belong in an
+`or` list – by typing each filter input by what its field keys on. The
+`StringFilter` in the sketches below no longer exists: `id` is filtered through a
+per-type `‹Type›Filter`, and the other keys through `KeywordFilter`,
+`IRIFilter` or a per-target filter. The combinator shape is unchanged.
+
 Amends [ADR 3 (Search API core query model)](./0003-search-api-core-query-model.md)
 and [ADR 4 (Search API GraphQL surface)](./0004-search-api-graphql-surface.md);
 settles the facet interaction left open by

--- a/docs/decisions/0019-type-a-filter-by-what-its-field-keys-on.md
+++ b/docs/decisions/0019-type-a-filter-by-what-its-field-keys-on.md
@@ -1,0 +1,171 @@
+# 19. Type a filter by what its field keys on
+
+Date: 2026-08-13
+
+## Status
+
+Accepted
+
+Amends [ADR 4 (Search API GraphQL surface)](./0004-search-api-graphql-surface.md);
+implements the `idOnly` reference strategy forward-declared in
+[ADR 3](./0003-search-api-core-query-model.md) and
+[ADR 11](./0011-decouple-rdf-depth-from-the-api-surface.md); completes the
+consumer half of [ADR 18](./0018-filter-across-several-fields-with-one-clause.md).
+
+## Context
+
+ADR 18 settled how a consumer states “everything referencing this IRI” – a
+cross-field `or` of `@oneOf` criteria. It settled the **mechanism** and left the
+**vocabulary** to the client: which fields belong in that `or` list.
+
+ADR 4 pointed every `filterable` keyword and reference field at one shared
+`StringFilter`, so introspection could enumerate a criterion’s fields perfectly
+and still not tell that `creator` and `material` want IRIs while `identifier`
+wants an accession number. The predicate list had to be hardcoded per deployment
+and drifted whenever a reference field was added. The consuming clients are
+**generic** – they know no domain profile and must not need one – so whatever
+answers this has to be reachable by the introspection query they already send.
+
+## Decision
+
+A filter input is typed by what its field keys on: `KeywordFilter` for literals,
+`IRIFilter` and per-target `‹Target›Filter` over a new `IRI` scalar for identity,
+with `‹Type›Where.id` typed self-referentially so a collection resolves to the
+filter type accepting its IRIs. The two discovery strategies this affords are
+described in
+[the package reference](../reference/search-api-graphql#finding-which-fields-accept-an-iri);
+what follows is only what the shape cost, and what it was chosen over.
+
+### The coarse strategy is exhaustive; the refined one narrows
+
+The two strategies do not carry the same guarantee, and a consumer has to know
+which it is holding.
+
+**Coarse is complete.** Every field that keys on identity takes an `IRI`, so
+selecting the criterion fields whose `in` element type is `IRI` returns all of
+them. A consumer that must not miss a reference uses this one.
+
+**Refined is a narrowing, not a filter of equal standing.** It keys on
+`ref.typeName`, which is the target a deployment **declares** – not necessarily
+the only type the data admits there. Linked Open Limburg declares
+`about: { typeName: 'Term' }` because SCHEMA-AP-NDE co-types referenced persons
+and organizations as `DefinedTerm`, while the profile also admits a Person or an
+Organization as the referent. So a consumer asking “which fields could hold this
+person IRI?” gets `creator` through `PersonFilter` and does **not** get `about`.
+What it returns is correct; what it returns is not everything.
+
+Declaring every admissible type per field would fix that and cost more than it
+buys: a field has one `ref.typeName` because it emits one reference type and
+resolves labels from one source, and multiplying the declaration multiplies both.
+The narrowing is worth having as a precision tool, not as a completeness claim.
+
+Refinement is also unavailable where the target is not itself a root type: there
+is no `‹Target›Where.id` to resolve the collection through, so coarse is the only
+strategy. Both limits are stated in
+[the package reference](../reference/search-api-graphql#finding-which-fields-accept-an-iri),
+since a consumer meets them before it meets this ADR.
+
+### `kind` is the discriminator, because `idOnly` now exists
+
+The obvious derivation – `reference` means IRI, `keyword` means literal – was
+wrong on the fields that mattered most, and a declaration-level marker
+(`iri: true` on a `keyword`) was the proposed fix. It was rejected.
+
+The reason those fields were `keyword` was never that they held literals. It was
+the **output shape**: `output` on a `reference` requires `ref`, and `ref` gave
+the `{ id, label }` object when what the deployment wanted was a flat list of
+IRIs. So a `reference` internal field laundered the IRIs and a `keyword` `derive`
+surfaced them – seven such pairs in Linked Open Limburg, for `sameAs`, `license`,
+`contentUrl`, `thumbnailUrl` and `landingPage`.
+
+Implementing `idOnly` removes the reason instead of working around it. The marker
+would have added a concept to the declaration language every deployment author
+reads, to serve two fields, while leaving all seven pairs standing and `kind` a
+non-discriminator. `idOnly` adds no concept – it was forward-declared in ADR 3
+and already documented as “the IRI” – and deletes fourteen declarations.
+
+### `IRI` validates in both directions
+
+Rejecting a bare token on input is **caller-input validation**, which this
+surface already owns: `argsToQuery` rejects an out-of-range `perPage` rather than
+letting it reach the engine, because a malformed input should produce an error
+naming the problem, not a silent wrong answer.
+
+It validates on the way **out** too. A type enforced in one direction only is not
+a type a consumer can rely on, and the coarse discovery strategy reads `IRI` as
+precisely the promise that a value is a selection key: serving a non-IRI under it
+would falsify the promise exactly where a consumer acts on it, by feeding a
+facet bucket back into the filter that is supposed to select it. The projection
+applies the same rule at the source, so the only way to reach the outbound error
+is an index written before that rule existed – which a reindex fixes, and which
+failing names instead of hiding. The cost is real and accepted: one such value
+fails the response rather than reading back as a visibly odd string.
+
+The check is a **scheme check, not an `http(s)` one**. `urn:`, `doi:`, `ark:`,
+`tag:`, `mailto:` and a deployment’s own minted scheme are ordinary Linked Data;
+rejecting them would refuse conformant data to catch a class of mistake a weaker
+rule catches anyway.
+
+### Blank-node referents stop being indexed
+
+Validation is only sound if the index cannot hold what the surface refuses, and
+`kind: 'reference'` did **not** guarantee an IRI: a profile-admitted blank-node
+referent projected as `_:b0`, which a facet would then offer and the filter
+refuse. `isAbsoluteIri` therefore lives in `@lde/search` and is applied by the
+projection as well, so the two cannot disagree.
+
+What a `labelOnly`/`idOnly` reference stores is a **selection key**, and a
+framing-minted label is not one: it recurs across documents and changes when
+unrelated triples do, so a bucket keyed on it neither groups what is equal nor
+separates what is not. An **inline** reference is untouched – it carries the
+referent’s fields rather than its identity, so a blank-node referent nests
+exactly as before, which ADR 11 depends on.
+
+## Consequences
+
+- A generic consumer builds ADR 18’s cross-field `or` from introspection, and the
+  hardcoded per-deployment predicate list disappears. The cost is paid once in
+  each deployment’s declaration instead of once per consumer.
+- **Breaking.** `StringFilter` is gone, `id` filters are per-type, and a variable
+  must be declared `[IRI!]` rather than `[String!]` – GraphQL checks variable
+  usage nominally, though the two are identical on the wire. `Type.id` and
+  `‹Type›Reference.id` are `IRI!`.
+- A deployment declaring an IRI-valued field as `keyword` now mis-declares it
+  visibly. The fix is `kind: 'reference'`, which no longer costs it the flat
+  output shape.
+- Blank-node referents disappear from `labelOnly`/`idOnly` reference fields.
+  Where a deployment needs them addressable, the answer is upstream – skolemize
+  in the graph, so the referent and every reference to it are rewritten together.
+
+## Rejected
+
+**An output-side `Reference` interface**, implemented by every `‹Type›Reference`
+so one fragment renders any reference field. Its premise is false: the reference
+types are not structurally identical. An inline type’s `id` is nullable _by
+design_ – a referent needs no identity (ADR 11) – and it carries the referent’s
+own `output` fields, which need not include a `label`; `idOnly` is not an object
+at all. Narrowed to `labelOnly` types it becomes buildable and still does not
+earn its place: a generic client is already introspecting to build the `or` list,
+so it can read `id`/`label` off each reference type structurally, and its queries
+are generated per deployment regardless. One shared fragment versus several
+generated ones is a difference paid by a code generator, not a reader.
+
+**An input-side interface.** `input TermFilter implements Reference` cannot be
+expressed: interfaces and unions are output-only in GraphQL, because abstract
+types resolve at execution time and that has no meaning for a value the client
+supplies. `GraphQLInputObjectTypeConfig` accordingly has no `interfaces`, and
+input interfaces remain an unaccepted RFC. The `IRI` scalar is the input-side
+abstraction instead – the shared supertype across `TermFilter`, `PersonFilter`
+and `IRIFilter`, tested structurally on `in`’s element type rather than
+nominally. Deliberately not named `Reference`, since `‹Type›Reference` already
+owns that word on the output side: `IRI` names the value, `Reference` the role.
+
+**Keeping one `ValueBucket`** whose `value` is a `String` whatever the facet
+keys on. It saves a consumer one bucket type to learn, but it puts a
+`String`-to-`IRI` boundary in the middle of the round trip this ADR exists to
+make typed: a consumer reads a bucket `value` and sends it straight back as the
+`‹Target›Filter` that selects it, and GraphQL checks variable usage nominally,
+so the two halves would not compose without a cast. `BooleanBucket` already
+resolves this the other way – it serves a real boolean so the bucket feeds `is`
+directly – and a reference facet has the same claim. Hence `IriBucket`, built
+from the same field factory as `ValueBucket` so the two cannot drift.

--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -165,9 +165,12 @@ editor.
   object’s fields directly and renders one referent at a time; scalars/booleans
   per kind; `date` → ISO 8601 string; nullability from `required` / `array` /
   `kind`.
-- **`where`** one input per `filterable` field (`StringFilter`, `IntRange` /
-  `FloatRange` / `DateRange`, or `Boolean`), plus **`id: StringFilter`** on every
-  type – the document’s IRI, declared by no type and filterable on all of them
+- **`where`** one input per `filterable` field, typed by what the field keys on:
+  a `keyword` holds literals (`KeywordFilter`), a `reference` holds identity
+  (`‹Target›Filter`, or `IRIFilter` when it names no target), and the numeric
+  kinds take `IntRange` / `FloatRange` / `DateRange`, a `boolean` a plain
+  `Boolean`. Every type also gets **`id: ‹Type›Filter`** – the document’s IRI,
+  declared by no type and filterable on all of them
   ([Lookup by IRI](./search#lookup-by-iri)). So the input always exists, even for
   a type that declares no filterable field of its own. Keys you write side by
   side all apply; two more keys combine them explicitly, so neither AND nor OR is
@@ -186,10 +189,13 @@ editor.
   defaults to `DESC`.
 - **Facets**: a keyed object with one field per `facetable` field, typed by
   the field’s declaration:
-  - a plain value facet returns `[ValueBucket!]!` – `value` + `count` + a
-    nullable `label`, the resolved data label for **reference** facets and
-    `null` for token/free-string facets whose display the consumer owns (its
-    own i18n, or the value itself);
+  - a **reference** facet returns `[IriBucket!]!` – `value` (an `IRI`) +
+    `count` + the resolved data `label`. `value` is typed as the
+    `‹Target›Filter` that selects it takes, so a bucket feeds that filter
+    back without a cast;
+  - a plain value facet returns `[ValueBucket!]!` – the same shape with a
+    `String` `value` and a `null` `label`, for token/free-string facets whose
+    display the consumer owns (its own i18n, or the value itself);
   - a numeric field with [`facetRanges`](./search#range-facets) returns
     `[RangeBucket!]!` instead – one bucket per declared half-open
     `[min, max)` bin, carrying `min`/`max` (null on an open end) and
@@ -226,6 +232,73 @@ first (in request order), then the remaining tagged languages, then untagged
 (`und`) last, so `[0]` is always the best available value. Override with the
 `languageOrder` schema option; the default ordering is exported as
 `defaultLanguageOrder` for composing your own.
+
+## Finding which fields accept an IRI
+
+In Linked Data one conceptual filter maps to several predicates, so a consumer
+building “everything referencing this IRI” has to know which of a type’s fields
+hold identity and which hold literals. The **filter input types answer that by
+introspection**, so nothing has to be hardcoded per deployment and nothing drifts
+when a field is added:
+
+```graphql
+scalar IRI
+
+input KeywordFilter {
+  in: [String!]
+} # literals
+input IRIFilter {
+  in: [IRI!]
+} # IRIs belonging to no collection
+input TermFilter {
+  in: [IRI!]
+} # IRIs of Term
+```
+
+There are two strategies, both answered by one cached introspection round-trip
+of the kind a client already sends – no metadata endpoint, and no directives
+(applied directives are absent from standard introspection anyway).
+
+**Coarse** – _“I hold an IRI and do not know where it came from.”_ Select every
+`‹Type›Criterion` field whose filter’s `in` element type is the `IRI` scalar.
+That yields the complete reference-field set for each collection.
+
+**Refined** – _“which fields could reference the collection I am browsing?”_ The
+`id` of every type is typed **self-referentially** (`TermWhere.id: TermFilter`),
+which is what connects a collection to the filter type accepting its IRIs:
+
+1. you queried some root field – an opaque string to you;
+2. follow its `where` argument to `‹Type›Where`, and its `id` key to a filter
+   type name;
+3. select the criterion fields of every collection whose filter is **that same
+   type**;
+4. build `or: [{ about: { in: [iri] } }, { material: { in: [iri] } }, …]`.
+
+The type name is **compared, never parsed** – a generic client needs no more
+knowledge of `TermFilter` than it already needs of the root field `terms`.
+
+**The two strategies do not carry the same guarantee.** Coarse is complete: every
+field keying on identity takes an `IRI`, so it returns all of them. Refined is a
+**narrowing** – it keys on the target a deployment _declares_, which need not be
+the only type the data admits there. A profile may allow a Person as the referent
+of a field declared `‹Term›`, and that field will not appear when you resolve
+through `PersonWhere.id`. What refined returns is correct; it is not necessarily
+everything. Use coarse whenever missing a reference would be wrong, and refined
+when a shorter, higher-precision list is what you want.
+
+**Known limit**: the refined strategy resolves only when the target is itself a
+root collection. A `ref` to a type no collection serves has no `‹Type›Where.id`
+to match against, so fall back to the coarse strategy – which is also the right
+one for a reference declared with no target at all (`IRIFilter`).
+
+Two further notes. `IRI` is wire-compatible with `String`, but GraphQL checks
+variable usage **nominally**, so a variable must be declared `[IRI!]` rather than
+`[String!]`. And a value with no scheme is rejected at coercion – so
+`where: { material: { in: ["boerenbont"] } }` is a coercion error explaining that
+the value is not an IRI, instead of a silently empty result, while the same value
+is perfectly valid on a `KeywordFilter` beside it. Passed through a variable it
+also carries the offending path (`where.material.in[0]`); written inline, GraphQL
+reports a source location instead.
 
 ## Pagination
 

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -294,13 +294,34 @@ for every kind alike, so the projection, the engine collection definition
 differently. Declare `array: true` wherever the source may carry several values
 you want to keep, including on an internal field a `derive` counts.
 
-A `reference` carries one of two strategies today: `labelOnly` (id + display
-label, resolved at query time from a label source) and `inline` (the referent’s
-own projected fields, carried inline). `idOnly` stays a forward declaration. A
-`labelOnly` reference’s `ref.typeName` is a name, not a key: it may name an
+A `reference` carries one of three strategies, which decide how much of the
+referent it carries and therefore what it surfaces as:
+
+| Strategy    | Carries                                                       | Surfaces as                               |
+| ----------- | ------------------------------------------------------------- | ----------------------------------------- |
+| `idOnly`    | the IRI                                                       | a bare `IRI`                              |
+| `labelOnly` | + a display label, resolved at query time from a label source | `{ id: IRI!, label: [LanguageString!]! }` |
+| `inline`    | + the referent’s own projected fields                         | a nested object                           |
+
+Reach for **`idOnly`** when the referent is not an entity this deployment
+describes – a canonical vocabulary URI, a licence, a content URL. It is the only
+strategy whose `ref.typeName` is optional, because it emits no type of its own to
+need a name for; declare one anyway where the IRIs form a nameable set, and an
+API surface can then tell them apart from IRIs at large. A `labelSource` is still
+honoured for facet bucket labels: the strategy governs the output shape, not
+whether a bucket can be labelled.
+
+A `labelOnly` reference’s `ref.typeName` is a name, not a key: it may name an
 indexed root type (`creator` → `Person`, with `labelSource: 'Person'`) – the
 standard way to reference entities of another collection; only an `inline`
 reference must resolve to a declared Reference Type.
+
+Note what this makes true of `kind`: **a `reference` holds identity, a `keyword`
+holds a literal.** A field over an IRI-valued property is a `reference` whatever
+shape you want it to surface as, so no declaration has to launder one through the
+other. The projection enforces the same rule from below – a reference value that
+is not an absolute IRI (a blank node label, a bare token) is dropped rather than
+indexed, since what a `labelOnly`/`idOnly` reference stores is a selection key.
 
 An **inline reference** resolves `ref.typeName` to a declared **Reference Type**
 and projects the referent through it – a nested `SearchDocument`, or an array
@@ -676,7 +697,7 @@ related to Van Gogh”, where the link may be recorded as `creator`, `about` or
 `contentLocation` depending on the source:
 
 ```graphql
-query Related($iri: StringFilter!) {
+query Related($iri: PersonFilter!) {
   heritageObjects(
     where: {
       material: { in: ["oil"] }

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -1,12 +1,14 @@
 import {
   GraphQLBoolean,
   GraphQLEnumType,
+  GraphQLError,
   GraphQLFloat,
   GraphQLInputObjectType,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
+  GraphQLScalarType,
   GraphQLSchema,
   GraphQLString,
   printSchema,
@@ -35,6 +37,7 @@ import {
   filterOn,
   filterOperatorFor,
   ID_FIELD,
+  isAbsoluteIri,
   OR_KEY,
   isRangeFacet,
   labelFieldNameOf,
@@ -107,6 +110,67 @@ const scalarOutput = (
 ): GraphQLOutputType =>
   field.required === true ? new GraphQLNonNull(scalar) : scalar;
 
+/**
+ * The IRI scalar: an absolute IRI, serialized as a string.
+ *
+ * Its job is to make a filter’s **element type** tell a consumer what the filter
+ * keys on, so “which of this type’s fields accept an IRI” is answerable by
+ * introspection instead of by a hardcoded, per-deployment list of predicates
+ * that drifts whenever a field is added. Wire-compatible with `String` – but
+ * deliberately NOT the same type, since the whole point is that the two are
+ * distinguishable. Consequence for consumers: a variable must be declared
+ * `[IRI!]`, not `[String!]`, because GraphQL checks variable usage nominally.
+ *
+ * **Input coercion validates; output serialization does not.** Rejecting a bare
+ * token on the way in is what turns `where: { material: { in: ["boerenbont"] } }`
+ * from a silent empty result into an error saying why – the same job
+ * `argsToQuery` already does for an out-of-range `perPage`.
+ *
+ * It validates on the way **out** too, and deliberately: a type that is enforced
+ * in one direction only is not a type a consumer can rely on, and the coarse
+ * discovery strategy reads `IRI` as the promise that a value is a selection key.
+ * Serving a non-IRI under it would make the promise false exactly where a
+ * consumer acts on it. The projection applies the same rule at the source, so
+ * the only way to reach this error is an index written before it existed – which
+ * a reindex fixes, and which failing names instead of hiding.
+ *
+ * What counts as an IRI is {@link isAbsoluteIri} – shared with the projection,
+ * so the surface cannot promise something the index contradicts.
+ */
+const iriScalar = new GraphQLScalarType<string, string>({
+  name: 'IRI',
+  description:
+    'An absolute IRI (RFC 3987), serialized as a string. Any scheme – `https:`, `urn:`, `doi:`, `ark:` – not only HTTP. A field or filter typed `IRI` keys on identity, never on a literal.',
+  specifiedByURL: 'https://www.rfc-editor.org/rfc/rfc3987',
+  serialize: (value: unknown) =>
+    assertIriOut(
+      (GraphQLString.serialize as (value: unknown) => string)(value),
+    ),
+  parseValue: (value: unknown) => assertIri(GraphQLString.parseValue(value)),
+  parseLiteral: (node, variables) =>
+    assertIri(GraphQLString.parseLiteral(node, variables)),
+});
+
+function assertIri(value: string): string {
+  if (!isAbsoluteIri(value)) {
+    throw new GraphQLError(
+      `IRI cannot represent “${value}”: an IRI needs a scheme (for example “https:”, “urn:” or “doi:”) and no whitespace. A value like this is usually a label or a token, which selects nothing on a field that keys on identity.`,
+    );
+  }
+  return value;
+}
+
+/** Outbound the fault is the index, not the caller, so the message points at
+ *  the fix rather than at the query. */
+function assertIriOut(value: string): string {
+  if (!isAbsoluteIri(value)) {
+    throw new GraphQLError(
+      `IRI cannot serialize “${value}”: the index holds a value that is not an absolute IRI on a field that keys on identity. The projection drops such values at the source, so this document predates that rule – reindex it.`,
+    );
+  }
+  return value;
+}
+
 /** SCREAMING_SNAKE_CASE for an enum value name, e.g. `datePosted` → `DATE_POSTED`. */
 function screamingSnake(name: string): string {
   return name.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toUpperCase();
@@ -147,24 +211,38 @@ export function buildGraphQLSchema(
       value: { type: new GraphQLNonNull(GraphQLString) },
     },
   });
-  // A plain value facet bucket: a selection key, its count, and (for reference
-  // facets) the engine-resolved data label; null for token/free-string facets
-  // whose display the consumer owns.
-  const valueBucket = new GraphQLObjectType({
-    name: 'ValueBucket',
-    fields: {
-      value: { type: new GraphQLNonNull(GraphQLString) },
-      count: { type: new GraphQLNonNull(GraphQLInt) },
-      label: {
-        type: new GraphQLList(new GraphQLNonNull(languageString)),
-        resolve: (bucket: Source, _args: unknown, context: SearchContext) => {
-          const label = bucket.label as LocalizedValue | undefined;
-          return label
-            ? toLanguageStrings(label, context.acceptLanguage, languageOrder)
-            : null;
-        },
+  // A value facet bucket: a selection key, its count, and (for reference facets)
+  // the engine-resolved data label; null for token/free-string facets whose
+  // display the consumer owns. Only the key’s type varies between the two – a
+  // facet keys on whatever its field keys on – so both are built from here and
+  // cannot drift apart.
+  const valueBucketFields = (
+    keyType: GraphQLScalarType,
+  ): Record<string, GraphQLFieldConfig<Source, SearchContext>> => ({
+    value: { type: new GraphQLNonNull(keyType) },
+    count: { type: new GraphQLNonNull(GraphQLInt) },
+    label: {
+      type: new GraphQLList(new GraphQLNonNull(languageString)),
+      resolve: (bucket: Source, _args: unknown, context: SearchContext) => {
+        const label = bucket.label as LocalizedValue | undefined;
+        return label
+          ? toLanguageStrings(label, context.acceptLanguage, languageOrder)
+          : null;
       },
     },
+  });
+  const valueBucket = new GraphQLObjectType({
+    name: 'ValueBucket',
+    fields: valueBucketFields(GraphQLString),
+  });
+  // A reference facet’s bucket, whose `value` is an `IRI` because the field it
+  // buckets keys on identity. This is what makes the round trip typed end to
+  // end: the bucket a consumer selects feeds straight into the ‹Target›Filter
+  // that selects it, with no `String`-to-`IRI` boundary in between – the
+  // contract BooleanBucket already keeps for `is`.
+  const iriBucket = new GraphQLObjectType({
+    name: 'IriBucket',
+    fields: valueBucketFields(iriScalar),
   });
   // A numeric range-facet bin: half-open `[min, max)` bounds (max null on an
   // open-ended top bin) and the count of documents in it.
@@ -204,12 +282,68 @@ export function buildGraphQLSchema(
     name: 'SortDirection',
     values: { ASC: { value: 'asc' }, DESC: { value: 'desc' } },
   });
-  const stringFilter = new GraphQLInputObjectType({
-    name: 'StringFilter',
+  // Membership filters, split by what the field keys on. A `keyword` field
+  // holds literals (an accession number, an ISO 8601 string, a token); a
+  // `reference` holds identity. One shared `StringFilter` said neither, which
+  // left `where: { material: { in: ["boerenbont"] } }` valid, silent and empty.
+  const keywordFilter = new GraphQLInputObjectType({
+    name: 'KeywordFilter',
+    description: 'Matches a field holding literal values.',
     fields: {
       in: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
     },
   });
+  // The fallback for a reference whose referent is nameable as no type: a
+  // canonical vocabulary URI, a licence, a content URL. Its `in` element type is
+  // what the COARSE discovery strategy matches on – select every criterion field
+  // whose filter takes IRIs, and you have the complete reference-field set with
+  // no origin collection at all.
+  const iriFilter = new GraphQLInputObjectType({
+    name: 'IRIFilter',
+    description:
+      'Matches a field holding IRIs that belong to no collection this API serves.',
+    fields: { in: { type: new GraphQLList(new GraphQLNonNull(iriScalar)) } },
+  });
+  /**
+   * The filter input for IRIs of one named target, `‹TypeName›Filter` – created
+   * once per target and shared by every field pointing at it, INCLUDING the
+   * target’s own `id`. That sharing is the whole mechanism: a consumer resolves
+   * the collection it is browsing to its filter type through `‹Type›Where.id`,
+   * then selects the criterion fields of every other type whose filter is that
+   * same type. The name is COMPARED, never parsed – a generic consumer needs no
+   * more knowledge of `TermFilter` than it already needs of `terms`.
+   */
+  const targetFilters = new Map<string, GraphQLInputObjectType>();
+  function targetFilter(typeName: string): GraphQLInputObjectType {
+    const existing = targetFilters.get(typeName);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const name = `${typeName}Filter`;
+    // graphql-js would reject the duplicate too, but only once the whole schema
+    // is assembled and without saying which declaration caused it. Checked
+    // against every name already claimed – the built-in filters, the `IRI`
+    // scalar, and every root/reference type – since a declaration is free to
+    // name a type `TermFilter` beside a root type `Term`.
+    if (
+      name === keywordFilter.name ||
+      name === iriFilter.name ||
+      name === iriScalar.name ||
+      takenTypeNames.has(name)
+    ) {
+      throw new Error(
+        `Type “${typeName}” would be filtered through “${name}”, which is already the name of another type; rename one of them.`,
+      );
+    }
+    takenTypeNames.add(name);
+    const filter = new GraphQLInputObjectType({
+      name,
+      description: `Matches a field holding IRIs of ${typeName}.`,
+      fields: { in: { type: new GraphQLList(new GraphQLNonNull(iriScalar)) } },
+    });
+    targetFilters.set(typeName, filter);
+    return filter;
+  }
   const intRange = rangeInput('IntRange', GraphQLInt);
   const floatRange = rangeInput('FloatRange', GraphQLFloat);
   const dateRange = rangeInput('DateRange', GraphQLString);
@@ -266,7 +400,15 @@ export function buildGraphQLSchema(
    * stays the id-plus-label pair its strategy carries.
    */
   function registerReferenceType(field: SearchField, owner: SearchType): void {
-    if (field.kind !== 'reference' || field.ref === undefined) {
+    if (
+      field.kind !== 'reference' ||
+      field.ref === undefined ||
+      // An `idOnly` reference carries the IRI and nothing else, so it surfaces
+      // as the IRI itself rather than as an object – there is no type to
+      // register, and no name needed to register one under.
+      field.ref.strategy === 'idOnly' ||
+      field.ref.typeName === undefined
+    ) {
       return;
     }
     if (referenceTypes.has(field.ref.typeName)) {
@@ -307,16 +449,18 @@ export function buildGraphQLSchema(
         > =>
           nested === undefined
             ? {
+                id: { type: new GraphQLNonNull(iriScalar) },
                 // The same word the label source declares its label field
                 // under (`label` by default): one resolved label, one name for
                 // it wherever it surfaces.
-                id: { type: new GraphQLNonNull(GraphQLString) },
                 [labelKeyOf(field)]: labelList(
                   (source) => source.label as LocalizedValue | undefined,
                 ),
               }
             : {
-                id: { type: GraphQLString },
+                // Nullable, and load-bearing: a referent needs no identity, so
+                // a blank-node one nests exactly like a named one, minus this.
+                id: { type: iriScalar },
                 ...Object.fromEntries(
                   outputFields(nested).map((nestedField) => [
                     nestedField.name,
@@ -367,6 +511,32 @@ export function buildGraphQLSchema(
             }
           : { type: scalarOutput(GraphQLString, field) };
       case 'reference': {
+        // `idOnly`: the IRI itself, not an object wrapping it – so a field whose
+        // referent this deployment does not describe (a vocabulary URI, a
+        // licence, a content URL) reads as the flat list of IRIs it is, while
+        // still declaring what it holds.
+        //
+        // The IR still carries a `Reference` here, as it does for every
+        // non-inline reference (see `SearchValue`): the strategy is a statement
+        // about the SURFACE, not about the port, so the flattening belongs on
+        // this side rather than in each adapter’s result reconstruction. A
+        // referent carrying no IRI drops out instead of nulling the field.
+        if (field.ref?.strategy === 'idOnly') {
+          const iriOf = (value: unknown): string | undefined =>
+            (value as { readonly id?: string } | null | undefined)?.id;
+          return field.array === true
+            ? {
+                type: nonNullListOf(iriScalar),
+                resolve: (source) =>
+                  ((source[field.name] as readonly unknown[] | undefined) ?? [])
+                    .map(iriOf)
+                    .filter((iri): iri is string => iri !== undefined),
+              }
+            : {
+                type: scalarOutput(iriScalar, field),
+                resolve: (source) => iriOf(source[field.name]) ?? null,
+              };
+        }
         const referenceType = referenceTypes.get(field.ref?.typeName ?? '')!;
         return field.array === true
           ? {
@@ -403,10 +573,18 @@ export function buildGraphQLSchema(
     }
   }
 
+  /** The filter input one field accepts, fixed by what the field keys on: a
+   *  `reference` keys on identity (its target’s filter, or `IRIFilter` when it
+   *  names no target), a `keyword` on literals. */
   function whereFieldType(field: SearchField): GraphQLInputType {
     switch (filterOperatorFor(field.kind)) {
       case 'in':
-        return stringFilter;
+        if (field.kind !== 'reference') {
+          return keywordFilter;
+        }
+        return field.ref?.typeName === undefined
+          ? iriFilter
+          : targetFilter(field.ref.typeName);
       case 'range':
         return field.kind === 'integer'
           ? intRange
@@ -432,7 +610,7 @@ export function buildGraphQLSchema(
           string,
           GraphQLFieldConfig<Source, SearchContext>
         > = {
-          id: { type: new GraphQLNonNull(GraphQLString) },
+          id: { type: new GraphQLNonNull(iriScalar) },
         };
         for (const field of outputFields(searchType)) {
           fields[field.name] = outputFieldConfig(field);
@@ -455,7 +633,11 @@ export function buildGraphQLSchema(
      */
     const fieldKeys = (): Record<string, GraphQLInputFieldConfig> => {
       const fields: Record<string, GraphQLInputFieldConfig> = {
-        [ID_FIELD]: { type: stringFilter },
+        // Typed self-referentially – `TermWhere.id: TermFilter` – so a consumer
+        // can resolve “the collection I am browsing” to “the filter type that
+        // accepts its IRIs”, which is what makes the refined discovery strategy
+        // work without hardcoding a single domain name.
+        [ID_FIELD]: { type: targetFilter(typeName) },
       };
       for (const field of filterable) {
         fields[field.name] = {
@@ -525,8 +707,8 @@ export function buildGraphQLSchema(
     });
 
     // Keyed facets object: one field per facetable field, typed by its kind
-    // (range fields → [RangeBucket!], boolean fields → [BooleanBucket!], else
-    // [ValueBucket!]). Only the selected
+    // (range fields → [RangeBucket!], boolean fields → [BooleanBucket!],
+    // reference fields → [IriBucket!], else [ValueBucket!]). Only the selected
     // fields are resolved (GraphQL prunes the rest), so the selection IS the
     // request; how they are computed – skip-own-filter, batched into one
     // engine dispatch – lives in facet-batch.ts.
@@ -596,10 +778,14 @@ export function buildGraphQLSchema(
   }
 
   /** The bucket type a facet’s kind earns: bins for a range facet, a real
-   *  boolean for a boolean one, a keyed value otherwise. */
+   *  boolean for a boolean one, an `IRI` key for a reference, a literal key
+   *  otherwise. The reference test is the one {@link whereFieldType} applies, so
+   *  a bucket and the filter it feeds cannot disagree about what the field keys
+   *  on. */
   function bucketTypeFor(field: SearchField): GraphQLObjectType {
     if (isRangeFacet(field)) return rangeBucket;
-    return field.kind === 'boolean' ? booleanBucket : valueBucket;
+    if (field.kind === 'boolean') return booleanBucket;
+    return field.kind === 'reference' ? iriBucket : valueBucket;
   }
 
   /** The keyed facets object for one type (only called with ≥ 1 facetable field). */

--- a/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
+++ b/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
@@ -12,12 +12,14 @@ type ThingSearchResult {
 }
 
 type Thing {
-  id: String!
+  id: IRI!
   title: [LanguageString!]!
   description: [LanguageString!]!
   keyword: [String!]!
   creator: [Agent!]!
   publisher: Agent
+  sameAs: [IRI!]!
+  license: IRI
   size: Int
   score: Float
   created: String
@@ -25,13 +27,18 @@ type Thing {
   open: Boolean!
 }
 
+"""
+An absolute IRI (RFC 3987), serialized as a string. Any scheme – \`https:\`, \`urn:\`, \`doi:\`, \`ark:\` – not only HTTP. A field or filter typed \`IRI\` keys on identity, never on a literal.
+"""
+scalar IRI @specifiedBy(url: "https://www.rfc-editor.org/rfc/rfc3987")
+
 type LanguageString {
   language: String
   value: String!
 }
 
 type Agent {
-  id: String!
+  id: IRI!
   label: [LanguageString!]!
 }
 
@@ -43,14 +50,21 @@ type Pagination {
 
 type ThingFacets {
   keyword: [ValueBucket!]!
-  creator: [ValueBucket!]!
-  publisher: [ValueBucket!]!
+  creator: [IriBucket!]!
+  publisher: [IriBucket!]!
+  sameAs: [IriBucket!]!
   status: [ValueBucket!]!
   open: [BooleanBucket!]!
 }
 
 type ValueBucket {
   value: String!
+  count: Int!
+  label: [LanguageString!]
+}
+
+type IriBucket {
+  value: IRI!
   count: Int!
   label: [LanguageString!]
 }
@@ -64,14 +78,16 @@ type BooleanBucket {
 Sibling keys are combined with AND. Use \`or\` for a disjunction, and \`and\` when a query needs more than one of them.
 """
 input ThingWhere {
-  id: StringFilter
-  keyword: StringFilter
-  creator: StringFilter
-  publisher: StringFilter
+  id: ThingFilter
+  keyword: KeywordFilter
+  creator: AgentFilter
+  publisher: AgentFilter
+  sameAs: IRIFilter
+  license: LicenseFilter
   size: IntRange
   score: FloatRange
   created: DateRange
-  status: StringFilter
+  status: KeywordFilter
   open: Boolean
 
   """
@@ -85,8 +101,31 @@ input ThingWhere {
   and: [ThingWhere!]
 }
 
-input StringFilter {
+"""Matches a field holding IRIs of Thing."""
+input ThingFilter {
+  in: [IRI!]
+}
+
+"""Matches a field holding literal values."""
+input KeywordFilter {
   in: [String!]
+}
+
+"""Matches a field holding IRIs of Agent."""
+input AgentFilter {
+  in: [IRI!]
+}
+
+"""
+Matches a field holding IRIs that belong to no collection this API serves.
+"""
+input IRIFilter {
+  in: [IRI!]
+}
+
+"""Matches a field holding IRIs of License."""
+input LicenseFilter {
+  in: [IRI!]
 }
 
 input IntRange {
@@ -108,14 +147,16 @@ input DateRange {
 A condition on exactly one field. Used inside \`or\`, where the criteria are alternatives.
 """
 input ThingCriterion @oneOf {
-  id: StringFilter
-  keyword: StringFilter
-  creator: StringFilter
-  publisher: StringFilter
+  id: ThingFilter
+  keyword: KeywordFilter
+  creator: AgentFilter
+  publisher: AgentFilter
+  sameAs: IRIFilter
+  license: LicenseFilter
   size: IntRange
   score: FloatRange
   created: DateRange
-  status: StringFilter
+  status: KeywordFilter
   open: Boolean
 }
 

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -313,6 +313,28 @@ describe('buildGraphQLSchema', () => {
     ]);
   });
 
+  it('refuses to serve a non-IRI under IRI, naming the index rather than the query', async () => {
+    // An index written before the projection dropped blank-node referents. The
+    // field is typed `IRI`, and the coarse discovery strategy reads that as the
+    // promise that the value is a selection key – serving `_:b0` under it would
+    // make the promise false exactly where a consumer acts on it.
+    const { engine } = fakeEngine({
+      total: 0,
+      hits: [],
+      facets: { publisher: [{ value: '_:b0', count: 1 }] },
+    });
+    const result = await run(
+      `{ datasets { facets { publisher { value } } } }`,
+      {
+        engine,
+        acceptLanguage: ['nl'],
+      },
+    );
+    expect(result.errors?.[0]?.message).toMatch(
+      /IRI cannot serialize “_:b0”.*reindex/is,
+    );
+  });
+
   it('exposes range-facet bucket bounds, null for value facets and open ends', async () => {
     const { engine } = fakeEngine({
       total: 0,
@@ -552,7 +574,7 @@ describe('buildGraphQLSchema', () => {
     expect(query.where).toContainEqual({
       or: [{ field: 'status', in: ['valid'] }],
     });
-    // An empty StringFilter compiles to an empty membership.
+    // An empty filter compiles to an empty membership.
     expect(query.where).toContainEqual({ or: [{ field: 'keyword', in: [] }] });
     expect(query.where).toContainEqual({
       or: [{ field: 'size', range: { min: 1, max: 9 } }],
@@ -580,7 +602,7 @@ describe('buildGraphQLSchema', () => {
       { or: [{ field: 'id', in: ['https://id.example.org/a', 'urn:b'] }] },
     ]);
 
-    // An empty StringFilter compiles to an empty membership, as for any field.
+    // An empty filter compiles to an empty membership, as for any field.
     const empty = fakeEngine(canned);
     await run(`{ datasets(where: { id: {} }) { pagination { total } } }`, {
       engine: empty.engine,
@@ -804,8 +826,23 @@ describe('buildGraphQLSchema', () => {
     expect(sdl).toMatch(/size: \[RangeBucket!\]!/);
     expect(sdl).toMatch(/iiif: \[BooleanBucket!\]!/);
     expect(sdl).toMatch(/input DatasetWhere/);
-    expect(sdl).toMatch(/status: StringFilter/);
+    expect(sdl).toMatch(/status: KeywordFilter/);
     expect(sdl).toMatch(/size: IntRange/);
+  });
+
+  it('buckets a reference facet on IRI, so a bucket feeds the filter that selects it', () => {
+    const sdl = printSchema(
+      buildGraphQLSchema(searchSchema(schema), datasetOptions),
+    );
+    // The round trip a consumer actually makes: read `publisher`’s bucket
+    // `value`, send it back as `where: { publisher: { in: [...] } }`. Both sides
+    // are `IRI`, so no `String`-to-`IRI` boundary sits in the middle – the same
+    // contract BooleanBucket keeps for `is`.
+    expect(sdl).toMatch(/publisher: \[IriBucket!\]!/);
+    expect(sdl).toMatch(/type IriBucket \{\s+value: IRI!/);
+    expect(sdl).toMatch(/publisher: OrganizationFilter/);
+    // A literal-keyed facet keeps the literal-keyed bucket.
+    expect(sdl).toMatch(/type ValueBucket \{\s+value: String!/);
   });
 
   it('gives a boolean facet a real boolean value and no label to interpret', () => {
@@ -886,7 +923,7 @@ describe('buildGraphQLSchema', () => {
       // criteria then offer `id` alone.
       const personWhere = sdl.slice(sdl.indexOf('input PersonWhere {'));
       expect(personWhere.slice(0, personWhere.indexOf('\n}'))).toContain(
-        'id: StringFilter',
+        'id: PersonFilter',
       );
       expect(sdl).toMatch(/input PersonWhere \{[^}]*or: \[PersonCriterion!\]/);
       // `and` carries further `Where`s, so there is no second clause type.
@@ -895,7 +932,7 @@ describe('buildGraphQLSchema', () => {
       // A criterion is an atom, and for a type with no filterable field the
       // only atom available is the IRI lookup.
       expect(sdl).toMatch(
-        /input PersonCriterion @oneOf \{\s*id: StringFilter\s*\}/,
+        /input PersonCriterion @oneOf \{\s*id: PersonFilter\s*\}/,
       );
       // The shared reference shape is emitted once, reused by both types.
       expect(sdl.match(/^type Agent /gm)).toHaveLength(1);
@@ -957,7 +994,7 @@ describe('buildGraphQLSchema', () => {
       expect(sdl.match(/^type Person /gm)).toHaveLength(1);
       expect(sdl).toMatch(/author: PersonReference/);
       expect(sdl).toMatch(
-        /type PersonReference \{\s+id: String!\s+label: \[LanguageString!\]!\s+\}/,
+        /type PersonReference \{\s+id: IRI!\s+label: \[LanguageString!\]!\s+\}/,
       );
     });
 
@@ -980,7 +1017,7 @@ describe('buildGraphQLSchema', () => {
         buildGraphQLSchema(searchSchema(namedLabel, withReferenceToRoot)),
       );
       expect(sdl).toMatch(
-        /type PersonReference \{\s+id: String!\s+name: \[LanguageString!\]!\s+\}/,
+        /type PersonReference \{\s+id: IRI!\s+name: \[LanguageString!\]!\s+\}/,
       );
     });
 
@@ -1185,7 +1222,7 @@ describe('nested inline references', () => {
     // get. `id` is nullable: a referent needs no identity, so a blank-node one
     // nests without one.
     expect(sdl).toMatch(
-      /type MediaObject \{\s+id: String\s+contentUrl: \[String!\]!\s+width: Int\s+caption: \[LanguageString!\]!\s+\}/,
+      /type MediaObject \{\s+id: IRI\s+contentUrl: \[String!\]!\s+width: Int\s+caption: \[LanguageString!\]!\s+\}/,
     );
     // An Internal Field inside a Reference Type stays out of the API.
     expect(sdl).not.toMatch(/rawWidth/);
@@ -1285,10 +1322,10 @@ describe('nested inline references', () => {
       ),
     );
     expect(sdl).toMatch(
-      /type MediaObject \{\s+id: String\s+thumbnail: Thumbnail\s+\}/,
+      /type MediaObject \{\s+id: IRI\s+thumbnail: Thumbnail\s+\}/,
     );
     expect(sdl).toMatch(
-      /type Thumbnail \{\s+id: String\s+contentUrl: \[String!\]!\s+\}/,
+      /type Thumbnail \{\s+id: IRI\s+contentUrl: \[String!\]!\s+\}/,
     );
   });
 });
@@ -1359,7 +1396,7 @@ describe('field descriptions', () => {
     // The `where` input names the field a second time; a reader filtering by it
     // is the one most likely to need telling what it covers.
     expect(sdl()).toMatch(
-      /"""\s+Creators identified by URI[^"]*"""\s+creator: StringFilter/,
+      /"""\s+Creators identified by URI[^"]*"""\s+creator: PersonFilter/,
     );
   });
 
@@ -1368,5 +1405,336 @@ describe('field descriptions', () => {
     // or this would pass whether or not one had been emitted.
     expect(sdl()).not.toMatch(/"""[^"]*"""\s+label: \[LanguageString/);
     expect(sdl()).toMatch(/\n {2}label: \[LanguageString!\]!/);
+  });
+});
+
+describe('discovering which fields accept an IRI', () => {
+  // Two collections, plus the fields a consumer has to be able to tell apart:
+  // references to an indexed target (`about`, `material`, `creator`), a
+  // reference to a target no collection serves (`license`), and a literal field
+  // whose values look nothing like IRIs (`identifier`).
+  const term: RootType = {
+    name: 'Term',
+    class: 'https://schema.org/DefinedTerm',
+    fields: [
+      {
+        name: 'label',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+    ],
+  };
+  const person: RootType = {
+    name: 'Person',
+    class: 'https://schema.org/Person',
+    fields: [
+      {
+        name: 'label',
+        kind: 'text',
+        locales: ['nl'],
+        output: true,
+        searchable: { weight: 5 },
+      },
+    ],
+  };
+  const work: RootType = {
+    name: 'CreativeWork',
+    class: 'https://schema.org/CreativeWork',
+    fields: [
+      { name: 'identifier', kind: 'keyword', filterable: true, output: true },
+      {
+        name: 'about',
+        kind: 'reference',
+        array: true,
+        filterable: true,
+        output: true,
+        labelSource: 'Term',
+        ref: { typeName: 'Term', strategy: 'labelOnly' },
+      },
+      {
+        name: 'material',
+        kind: 'reference',
+        array: true,
+        filterable: true,
+        output: true,
+        labelSource: 'Term',
+        ref: { typeName: 'Term', strategy: 'labelOnly' },
+      },
+      {
+        name: 'creator',
+        kind: 'reference',
+        array: true,
+        filterable: true,
+        output: true,
+        labelSource: 'Person',
+        ref: { typeName: 'Person', strategy: 'labelOnly' },
+      },
+      {
+        name: 'license',
+        kind: 'reference',
+        array: true,
+        filterable: true,
+        output: true,
+        ref: { strategy: 'idOnly' },
+      },
+      // Single-valued, so the flat IRI is the value rather than a list of them.
+      {
+        name: 'iiifManifest',
+        kind: 'reference',
+        output: true,
+        ref: { strategy: 'idOnly' },
+      },
+    ],
+  };
+  const built = buildGraphQLSchema(searchSchema(term, person, work));
+
+  /**
+   * ONE introspection round-trip, of the kind a consumer already sends – no
+   * bespoke endpoint, no metadata query, no directives (applied directives are
+   * absent from standard introspection anyway). Everything below is derived
+   * from this result; not one domain name is written into the traversal.
+   */
+  const INTROSPECTION = `{
+    __schema {
+      queryType { fields { name args { name type { name ofType { name } } } } }
+      types {
+        name
+        inputFields { name type { name ofType { name kind ofType { name ofType { name } } } } }
+      }
+    }
+  }`;
+
+  interface TypeRef {
+    readonly name: string | null;
+    readonly kind?: string;
+    readonly ofType?: TypeRef | null;
+  }
+  interface InputType {
+    readonly name: string;
+    readonly inputFields:
+      readonly { readonly name: string; readonly type: TypeRef }[] | null;
+  }
+
+  /** The innermost named type of a possibly wrapped reference. */
+  const named = (type: TypeRef | null | undefined): string | undefined =>
+    type == null ? undefined : (type.name ?? named(type.ofType));
+
+  async function introspect() {
+    const result = await graphql({ schema: built, source: INTROSPECTION });
+    expect(result.errors).toBeUndefined();
+    const data = result.data as unknown as {
+      __schema: {
+        queryType: {
+          fields: readonly {
+            name: string;
+            args: readonly { name: string; type: TypeRef }[];
+          }[];
+        };
+        types: readonly InputType[];
+      };
+    };
+    const byName = new Map(
+      data.__schema.types.map((type) => [type.name, type]),
+    );
+    /** The `‹Type›Criterion` a root field reaches through its `where` argument:
+     *  `where` → the Where input → its `or` key → the criterion element type.
+     *  Structural throughout; no name is pattern-matched. */
+    const criterionOf = (
+      rootField:
+        { args: readonly { name: string; type: TypeRef }[] } | undefined,
+    ) => {
+      const whereType = byName.get(
+        named(rootField?.args.find((arg) => arg.name === 'where')?.type) ?? '',
+      );
+      const or = whereType?.inputFields?.find((field) => field.name === 'or');
+      return byName.get(named(or?.type) ?? '');
+    };
+    /** The element type of a filter input's `in` key, or undefined when the
+     *  filter has none (a range or a boolean). */
+    const elementOf = (filterName: string | undefined) =>
+      named(
+        byName
+          .get(filterName ?? '')
+          ?.inputFields?.find((field) => field.name === 'in')?.type,
+      );
+    return { data, byName, criterionOf, elementOf };
+  }
+
+  it('answers the coarse strategy: every field that accepts an IRI, with no origin collection', async () => {
+    // What a consumer holding an IRI of unknown provenance needs: select every
+    // criterion field whose filter takes IRIs. No knowledge of the domain, and
+    // no idea which collection the IRI came from.
+    const { data, criterionOf, elementOf } = await introspect();
+    const iriFields = new Map<string, string[]>();
+    for (const rootField of data.__schema.queryType.fields) {
+      const criterion = criterionOf(rootField);
+      iriFields.set(
+        rootField.name,
+        (criterion?.inputFields ?? [])
+          .filter((field) => elementOf(named(field.type)) === 'IRI')
+          .map((field) => field.name),
+      );
+    }
+
+    // Every reference field is found – whether or not its target is a
+    // collection – and `identifier`, which keys on a literal, is not.
+    expect(iriFields.get('creativeWorks')).toEqual([
+      'id',
+      'about',
+      'material',
+      'creator',
+      'license',
+    ]);
+    expect(iriFields.get('terms')).toEqual(['id']);
+  });
+
+  it('answers the refined strategy: the fields that could reference the collection being browsed', async () => {
+    // The consumer knows only which root field it queried – an opaque string to
+    // it. It resolves that collection to its filter type through `‹Type›Where.id`,
+    // then selects the criterion fields of every collection whose filter is the
+    // SAME type. The type name is compared, never parsed.
+    const { data, criterionOf } = await introspect();
+    const browsing = data.__schema.queryType.fields.find(
+      (field) => field.name === 'terms',
+    );
+    const idFilter = named(
+      criterionOf(browsing)?.inputFields?.find((field) => field.name === 'id')
+        ?.type,
+    );
+
+    const referencing = new Map<string, string[]>();
+    for (const rootField of data.__schema.queryType.fields) {
+      referencing.set(
+        rootField.name,
+        (criterionOf(rootField)?.inputFields ?? [])
+          .filter((field) => named(field.type) === idFilter)
+          .map((field) => field.name),
+      );
+    }
+
+    // Only the Term-valued references – `creator` points at Person and
+    // `license` at a target no collection serves, so neither is offered.
+    expect(referencing.get('creativeWorks')).toEqual(['about', 'material']);
+    // The collection's own identity is the other half of the entity-page query:
+    // `or: [{ id: $iri }, { about: $iri }, { material: $iri }]`.
+    expect(referencing.get('terms')).toEqual(['id']);
+  });
+
+  it('rejects a value that is not an IRI, instead of matching nothing', async () => {
+    // The mistake this exists to catch: a readable token pasted into a field
+    // that keys on identity. Previously valid against the schema, and silently
+    // empty.
+    const engine: SearchEngine = {
+      schema: searchSchema(term, person, work),
+      async search() {
+        throw new Error('the engine must never be reached');
+      },
+      searchFacets: noFacets,
+    };
+    const result = await graphql({
+      schema: built,
+      source: `{ creativeWorks(where: { material: { in: ["boerenbont"] } }) { pagination { total } } }`,
+      contextValue: { engine, acceptLanguage: ['nl'] },
+    });
+    expect(result.errors?.[0]?.message).toMatch(
+      /IRI cannot represent “boerenbont”/,
+    );
+    // …while the literal-keyed field beside it takes the very same value.
+    const ok = await graphql({
+      schema: built,
+      source: `{ creativeWorks(where: { identifier: { in: ["boerenbont"] } }) { pagination { total } } }`,
+      contextValue: { engine, acceptLanguage: ['nl'] },
+    });
+    expect(ok.errors?.[0]?.message).not.toMatch(/IRI cannot represent/);
+  });
+
+  it('carries IRIs through variables and back out as a flat list', async () => {
+    // The other half of the round-trip: a consumer declares `[IRI!]` (not
+    // `[String!]` – GraphQL checks variable usage nominally), and an idOnly
+    // reference comes back as the bare IRIs it holds rather than as objects
+    // wrapping them.
+    const engine: SearchEngine = {
+      schema: searchSchema(term, person, work),
+      async search(): Promise<SearchResult> {
+        return {
+          total: 2,
+          hits: [
+            {
+              id: 'https://works/1',
+              document: {
+                license: [
+                  { id: 'https://creativecommons.org/licenses/by/4.0/' },
+                  // A referent carrying no IRI drops out, rather than nulling
+                  // the non-null list and with it the whole hit.
+                  {},
+                ],
+                iiifManifest: { id: 'https://works/1/manifest.json' },
+              },
+            },
+            // A work asserting no licence: the list is empty, never null.
+            { id: 'https://works/2', document: {} },
+          ],
+          facets: {},
+        };
+      },
+      searchFacets: noFacets,
+    };
+    const result = await graphql({
+      schema: built,
+      source: `query ($iris: [IRI!]) {
+        creativeWorks(where: { material: { in: $iris } }) {
+          items { id license iiifManifest }
+        }
+      }`,
+      variableValues: { iris: ['https://id.example.org/term/1'] },
+      contextValue: { engine, acceptLanguage: ['nl'] },
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      creativeWorks: {
+        items: [
+          {
+            id: 'https://works/1',
+            license: ['https://creativecommons.org/licenses/by/4.0/'],
+            iiifManifest: 'https://works/1/manifest.json',
+          },
+          // A work asserting neither: an empty list, and a null scalar.
+          { id: 'https://works/2', license: [], iiifManifest: null },
+        ],
+      },
+    });
+  });
+
+  it('refuses a type whose filter name would collide with a built-in one', async () => {
+    // graphql-js would reject the duplicate too, but only once the whole schema
+    // is assembled and without naming the declaration that caused it.
+    const keyword: RootType = {
+      name: 'Keyword',
+      class: 'https://example.org/Keyword',
+      fields: [],
+    };
+    expect(() => buildGraphQLSchema(searchSchema(keyword))).toThrow(
+      /“Keyword” would be filtered through “KeywordFilter”/,
+    );
+
+    // …and equally when the clash is with a type the declaration itself emits:
+    // a reference served as `TermFilter` beside a root type `Term`.
+    const clashing: RootType = {
+      name: 'Term',
+      class: 'https://example.org/Term',
+      fields: [
+        {
+          name: 'seeAlso',
+          kind: 'reference',
+          output: true,
+          ref: { typeName: 'TermFilter', strategy: 'labelOnly' },
+        },
+      ],
+    };
+    expect(() => buildGraphQLSchema(searchSchema(clashing))).toThrow(
+      /“Term” would be filtered through “TermFilter”/,
+    );
   });
 });

--- a/packages/search-api-graphql/test/generator-stability.test.ts
+++ b/packages/search-api-graphql/test/generator-stability.test.ts
@@ -3,7 +3,7 @@ import { searchSchema, type SearchType } from '@lde/search';
 import { printGraphQLSchema } from '../src/build-schema.js';
 
 /**
- * A neutral fixture exercising every kind + capability — NOT a real domain. Its
+ * A neutral fixture exercising every kind + capability – NOT a real domain. Its
  * SDL is snapshotted purely to pin the **generator**: any change to how
  * `buildGraphQLSchema` maps the field model (nullability, type names, enums,
  * reference reuse) surfaces as a snapshot diff before this library is published,
@@ -55,6 +55,27 @@ const THING: SearchType = {
       filterable: true,
       output: true,
       ref: { typeName: 'Agent', strategy: 'labelOnly' },
+    },
+    // An idOnly reference naming no target: a bare IRI in, a bare IRI out, and
+    // an IRIFilter to select it by – the shape a canonical vocabulary URI or a
+    // licence takes, whose referent this deployment describes nowhere.
+    {
+      name: 'sameAs',
+      kind: 'reference',
+      array: true,
+      facetable: true,
+      filterable: true,
+      output: true,
+      ref: { strategy: 'idOnly' },
+    },
+    // An idOnly reference that DOES name its target, so its IRIs are told apart
+    // from IRIs at large even though no collection serves them.
+    {
+      name: 'license',
+      kind: 'reference',
+      filterable: true,
+      output: true,
+      ref: { typeName: 'License', strategy: 'idOnly' },
     },
     {
       name: 'size',

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -23,7 +23,7 @@ export default mergeConfig(
           lines: 100,
           // Full-suite baseline, re-anchored when covered branches are
           // deleted (autoUpdate only ever raises; see AGENTS.md).
-          branches: 95.85,
+          branches: 96.44,
           statements: 100,
         },
       },

--- a/packages/search/CONTEXT.md
+++ b/packages/search/CONTEXT.md
@@ -129,6 +129,16 @@ How much of a referenced entity a reference carries: `idOnly` (the IRI),
 `labelOnly` (+ its Label Source’s label, resolved at query time), `inline`
 (+ its Reference Type’s projected fields).
 
+**Referent Identity**:
+The referent’s IRI – what a reference filters and facets on, always, and never
+its label. A label is for display and for free-text search: two datasets spell
+one concept differently, and one spelling covers concepts that are not the same
+thing, so it is not a selection key. A referent carrying no IRI therefore has
+nothing to select on, and only an **Inline Reference** – which carries fields,
+not identity – can hold it at all. The rule is what makes a facet count mean
+something: one bucket, one thing.
+_Avoid_: term key, facet value, reference id
+
 **Inline Reference**:
 A reference carrying its referent’s projected fields. Serves two jobs, told
 apart only by Roles:

--- a/packages/search/src/adapter.ts
+++ b/packages/search/src/adapter.ts
@@ -34,6 +34,7 @@ export {
   labelFieldNameOf,
   DEFAULT_LABEL_FIELD,
   isRangeFacet,
+  isAbsoluteIri,
   isoToUnixSeconds,
   unixSecondsToIso,
 } from './schema.js';

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -10,6 +10,7 @@ import {
   displayFieldName,
   inlineFramingDepth,
   irAlias,
+  isAbsoluteIri,
   isInternalField,
   isInlineReference,
   isoToUnixSeconds,
@@ -80,7 +81,7 @@ export function projectDocument(
 ): SearchDocument {
   if (documentKey(node) === undefined) {
     throw new Error(
-      `Cannot project a “${searchType.name}” node without an @id (a blank node label is not one): every search document needs a stable key, and an empty one would collide with other keyless nodes.`,
+      `Cannot project a “${searchType.name}” node whose @id is not an absolute IRI (got ${JSON.stringify(node['@id']) ?? 'none'}; a blank node label or a relative reference is not one): every search document needs a stable key, and an empty one would collide with other keyless nodes.`,
     );
   }
   // The guard above is what makes this a SearchDocument: projectFields sets `id`
@@ -155,15 +156,17 @@ function projectFields(
 }
 
 /**
- * The document key a framed node carries, if any. A blank node label (`_:b0`) is
- * not one: framing mints it per call, so it recurs across documents and can
- * change when unrelated triples do. A node bearing one is therefore projected as
- * if framing had pruned its `@id` – which it does whenever the label occurs only
- * once in the framing results.
+ * The document key a framed node carries, if any – an {@link isAbsoluteIri
+ * absolute IRI}, the same rule {@link iriString} applies to a referent, so a
+ * root and a reference cannot disagree about what counts as identity. A blank
+ * node label (`_:b0`) is not one: framing mints it per call, so it recurs across
+ * documents and can change when unrelated triples do. A node bearing one is
+ * therefore projected as if framing had pruned its `@id` – which it does
+ * whenever the label occurs only once in the framing results.
  */
 function documentKey(node: FramedNode): string | undefined {
   const id = node['@id'];
-  return typeof id === 'string' && !id.startsWith('_:') ? id : undefined;
+  return typeof id === 'string' && isAbsoluteIri(id) ? id : undefined;
 }
 
 /**
@@ -520,14 +523,25 @@ function literalString(value: unknown): string | undefined {
   return undefined;
 }
 
+/**
+ * The IRI a reference value carries, or `undefined` when it carries none. A
+ * value may arrive as a bare string – `schema:sameAs`, `contentUrl`,
+ * `thumbnailUrl` and `landingPage` all range on `schema:URL`, which a source may
+ * emit as a literal rather than a node – or as a node object.
+ *
+ * **A referent with no IRI yields nothing**, the same rule {@link documentKey}
+ * applies to a root and for the same reason: what a `labelOnly`/`idOnly`
+ * reference stores is a selection key, and a blank node label is not one.
+ * Framing mints it per call, so it recurs across documents and changes when
+ * unrelated triples do – indexing it would key a facet bucket on a value that
+ * neither groups what is equal nor separates what is not. An **inline**
+ * reference is untouched by this: it carries the referent’s fields rather than
+ * its identity ({@link applyInlineReference}), so a blank-node referent nests
+ * exactly as before.
+ */
 function iriString(value: unknown): string | undefined {
-  if (typeof value === 'string') {
-    return value;
-  }
-  if (isObject(value) && typeof value['@id'] === 'string') {
-    return value['@id'];
-  }
-  return undefined;
+  const iri = isObject(value) ? value['@id'] : value;
+  return typeof iri === 'string' && isAbsoluteIri(iri) ? iri : undefined;
 }
 
 function toInteger(literal: string | undefined): number | undefined {

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -216,29 +216,57 @@ export interface ReferenceField extends SearchFieldBase, Searchable {
    * resolution.
    */
   readonly labelSource?: string;
-  /** The referenced entity’s shape and how much of it to carry. Required when
-   *  the field is `output` (the API surfaces need the reference type name);
-   *  optional for a facet- or filter-only reference. */
-  readonly ref?: {
-    /** Logical API type name of the referenced entity (PascalCase, e.g.
-     *  `Organization`) – names the reference’s type in the API surfaces, the
-     *  way {@link SearchType.name} names a root type; fields sharing it share
-     *  one emitted type. For a `labelOnly`/`idOnly` reference it is a name,
-     *  not a key: it need not correspond to any indexed root type, and it may
-     *  name one (`creator` → `Person`, with the labels resolved from that
-     *  root’s collection via `labelSource`) – an API surface then serves the
-     *  reference under a derived name (GraphQL: `‹Name›Reference`) to keep
-     *  type names unique. An `inline` reference’s typeName instead resolves to
-     *  a declared {@link ReferenceType}, so it can never name a root type. */
-    readonly typeName: string;
-    /** How much of the referenced entity the reference carries. `labelOnly`
-     *  (id + display label, resolved from a label source) and `inline` (the
-     *  referent’s own projected fields, carried inline through a declared
-     *  {@link ReferenceType} – see {@link isInlineReference}) are implemented;
-     *  `idOnly` is a forward declaration, so that declarations (and the SHACL
-     *  `search:nestedStrategy` mapping) keep their shape when it lands. */
-    readonly strategy: 'labelOnly' | 'idOnly' | 'inline';
-  };
+  /**
+   * The referenced entity’s shape and how much of it to carry. Required when
+   * the field is `output` – the strategy is what decides the output shape, so
+   * a surfaced reference must state it; optional for a facet- or filter-only
+   * reference.
+   *
+   * A **discriminated union by `strategy`**, because `typeName` is load-bearing
+   * for two of the three and meaningless for the third: a `labelOnly` reference
+   * needs a name to emit its id-plus-label type under, an `inline` one needs a
+   * name that resolves to a declared {@link ReferenceType}, and an `idOnly` one
+   * carries a bare IRI that may belong to no declared type at all (`sameAs`
+   * points at a vocabulary nobody indexes). Declaring `typeName` on an `idOnly`
+   * reference is still useful where a target *is* nameable – an API surface can
+   * then tell IRIs of that target apart from IRIs at large.
+   */
+  readonly ref?:
+    | {
+        /** Logical API type name of the referenced entity (PascalCase, e.g.
+         *  `Organization`) – names the reference’s type in the API surfaces,
+         *  the way {@link SearchType.name} names a root type; fields sharing it
+         *  share one emitted type. For a `labelOnly` reference it is a name,
+         *  not a key: it need not correspond to any indexed root type, and it
+         *  may name one (`creator` → `Person`, with the labels resolved from
+         *  that root’s collection via `labelSource`) – an API surface then
+         *  serves the reference under a derived name (GraphQL:
+         *  `‹Name›Reference`) to keep type names unique. An `inline`
+         *  reference’s typeName instead resolves to a declared
+         *  {@link ReferenceType}, so it can never name a root type. */
+        readonly typeName: string;
+        /** `labelOnly` carries the id plus a display label resolved from a
+         *  label source; `inline` carries the referent’s own projected fields
+         *  through a declared {@link ReferenceType} (see
+         *  {@link isInlineReference}). */
+        readonly strategy: 'labelOnly' | 'inline';
+      }
+    | {
+        /** Optional here, unlike the other strategies: an `idOnly` reference
+         *  emits no type of its own, so a name is not needed to emit one under.
+         *  Declare it when the referent’s IRIs form a nameable set an API
+         *  surface should distinguish; omit it for IRIs that belong to no such
+         *  set. */
+        readonly typeName?: string;
+        /** The IRI, and nothing else – no label resolution, no nested fields.
+         *  Surfaces as a bare IRI rather than an object, which is what makes it
+         *  the right strategy for a reference whose referent is not an entity
+         *  this deployment describes: a canonical vocabulary URI, a licence, a
+         *  content URL. A {@link ReferenceField.labelSource} is still honoured
+         *  for facet bucket labels – the strategy governs the output shape, not
+         *  whether a bucket can be labelled. */
+        readonly strategy: 'idOnly';
+      };
 }
 
 /**
@@ -1265,6 +1293,32 @@ export function isRangeFacet(
 ): field is NumericField & { readonly facetRanges: readonly FacetRange[] } {
   return field.facetRanges !== undefined && field.facetRanges.length > 0;
 }
+
+/**
+ * Whether a value is an **absolute IRI**: a scheme, then anything with no
+ * whitespace. The single definition the projection (which
+ * drops a reference value failing it) and an API surface (which types such a
+ * value as an IRI, and rejects one that is not) both read, so the two cannot
+ * disagree about what a reference holds – the argument {@link physicalFields}
+ * makes for the physical fanout.
+ *
+ * Deliberately a **scheme check, not an `http(s)` one**. `urn:`, `doi:`, `ark:`,
+ * `tag:`, `mailto:` and a deployment’s own minted scheme (`urn:lde:…`) are
+ * ordinary Linked Data, and rejecting them would make this package refuse
+ * conformant data. What the check does exclude is what a reference must never
+ * hold: a blank node label (`_:b0` – a scheme must start with a letter), a bare
+ * token (`boerenbont`), and a relative reference. Full RFC 3987 parsing would
+ * buy nothing over that while starting to reject real data with a character
+ * someone forgot to percent-encode.
+ */
+export function isAbsoluteIri(value: string): boolean {
+  return ABSOLUTE_IRI.test(value);
+}
+
+/** Scheme (RFC 3986 `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`), then any
+ *  run of non-whitespace. Non-ASCII is deliberately allowed: an IRI is not
+ *  restricted to ASCII. */
+const ABSOLUTE_IRI = /^[A-Za-z][A-Za-z0-9+.-]*:\S*$/;
 
 /**
  * The engine storage codec for `date` fields: stored as Unix seconds (a

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -267,6 +267,45 @@ describe('projectDocument', () => {
     ]);
   });
 
+  it('drops a reference value that is not an absolute IRI', () => {
+    // What a labelOnly/idOnly reference stores is a SELECTION KEY, and a blank
+    // node label is not one: framing mints it per call, so it recurs across
+    // documents and changes when unrelated triples do – a facet bucket keyed on
+    // it would neither group what is equal nor separate what is not. The same
+    // rule documentKey applies to a root, so the two cannot disagree about what
+    // counts as identity.
+    const document = projectDocument(
+      {
+        '@id': 'https://ex/d/blank-referent',
+        [dsKey('class')]: [
+          { '@id': 'http://schema.org/Person' },
+          { '@id': '_:b0' },
+          { '@id': '/relative' },
+          'boerenbont',
+          { '@id': 'urn:example:ok' },
+        ],
+      },
+      {
+        name: 'Dataset',
+        class: DATASET,
+        fields: [
+          {
+            name: 'class',
+            path: `${DR}class`,
+            kind: 'reference',
+            array: true,
+            facetable: true,
+          },
+        ],
+      },
+    );
+
+    expect(document.class).toEqual([
+      'http://schema.org/Person',
+      'urn:example:ok',
+    ]);
+  });
+
   it('folds the transformed values (not the raw ones) for a facet search field', () => {
     const document = projectDocument(
       { '@id': 'https://ex/d/4', [dsKey('format')]: [`${IANA}text/turtle`] },
@@ -1060,7 +1099,7 @@ describe('projectDocument', () => {
         { [dsKey('title')]: { '@value': 'No id' } },
         { name: 'Dataset', class: DATASET, fields },
       ),
-    ).toThrow(/without an @id/);
+    ).toThrow(/@id is not an absolute IRI/);
   });
 
   it('throws when the framed node is keyed by a blank node label', () => {
@@ -1076,7 +1115,7 @@ describe('projectDocument', () => {
           fields,
         },
       ),
-    ).toThrow(/without an @id/);
+    ).toThrow(/@id is not an absolute IRI/);
   });
 
   it('projects nothing for a localized field with no locales (rejected at declaration time)', () => {

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -11,6 +11,7 @@ import {
   filterableFields,
   inlineFramingDepth,
   irAlias,
+  isAbsoluteIri,
   isoToUnixSeconds,
   isRangeFacet,
   nestedFieldName,
@@ -326,6 +327,43 @@ describe('isRangeFacet', () => {
     expect(isRangeFacet(size)).toBe(true);
     expect(isRangeFacet({ ...size, facetRanges: [] })).toBe(false);
     expect(isRangeFacet({ ...size, facetRanges: undefined })).toBe(false);
+  });
+});
+
+describe('isAbsoluteIri', () => {
+  it('accepts any scheme, not only http(s)', () => {
+    // Restricting to http(s) would reject conformant Linked Data: URNs, DOIs,
+    // ARKs and a deployment’s own minted scheme are all ordinary here.
+    for (const iri of [
+      'https://sws.geonames.org/2756308/',
+      'http://example.org/x',
+      'urn:uuid:0b7a1e1e-0000-4000-8000-000000000000',
+      'urn:nbn:nl:ui:13-abcdef',
+      'urn:lde:Dataset/publisherName',
+      'doi:10.1234/5678',
+      'ark:/61567/dataset',
+      'tag:example.org,2026:x',
+      'mailto:someone@example.org',
+      'thing:abc123',
+      'https://example.org/café', // an IRI is not restricted to ASCII
+    ]) {
+      expect(isAbsoluteIri(iri)).toBe(true);
+    }
+  });
+
+  it('rejects what a reference must never hold', () => {
+    for (const value of [
+      '_:b0', // a blank node label – a scheme must start with a letter
+      'boerenbont', // a bare token: the mistake this check exists to catch
+      '/relative/path',
+      '//example.org/x',
+      'http://example.org/a b', // unencoded space
+      'http://example.org/a\nb',
+      '1nvalid:scheme',
+      '',
+    ]) {
+      expect(isAbsoluteIri(value)).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
Fix #723

[ADR 18](../blob/main/docs/decisions/0018-filter-across-several-fields-with-one-clause.md) settled how a consumer states “everything referencing this IRI” – a cross-field `or` of `@oneOf` criteria – but left the vocabulary to the client: **which fields belong in that `or` list**. Nothing in the surface answered it. Every filterable keyword and reference field pointed at one shared `StringFilter`, so introspection could enumerate a criterion’s fields perfectly and still not tell that `creator` and `material` want IRIs while `identifier` wants an accession number. The list had to be hardcoded per deployment and drifted whenever a reference field was added.

## A filter is typed by what its field keys on

```graphql
scalar IRI

input KeywordFilter { in: [String!] }   # literals
input IRIFilter     { in: [IRI!]    }   # IRIs belonging to no collection
input TermFilter    { in: [IRI!]    }   # IRIs of Term, one per ref.typeName
```

`‹Type›Where.id` is typed **self-referentially** (`TermWhere.id: TermFilter`), connecting “the collection I am browsing” to “the filter type that accepts its IRIs”. Two discovery strategies fall out, both answered by one cached introspection round-trip:

- **coarse** – select every criterion field whose filter’s `in` element type is `IRI`; the complete reference-field set, needing no origin collection;
- **refined** – resolve the queried root field through `where` → `‹Type›Where.id` → a filter type name, then select the criterion fields of every collection whose filter is that same type.

The type name is **compared, never parsed**. Both are exercised by tests reading only the introspection result, with no domain name in the traversal.

## `kind` becomes the discriminator, because `idOnly` now exists

The issue proposed a declaration-level marker (`iri: true` on a `keyword`), since `sameAs` and `license` hold IRIs while being keyword-kind. Investigating *why* showed the marker would treat a symptom: the reason was never that they hold literals but the **output shape** – `output` on a `reference` requires `ref`, and `ref` gave the `{ id, label }` object when the deployment wanted a flat list of IRIs. Linked Open Limburg carries seven such internal-reader/keyword-derive pairs.

Implementing `idOnly` – forward-declared since ADR 3, already documented as “the IRI” – removes the reason instead. It surfaces as a bare `IRI`, each pair collapses to one field, and `kind` is the discriminator after all. Its `ref.typeName` is optional, since it emits no type to name.

## The type is enforced in both directions

`parseValue`/`parseLiteral` reject a value with no scheme, so `where: { material: { in: ["boerenbont"] } }` is a coercion error rather than a silent empty result – the job `argsToQuery` already does for an out-of-range `perPage`.

`serialize` enforces it too. A type checked in one direction only is not one a consumer can rely on, and the coarse strategy reads `IRI` as the promise that a value is a selection key; serving a non-IRI under it would falsify the promise exactly where a consumer acts on it. The projection applies the same rule at the source, so the only way to reach the outbound error is an index predating it – which a reindex fixes.

That consistency is also why a reference facet now returns **`IriBucket`** (`value: IRI!`) rather than `ValueBucket`: the bucket a consumer selects feeds the `‹Target›Filter` that selects it, without crossing a type boundary. Both bucket types are built from the same field factory so they cannot drift.

The check is a **scheme check, not `http(s)`** – `urn:`, `doi:`, `ark:`, `tag:` and a deployment’s own minted scheme are ordinary Linked Data. It lives in `@lde/search` as `isAbsoluteIri`, shared with the projection.

## Blank-node referents

That sharing is load-bearing: `kind: 'reference'` did **not** guarantee an IRI. A profile-admitted blank-node referent projected as `_:b0`, which a facet would offer and the filter then refuse. `iriString` now applies the rule `documentKey` already applied to a root, so such a value is dropped – what a `labelOnly`/`idOnly` reference stores is a selection key, and a framing-minted label is not one. **Inline references are untouched**: they carry fields rather than identity, so a blank-node referent nests exactly as before, which ADR 11 depends on.

## Rejected, and recorded in ADR 19

The output-side `interface Reference` (issue item 6) is **dropped**: its premise – that the reference types are structurally identical – is false, since an inline type’s `id` is nullable by design and it carries no guaranteed label field (all the more so now a type can name its own via `labelField`). Narrowed to `labelOnly` types it becomes buildable and still fails the deletion test, since a generic client is already introspecting and generating its queries per deployment. The ADR also records why an input-side interface cannot exist (abstract types are output-only in GraphQL) and why keeping a single `ValueBucket` was rejected.

## Notes for review

- `packages/search-api-graphql/vite.config.ts` moves the branch threshold, an `autoUpdate` re-anchor from the new covered branches.
- `@lde/search-typesense` needs no change: the engine stores IRIs as strings, and the IR still carries a `Reference` for every non-inline reference – the strategy governs this surface, not the port, so the `idOnly` flattening happens in the resolver.
- Rebased onto current `main`, so it sits on top of `labelField` (#729).
- Downstream, LOL can collapse its seven `_x`/`x` pairs and regenerate its SDL snapshot.

Ships as breaking: `StringFilter` is gone, `id` filters are per-type, a reference facet returns `IriBucket`, and a variable must be declared `[IRI!]` rather than `[String!]` (GraphQL checks variable usage nominally, though the two are identical on the wire).
