### PR TITLE
fix(search)!: drop an unselectable bucket instead of failing the response

### DIFF
--- a/docs/decisions/0004-search-api-graphql-surface.md
+++ b/docs/decisions/0004-search-api-graphql-surface.md
@@ -24,7 +24,7 @@ single `StringFilter` is replaced by filter inputs typed by what the field keys
 on (`KeywordFilter`, `IRIFilter`, `‹Target›Filter` over a new `IRI` scalar),
 `id` is filtered per type, and `idOnly` is implemented – so a reference surfaces
 as a bare `IRI` rather than being forward-declared. A reference facet’s bucket
-is `IriBucket`, whose `value` is an `IRI`, so the round trip from bucket to
+is `IRIBucket`, whose `value` is an `IRI`, so the round trip from bucket to
 filter is typed end to end. The `StringFilter`, `ValueBucket` and `idOnly` rows
 below are historical.
 

--- a/docs/decisions/0019-type-a-filter-by-what-its-field-keys-on.md
+++ b/docs/decisions/0019-type-a-filter-by-what-its-field-keys-on.md
@@ -95,11 +95,32 @@ It validates on the way **out** too. A type enforced in one direction only is no
 a type a consumer can rely on, and the coarse discovery strategy reads `IRI` as
 precisely the promise that a value is a selection key: serving a non-IRI under it
 would falsify the promise exactly where a consumer acts on it, by feeding a
-facet bucket back into the filter that is supposed to select it. The projection
-applies the same rule at the source, so the only way to reach the outbound error
-is an index written before that rule existed – which a reindex fixes, and which
-failing names instead of hiding. The cost is real and accepted: one such value
-fails the response rather than reading back as a visibly odd string.
+facet bucket back into the filter that is supposed to select it.
+
+**What a bad value costs depends on what it is.** Where the value is the
+document’s identity – `id`, a reference’s `id` – raising is right: the document
+cannot be selected at all, so serving it hands back something unusable. Where it
+is a facet bucket, raising is wrong, and not by a little: `value: IRI!` sits
+inside `[IRIBucket!]!` inside `Facets!` inside `‹Type›SearchResult!` inside a
+non-null root field, so a raising coercion nulls the **whole response** and takes
+`items` and `pagination` with it.
+[ADR 5](./0005-batch-facet-queries-through-the-engine-port.md)’s degradation
+contract exists to stop a supplementary sidebar count doing exactly that – it
+degrades a failed facet to an empty list precisely so the response survives. So
+the facet resolvers filter
+unselectable buckets out instead – a bucket that cannot be sent back as the
+filter selecting it is not a bucket worth serving, and dropping it keeps the
+promise without the collateral.
+
+That leaves the outbound error reachable only from an index written before the
+projection guard existed – which a reindex fixes. For that to be true the guard
+has to cover **every** route a reference value can take, not just the graph path:
+`iriString` covers the path, and `applyFacet` and the `derive` branch of
+`applyField` cover `from` projection values, `transform` results and derived
+values. Missing any of them would leave the surface promising `IRI` over
+something the projection had let through – and the conversion this ADR
+prescribes, `keyword` `derive` → `kind: 'reference'`, routes straight through
+the busiest of them.
 
 The check is a **scheme check, not an `http(s)` one**. `urn:`, `doi:`, `ark:`,
 `tag:`, `mailto:` and a deployment’s own minted scheme are ordinary Linked Data;
@@ -167,5 +188,5 @@ make typed: a consumer reads a bucket `value` and sends it straight back as the
 `‹Target›Filter` that selects it, and GraphQL checks variable usage nominally,
 so the two halves would not compose without a cast. `BooleanBucket` already
 resolves this the other way – it serves a real boolean so the bucket feeds `is`
-directly – and a reference facet has the same claim. Hence `IriBucket`, built
+directly – and a reference facet has the same claim. Hence `IRIBucket`, built
 from the same field factory as `ValueBucket` so the two cannot drift.

--- a/docs/reference/search-api-graphql.md
+++ b/docs/reference/search-api-graphql.md
@@ -208,7 +208,7 @@ editor.
   defaults to `DESC`.
 - **Facets**: a keyed object with one field per `facetable` field, typed by
   the field’s declaration:
-  - a **reference** facet returns `[IriBucket!]!` – `value` (an `IRI`) +
+  - a **reference** facet returns `[IRIBucket!]!` – `value` (an `IRI`) +
     `count` + the resolved data `label`. `value` is typed as the
     `‹Target›Filter` that selects it takes, so a bucket feeds that filter
     back without a cast;

--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -698,20 +698,20 @@ inline on every referring document.
 Filters you write side by side must **all** match:
 
 ```graphql
-where: { material: { in: ["oil"] }, status: { in: ["valid"] } }
+where: { material: { in: ["https://vocab.getty.edu/aat/300015050"] }, status: { in: ["valid"] } }
 ```
 
 When you want a value matched in **any** of several fields instead, put those
 alternatives under `or`. This is the query behind an entity page – “everything
-related to Van Gogh”, where the link may be recorded as `creator`, `about` or
-`contentLocation` depending on the source:
+related to Van Gogh”, where the link may be recorded as `creator`, `contributor`
+or `publisher` depending on the source:
 
 ```graphql
-query Related($iri: PersonFilter!) {
+query Related($agent: PersonFilter!) {
   heritageObjects(
     where: {
-      material: { in: ["oil"] }
-      or: [{ creator: $iri }, { about: $iri }, { contentLocation: $iri }]
+      material: { in: ["https://vocab.getty.edu/aat/300015050"] }
+      or: [{ creator: $agent }, { contributor: $agent }, { publisher: $agent }]
     }
   ) {
     pagination {
@@ -732,12 +732,21 @@ You get one search, so `total`, the ranking and the facet counts are all correct
 each of them.
 
 Add `id` to the alternatives to include the entity’s **own** record alongside
-everything referring to it: `or: [{ id: $iri }, { creator: $iri }, …]`.
+everything referring to it – `or: [{ id: $work }, { isPartOf: $work }]` asks for a
+work together with its parts.
+
+Note what the alternatives have in common: they all accept IRIs **of the same
+type**, so one variable serves them all. That is not a coincidence – it is what
+[the GraphQL surface](./search-api-graphql#finding-which-fields-accept-an-iri)
+lets a consumer discover: given a collection, which fields of which collections
+accept its IRIs. Fields pointing at _different_ targets carry different filter
+types, and since GraphQL checks variable usage nominally, each needs its own
+variable.
 
 Three things to know when writing `or`:
 
 - **It sits alongside your other filters**, which still all apply. Above, every
-  hit is an oil painting _and_ related to the IRI.
+  hit is an oil painting _and_ related to the agent.
 - **Each alternative names one field.** `{ creator: $a, about: $b }` in a single
   entry is rejected by the schema – write it as two entries.
 - **A field may appear more than once**, which is how you ask for two ranges on
@@ -765,8 +774,8 @@ That is the only thing `and` is needed for. For plain filters it changes nothing
 since side-by-side keys already all apply – these are the same query:
 
 ```graphql
-where: { status: { in: ["valid"] }, material: { in: ["oil"] } }
-where: { and: [{ status: { in: ["valid"] } }, { material: { in: ["oil"] } }] }
+where: { status: { in: ["valid"] }, material: { in: ["https://vocab.getty.edu/aat/300015050"] } }
+where: { and: [{ status: { in: ["valid"] } }, { material: { in: ["https://vocab.getty.edu/aat/300015050"] } }] }
 ```
 
 #### Facet counts under an `or`

--- a/packages/search-api-graphql/src/build-schema.ts
+++ b/packages/search-api-graphql/src/build-schema.ts
@@ -123,21 +123,28 @@ const scalarOutput = (
  * distinguishable. Consequence for consumers: a variable must be declared
  * `[IRI!]`, not `[String!]`, because GraphQL checks variable usage nominally.
  *
- * **Input coercion validates; output serialization does not.** Rejecting a bare
- * token on the way in is what turns `where: { material: { in: ["boerenbont"] } }`
- * from a silent empty result into an error saying why – the same job
- * `argsToQuery` already does for an out-of-range `perPage`.
+ * **It validates in both directions.** Rejecting a bare token on the way in is
+ * what turns `where: { material: { in: ["boerenbont"] } }` from a silent empty
+ * result into an error saying why – the same job `argsToQuery` already does for
+ * an out-of-range `perPage`. Outbound matters for the same reason: a type
+ * enforced in one direction only is not one a consumer can rely on, and the
+ * coarse discovery strategy reads `IRI` as the promise that a value is a
+ * selection key.
  *
- * It validates on the way **out** too, and deliberately: a type that is enforced
- * in one direction only is not a type a consumer can rely on, and the coarse
- * discovery strategy reads `IRI` as the promise that a value is a selection key.
- * Serving a non-IRI under it would make the promise false exactly where a
- * consumer acts on it. The projection applies the same rule at the source, so
- * the only way to reach this error is an index written before it existed – which
- * a reindex fixes, and which failing names instead of hiding.
+ * **Where a bad value is dropped rather than raised.** Raising is right where
+ * the value IS the document’s identity (`id`, a reference’s `id`): such a
+ * document cannot be selected, so serving it would hand back something
+ * unusable. It is wrong for a facet bucket – `value: IRI!` sits inside a chain
+ * of non-nulls up to the root field, so raising there nulls the WHOLE response
+ * and discards `items`, which is precisely what facet-batch.ts’s degradation
+ * contract forbids a supplementary sidebar count from doing. The facet
+ * resolvers therefore filter unselectable buckets out instead.
  *
  * What counts as an IRI is {@link isAbsoluteIri} – shared with the projection,
- * so the surface cannot promise something the index contradicts.
+ * which applies it on every route a reference value can take (graph path,
+ * `derive`, `from`, `transform`), so the surface cannot promise something the
+ * index contradicts and the outbound error is reachable only from an index
+ * written before that rule existed.
  */
 const iriScalar = new GraphQLScalarType<string, string>({
   name: 'IRI',
@@ -265,7 +272,7 @@ export function buildGraphQLSchema(
   // that selects it, with no `String`-to-`IRI` boundary in between – the
   // contract BooleanBucket already keeps for `is`.
   const iriBucket = new GraphQLObjectType({
-    name: 'IriBucket',
+    name: 'IRIBucket',
     fields: valueBucketFields(iriScalar),
   });
   // A numeric range-facet bin: half-open `[min, max)` bounds (max null on an
@@ -396,7 +403,28 @@ export function buildGraphQLSchema(
   // collide: searchSchema resolves its typeName to a declared Reference Type
   // and rejects duplicate names schema-wide.
   const referenceTypes = new Map<string, GraphQLObjectType>();
-  const takenTypeNames = new Set(rootTypeNames);
+  // Seeded with the shared types every schema carries, not just the root type
+  // names: a declaration is free to name a type `IRI` or `ValueBucket`, and
+  // without this it would pass both collision checks and fail at
+  // `new GraphQLSchema` with graphql-js’s “Schema must contain uniquely named
+  // types” – naming neither the declaration nor the field, which is the opaque
+  // failure these checks exist to replace.
+  const takenTypeNames = new Set([
+    ...rootTypeNames,
+    iriScalar.name,
+    keywordFilter.name,
+    iriFilter.name,
+    languageString.name,
+    valueBucket.name,
+    iriBucket.name,
+    rangeBucket.name,
+    booleanBucket.name,
+    paginationType.name,
+    sortDirection.name,
+    intRange.name,
+    floatRange.name,
+    dateRange.name,
+  ]);
   /** The label key each id-plus-label reference type was registered with; no
    *  entry for a surfaced inline one, which carries fields instead of a label. */
   const labelKeys = new Map<string, string>();
@@ -812,7 +840,7 @@ export function buildGraphQLSchema(
 
     // Keyed facets object: one field per facetable field, typed by its kind
     // (range fields → [RangeBucket!], boolean fields → [BooleanBucket!],
-    // reference fields → [IriBucket!], else [ValueBucket!]). Only the selected
+    // reference fields → [IRIBucket!], else [ValueBucket!]). Only the selected
     // fields are resolved (GraphQL prunes the rest), so the selection IS the
     // request; how they are computed – skip-own-filter, batched into one
     // engine dispatch – lives in facet-batch.ts.
@@ -927,13 +955,33 @@ export function buildGraphQLSchema(
           GraphQLFieldConfig<Source, SearchContext>
         > = {};
         for (const field of facetable) {
+          const bucketType = bucketTypeFor(field);
           fields[field.name] = {
-            type: nonNullListOf(bucketTypeFor(field)),
+            type: nonNullListOf(bucketType),
             // The skip-own-filter query building, the batching into one
             // engine dispatch and the degrade-to-[] error handling all live
             // in the loader (facet-batch.ts).
-            resolve: (source: Source) =>
-              (source.loadFacet as FacetLoader)(field.name),
+            resolve: async (source: Source) => {
+              const buckets = await (source.loadFacet as FacetLoader)(
+                field.name,
+              );
+              if (bucketType !== iriBucket) {
+                return buckets;
+              }
+              // A bucket keyed on something that is not an IRI is not a
+              // selection key – it cannot be sent back as the filter that
+              // selects it – so it is dropped rather than served under `IRI`.
+              // Dropping, not throwing: `value: IRI!` sits inside a chain of
+              // non-nulls up to the root field, so a raising coercion here
+              // would null the WHOLE response and take `items` with it, which
+              // is exactly what facet-batch.ts’s degradation contract forbids
+              // a supplementary sidebar count from doing.
+              return buckets.filter(
+                (bucket) =>
+                  typeof bucket.value === 'string' &&
+                  isAbsoluteIri(bucket.value),
+              );
+            },
           };
         }
         return fields;

--- a/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
+++ b/packages/search-api-graphql/test/__snapshots__/generator-stability.test.ts.snap
@@ -67,9 +67,9 @@ type Pagination {
 
 type ThingFacets {
   keyword: [ValueBucket!]!
-  creator: [IriBucket!]!
-  publisher: [IriBucket!]!
-  sameAs: [IriBucket!]!
+  creator: [IRIBucket!]!
+  publisher: [IRIBucket!]!
+  sameAs: [IRIBucket!]!
   status: [ValueBucket!]!
   open: [BooleanBucket!]!
 }
@@ -80,7 +80,7 @@ type ValueBucket {
   label: [LanguageString!]
 }
 
-type IriBucket {
+type IRIBucket {
   value: IRI!
   count: Int!
   label: [LanguageString!]

--- a/packages/search-api-graphql/test/build-schema.test.ts
+++ b/packages/search-api-graphql/test/build-schema.test.ts
@@ -318,23 +318,47 @@ describe('buildGraphQLSchema', () => {
     ]);
   });
 
-  it('refuses to serve a non-IRI under IRI, naming the index rather than the query', async () => {
-    // An index written before the projection dropped blank-node referents. The
-    // field is typed `IRI`, and the coarse discovery strategy reads that as the
-    // promise that the value is a selection key – serving `_:b0` under it would
-    // make the promise false exactly where a consumer acts on it.
+  it('drops an unselectable bucket rather than nulling the response around it', async () => {
+    // A stale bucket from an index written before the projection guard. Its
+    // `value: IRI!` is non-null all the way up to the root field, so raising
+    // here would take `items` and `pagination` with it – the collateral ADR 5’s
+    // degradation contract exists to prevent. It is dropped instead: a bucket
+    // that cannot be sent back as the filter selecting it is not worth serving.
     const { engine } = fakeEngine({
-      total: 0,
-      hits: [],
-      facets: { publisher: [{ value: '_:b0', count: 1 }] },
+      total: 1,
+      hits: canned.hits,
+      facets: {
+        publisher: [
+          { value: '_:b0', count: 1 },
+          { value: 'https://org/1', count: 2 },
+        ],
+      },
     });
     const result = await run(
-      `{ datasets { facets { publisher { value } } } }`,
-      {
-        engine,
-        acceptLanguage: ['nl'],
-      },
+      `{ datasets { pagination { total } items { id } facets { publisher { value count } } } }`,
+      { engine, acceptLanguage: ['nl'] },
     );
+    expect(result.errors).toBeUndefined();
+    const data = result.data?.datasets as Record<string, unknown>;
+    expect(data.pagination).toEqual({ total: 1 });
+    expect(data.items).toEqual([{ id: 'https://d/1' }]);
+    expect((data.facets as Record<string, unknown>).publisher).toEqual([
+      { value: 'https://org/1', count: 2 },
+    ]);
+  });
+
+  it('refuses to serve a non-IRI as a document’s identity, naming the index rather than the query', async () => {
+    // Identity is the case where raising is right: a document keyed on `_:b0`
+    // cannot be selected at all, so serving it hands back something unusable.
+    const { engine } = fakeEngine({
+      total: 1,
+      facets: {},
+      hits: [{ id: '_:b0', document: { status: 'valid' } }],
+    });
+    const result = await run(`{ datasets { items { id } } }`, {
+      engine,
+      acceptLanguage: ['nl'],
+    });
     expect(result.errors?.[0]?.message).toMatch(
       /IRI cannot serialize “_:b0”.*reindex/is,
     );
@@ -843,8 +867,8 @@ describe('buildGraphQLSchema', () => {
     // `value`, send it back as `where: { publisher: { in: [...] } }`. Both sides
     // are `IRI`, so no `String`-to-`IRI` boundary sits in the middle – the same
     // contract BooleanBucket keeps for `is`.
-    expect(sdl).toMatch(/publisher: \[IriBucket!\]!/);
-    expect(sdl).toMatch(/type IriBucket \{\s+value: IRI!/);
+    expect(sdl).toMatch(/publisher: \[IRIBucket!\]!/);
+    expect(sdl).toMatch(/type IRIBucket \{\s+value: IRI!/);
     expect(sdl).toMatch(/publisher: OrganizationFilter/);
     // A literal-keyed facet keeps the literal-keyed bucket.
     expect(sdl).toMatch(/type ValueBucket \{\s+value: String!/);

--- a/packages/search-api-graphql/vite.config.ts
+++ b/packages/search-api-graphql/vite.config.ts
@@ -23,7 +23,7 @@ export default mergeConfig(
           lines: 100,
           // Full-suite baseline, re-anchored when covered branches are
           // deleted (autoUpdate only ever raises; see AGENTS.md).
-          branches: 96.91,
+          branches: 96.96,
           statements: 100,
         },
       },

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -218,7 +218,17 @@ function applyField(
     return applyProjectionValue(document, field, field.from, context);
   }
   if (field.derive !== undefined) {
-    const value = field.derive(document, context);
+    const derived = field.derive(document, context);
+    // A derived `reference` is held to the same rule as a read one: what it
+    // stores is a selection key, and the surface types it `IRI`. ADR 19 sends
+    // an IRI-valued `keyword` derive here by converting it to `reference`, so
+    // this is the busiest way a non-IRI could otherwise reach the index. A
+    // value that survives nothing leaves the field absent, exactly as a derive
+    // returning `undefined` does.
+    const value =
+      field.kind === 'reference' && derived !== undefined
+        ? derivedIris(derived)
+        : derived;
     if (value !== undefined) {
       document[field.name] = value;
     }
@@ -360,7 +370,16 @@ function applyFacet(
   raw: readonly string[],
   field: KeywordField | ReferenceField,
 ): void {
-  const values = dedupe(field.transform ? raw.map(field.transform) : raw);
+  // A `reference` stores identity, so what it stores must be an IRI whatever
+  // route the value arrived by. {@link iriString} guards the graph path, but a
+  // `transform` runs after it and a `from` projection value never passes it at
+  // all – so both are checked here, at the one point they share. Without this
+  // the surface would promise `IRI` over a value the projection let through.
+  const referenced = field.kind === 'reference';
+  const transformed = field.transform ? raw.map(field.transform) : raw;
+  const values = dedupe(
+    referenced ? transformed.filter(isAbsoluteIri) : transformed,
+  );
   const folded = dedupe(values.map((value) => fold(value)));
   const searchField = physicalFields(field).search[0];
   if (field.array === true) {
@@ -542,6 +561,21 @@ function literalString(value: unknown): string | undefined {
 function iriString(value: unknown): string | undefined {
   const iri = isObject(value) ? value['@id'] : value;
   return typeof iri === 'string' && isAbsoluteIri(iri) ? iri : undefined;
+}
+
+/** What a `derive` on a `reference` field is allowed to have produced: the
+ *  absolute IRIs among its return value, keeping the shape the declaration
+ *  promises (a list stays a list, a single value stays single) so `array` still
+ *  decides the stored shape. A lone non-IRI becomes `undefined`, i.e. absent –
+ *  the same outcome the graph path gives it. */
+function derivedIris(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.filter(
+      (entry): entry is string =>
+        typeof entry === 'string' && isAbsoluteIri(entry),
+    );
+  }
+  return typeof value === 'string' && isAbsoluteIri(value) ? value : undefined;
 }
 
 function toInteger(literal: string | undefined): number | undefined {

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -830,6 +830,7 @@ export interface SearchTypeIssue {
     | 'unknown-kind'
     | 'invalid-locale'
     | 'missing-ref'
+    | 'missing-ref-type-name'
     | 'ref-not-allowed'
     | 'text-requires-locales'
     | 'locales-not-allowed'
@@ -932,7 +933,9 @@ const LOCALE_PATTERN = /^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$/;
  * - a `text` field’s declared locales are BCP-47-shaped (no `_`, which is the
  *   reserved name↔locale separator);
  * - a `reference` field that is `output` declares `ref` (the API surfaces
- *   need the reference type name); `ref` on any other kind is meaningless;
+ *   need the reference type name), and – unless its strategy is `idOnly`, which
+ *   emits no type of its own – that `ref` declares a `typeName`; `ref` on any
+ *   other kind is meaningless;
  * - `joinable` only on a `reference` field, and only alongside a `labelSource`
  *   – the join addresses the referent’s collection, which is the one the label
  *   source names, so without it the flag states an edge to nowhere – and never
@@ -1001,6 +1004,19 @@ export function validateSearchType(
     if (field.kind === 'reference') {
       if (field.output === true && field.ref === undefined) {
         issue('missing-ref');
+      }
+      // `typeName` is optional only for `idOnly`, which emits no type and so
+      // needs no name to emit one under. Every other surfaced strategy is
+      // served AS a named type, and without a name an API surface has nothing
+      // to emit – the GraphQL one silently prints `undefined` as the field’s
+      // type, publishing a contract that is not a schema.
+      if (
+        field.output === true &&
+        field.ref !== undefined &&
+        field.ref.strategy !== 'idOnly' &&
+        field.ref.typeName === undefined
+      ) {
+        issue('missing-ref-type-name');
       }
       // A join addresses the referent’s collection, which is the collection the
       // label source names: without one the flag states an edge to nowhere.

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -525,6 +525,82 @@ describe('projectDocument', () => {
     expect(document).not.toHaveProperty('external');
   });
 
+  it('holds a reference to absolute IRIs on every route a value can arrive by', () => {
+    // `iriString` guards the graph path, but three routes bypass it: a
+    // `derive`, a `from` projection value, and a `transform` that runs after
+    // the path was checked. The surface types all of them `IRI`, so all of them
+    // are guarded – otherwise the API promises identity over a value the
+    // projection let through, and the outbound error blames a stale index for
+    // something a live declaration produced.
+    const document = projectDocument(
+      {
+        '@id': 'https://ex/d/12',
+        [dsKey('title')]: { '@id': 'https://ex/term/1' },
+      },
+      {
+        name: 'Dataset',
+        class: DATASET,
+        fields: [
+          // ADR 19 sends IRI-valued keyword derives here; a returned non-IRI is
+          // dropped, exactly as the graph path drops one.
+          {
+            name: 'derived',
+            kind: 'reference',
+            array: true,
+            filterable: true,
+            // A bare token, a blank-node label and a non-string all fail the
+            // rule; only the IRI is a selection key.
+            derive: () => ['https://ex/org/1', 'boerenbont', '_:b0', 42],
+          },
+          {
+            name: 'derivedSingle',
+            kind: 'reference',
+            filterable: true,
+            derive: () => 'not-an-iri',
+          },
+          {
+            name: 'derivedNonString',
+            kind: 'reference',
+            filterable: true,
+            derive: () => 42,
+          },
+          {
+            name: 'derivedSingleValid',
+            kind: 'reference',
+            filterable: true,
+            derive: () => 'https://ex/org/2',
+          },
+          // A `from` projection value never passes `iriString` at all.
+          {
+            name: 'fromContext',
+            kind: 'reference',
+            filterable: true,
+            from: 'dataset',
+          },
+          // A transform runs after the path was validated, so it can undo it.
+          {
+            name: 'sameAs',
+            kind: 'reference',
+            array: true,
+            path: dcterms.title.value,
+            filterable: true,
+            transform: (value) => value.replace('https://ex/term/', ''),
+          },
+        ],
+      },
+      undefined,
+      { dataset: 'not-an-iri' },
+    );
+    expect(document.derived).toEqual(['https://ex/org/1']);
+    expect(document).not.toHaveProperty('derivedSingle');
+    expect(document).not.toHaveProperty('derivedNonString');
+    expect(document.derivedSingleValid).toBe('https://ex/org/2');
+    expect(document.fromContext).toBeUndefined();
+    // Every transformed value fails the rule, so the field is left absent –
+    // the same outcome the graph path gives a reference it cannot key on.
+    expect(document).not.toHaveProperty('sameAs');
+  });
+
   it('prunes an internal (zero-role) field of every non-text kind from the document', () => {
     const document = projectDocument(
       {

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -467,6 +467,49 @@ describe('validateSearchType', () => {
     ).toEqual([]);
   });
 
+  it('requires a ref typeName on every surfaced strategy but idOnly', () => {
+    // An `idOnly` reference emits no type of its own, so it needs no name to
+    // emit one under – `sameAs` points at a vocabulary nobody indexes. Every
+    // other surfaced strategy IS served as a named type, and without a name the
+    // GraphQL surface prints `undefined` as the field's type: a published
+    // contract that is not a schema. TypeScript's union already forbids it, so
+    // this guards a declaration built outside it (plain JS, a generator).
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'creator',
+          kind: 'reference',
+          output: true,
+          ref: { strategy: 'labelOnly' },
+        } as never),
+      ),
+    ).toEqual([{ field: 'creator', reason: 'missing-ref-type-name' }]);
+
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'sameAs',
+          kind: 'reference',
+          output: true,
+          ref: { strategy: 'idOnly' },
+        }),
+      ),
+    ).toEqual([]);
+
+    // Not surfaced, so nothing has to be emitted for it: a filter-only
+    // reference falls back to the target-less IRI filter.
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'seeAlso',
+          kind: 'reference',
+          filterable: true,
+          ref: { strategy: 'labelOnly' },
+        } as never),
+      ),
+    ).toEqual([]);
+  });
+
   it('rejects ref on a non-reference kind', () => {
     const type = typeWith({
       name: 'format',

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 99.49,
+          branches: 99.51,
           statements: 100,
         },
       },


### PR DESCRIPTION
Follow-up to #728, from a review of that PR that landed after it merged. Two of its findings are runtime faults in the released 0.21.0, one is a missed guard, and one is a naming inconsistency that only gets more expensive to correct.

## A stale bucket nulled the whole response

The outbound `IRI` coercion raised wherever it sat. On a facet bucket that is the wrong call: `value: IRI!` is inside `[IRIBucket!]!` inside `Facets!` inside `‹Type›SearchResult!` inside a non-null root field, so GraphQL’s null propagation carried the error all the way to `data: null`. One unusable bucket destroyed `items` and `pagination` – precisely the collateral [ADR 5](../blob/main/docs/decisions/0005-batch-facet-queries-through-the-engine-port.md)’s degradation contract exists to prevent a supplementary sidebar count from causing.

Buckets are now filtered instead: a bucket that cannot be sent back as the filter that selects it is not worth serving, and dropping it keeps `IRI`’s promise without the collateral. Raising is kept where the value **is** identity (`id`, a reference’s `id`) – there the document genuinely cannot be selected, so serving it would hand back something unusable. Both halves have a test; #728’s test asserted only the error message, which is why it passed while the response was being destroyed.

## The invariant that justified raising was not true yet

#728 argued outbound validation was safe because “the projection applies the same rule at the source, so the only way to reach this error is an index written before it existed”. Three routes wrote a reference value without ever passing `isAbsoluteIri`:

- `applyField` – a `derive` assigned its return value straight to the document;
- `applyProjectionValue` – a `from` projection value was written unchecked;
- `applyFacet` – a `transform` ran *after* `iriString` had validated, so it could undo it.

The first is not hypothetical: ADR 19 tells deployments to convert IRI-valued `keyword` `derive` fields to `kind: 'reference'`, which routes straight through it. Such a value indexed cleanly and then failed every response carrying it, under an error instructing the operator to reindex – which reproduced the value exactly.

`applyFacet` now holds `from` values and `transform` results to the same rule the graph path passes, and a `derive` on a `reference` keeps only the absolute IRIs it returned, leaving the field absent when none survive – the same outcome the graph path gives a reference it cannot key on. The claim in ADR 19 and the scalar’s docblock is rewritten to say what is now true, rather than what was assumed.

## Two smaller things

**The collision guard was incomplete.** It checked the new reserved names only on the `targetFilter` path, while `takenTypeNames` was seeded from root type names alone – so a type named `IRI`, `ValueBucket` or `KeywordFilter` passed every check and failed at `new GraphQLSchema` with graphql-js’s generic “Schema must contain uniquely named types”, naming neither the declaration nor the field. That is the opaque failure the guard exists to replace. It is now seeded with every shared built-in name.

Also folded in: `ref.typeName` is validated on every surfaced strategy but `idOnly`. `idOnly` is what made `typeName` optional in the first place, and without this a `labelOnly` reference missing a name prints `undefined` as its field’s type – a published contract that is not a schema.

**`IriBucket` → `IRIBucket`.** One concept, three names it minted – `IRI`, `IRIFilter`, `IriBucket` – and they did not agree. #728 was the moment to fix this for free and the review reached it too late, so this is a second breaking release for a rename. Worth it: this is a surface [ADR 4](../blob/main/docs/decisions/0004-search-api-graphql-surface.md) freezes, the cost only grows with every consumer that adopts 0.21.0, and the inconsistency is in the one place a generic consumer reads structurally.

## Notes for review

- The coverage thresholds in both `vite.config.ts` files are `autoUpdate` re-anchors from the new covered branches.
- `docs/reference/search.md`’s `or` example now uses real IRIs and same-target fields; the previous one filtered `material` on `"oil"`, which the input coercion shipped in 0.21.0 now rejects, and spread one `PersonFilter` variable across fields with three different targets.
