### PR TITLE
fix(search): apply the date storage codec to a derived date, and export the codec

### DIFF
--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -65,7 +65,9 @@ npm install @lde/search
 Exports are stratified by audience:
 
 - **`@lde/search`** – the authoring surface: `defineSearchType`,
-  `searchSchema`, `projectRoots`, validation, and every model/query/result type.
+  `searchSchema`, `projectRoots`, validation, every model/query/result type,
+  and `isoToUnixSeconds` / `unixSecondsToIso` (the `date` storage codec, for a
+  value the projection does not convert itself).
 - **`@lde/search/adapter`** – plumbing for engine adapters and API surfaces:
   - `assertTypeInSchema` – the port membership guard (the exact declaration
     object must be in the schema);

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -25,6 +25,13 @@ export {
   ID_FIELD,
   AND_KEY,
   OR_KEY,
+  // The `date` storage codec. A schema author needs it whenever a value
+  // bypasses the projection’s own conversion – a `date` populated outside the
+  // projection, or a derive that computes seconds from something other than an
+  // ISO string – so it belongs on the authoring surface, not only the adapter
+  // one.
+  isoToUnixSeconds,
+  unixSecondsToIso,
 } from './schema.js';
 export type {
   FieldKind,

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -228,7 +228,13 @@ function applyField(
     const value =
       field.kind === 'reference' && derived !== undefined
         ? derivedIris(derived)
-        : derived;
+        : // A derived `date` goes through the same storage codec as a read one:
+          // the field is stored as Unix seconds, so an ISO string returned here
+          // would otherwise land as a string in an int64 field. A derive that
+          // already computed seconds returns a number and passes through.
+          field.kind === 'date' && typeof derived === 'string'
+          ? isoToUnixSeconds(derived)
+          : derived;
     if (value !== undefined) {
       document[field.name] = value;
     }

--- a/packages/search/src/project.ts
+++ b/packages/search/src/project.ts
@@ -235,7 +235,11 @@ function applyField(
           field.kind === 'date' && typeof derived === 'string'
           ? isoToUnixSeconds(derived)
           : derived;
-    if (value !== undefined) {
+    // NaN is not a value any kind stores, and a derive is the only route that
+    // can produce one (`setNumber` guards the read route). It serializes as
+    // `null`, which an engine rejects for a numeric field – so drop it, leaving
+    // the field absent as an unparseable string already does.
+    if (value !== undefined && !Number.isNaN(value)) {
       document[field.name] = value;
     }
     return;

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -133,6 +133,12 @@ export interface SearchFieldBase {
    * dataset being indexed). It is what lets a derive relate a projected value
    * to its provenance: dropping a polymorphic `isPartOf` value that merely
    * points back at the containing dataset, say.
+   *
+   * The returned value goes through the same storage conversion a read one
+   * does, so a derive states its value in the field’s own terms: a `date`
+   * derive may return an ISO 8601 string ({@link isoToUnixSeconds} is applied
+   * for it) or the stored Unix seconds directly, and a `reference` derive is
+   * held to absolute IRIs.
    */
   readonly derive?: (
     document: ProjectedNode,

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -550,12 +550,20 @@ describe('projectDocument', () => {
           // An unparseable string leaves the field absent, exactly as a derive
           // returning `undefined` does.
           { name: 'created', kind: 'date', derive: () => 'not-a-date' },
+          // …and so does a derive that computed its own seconds from an
+          // unparseable input, rather than shipping NaN into an int64 field.
+          {
+            name: 'available',
+            kind: 'date',
+            derive: () => Date.parse('not-a-date') / 1000,
+          },
         ],
       },
     );
     expect(document.issued).toBe(1_704_067_200);
     expect(document.modified).toBe(1_704_067_200);
     expect(document).not.toHaveProperty('created');
+    expect(document).not.toHaveProperty('available');
   });
 
   it('holds a reference to absolute IRIs on every route a value can arrive by', () => {

--- a/packages/search/test/project.test.ts
+++ b/packages/search/test/project.test.ts
@@ -525,6 +525,39 @@ describe('projectDocument', () => {
     expect(document).not.toHaveProperty('external');
   });
 
+  it('applies the date storage codec to a derived date, as it does to a read one', () => {
+    const document = projectDocument(
+      { '@id': 'https://ex/d/12' },
+      {
+        name: 'Dataset',
+        class: DATASET,
+        fields: [
+          // A derive returning an ISO string is converted, so it cannot land a
+          // string in a field the collection declares int64.
+          {
+            name: 'issued',
+            kind: 'date',
+            sortable: true,
+            derive: () => '2024-01-01T00:00:00.000Z',
+          },
+          // A derive that already computed seconds passes through untouched.
+          {
+            name: 'modified',
+            kind: 'date',
+            sortable: true,
+            derive: () => 1_704_067_200,
+          },
+          // An unparseable string leaves the field absent, exactly as a derive
+          // returning `undefined` does.
+          { name: 'created', kind: 'date', derive: () => 'not-a-date' },
+        ],
+      },
+    );
+    expect(document.issued).toBe(1_704_067_200);
+    expect(document.modified).toBe(1_704_067_200);
+    expect(document).not.toHaveProperty('created');
+  });
+
   it('holds a reference to absolute IRIs on every route a value can arrive by', () => {
     // `iriString` guards the graph path, but three routes bypass it: a
     // `derive`, a `from` projection value, and a `transform` that runs after

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 99.51,
+          branches: 99.52,
           statements: 100,
         },
       },


### PR DESCRIPTION
A `date` field is stored as Unix seconds. The projection applies that codec to a `path`-read value, but a `derive`s return value was stored exactly as returned – so a derive handing back an ISO 8601 string wrote a string into a field the collection declares `int64`, silently.

- **A derived `date` goes through the same storage codec a read one does.** A derive states its value in the field’s own terms: an ISO 8601 string is converted, a derive that already computed seconds passes through untouched, and an unparseable string leaves the field absent – exactly as a derive returning `undefined` does. This makes derives consistent with paths, which is what the issue was really about.
- **A derive returning `NaN` leaves the field absent too.** A derive is the only route a `NaN` can reach a document by – the read route guards it in `setNumber`. Blessing a derive that computes stored seconds itself makes the case reachable (`Date.parse(bad) / 1000`), and `NaN` serializes as `null`, which an engine rejects for a numeric field. Both routes now drop it alike.
- **`isoToUnixSeconds` / `unixSecondsToIso` are re-exported from the package root.** They are the documented encoding of a declared field kind, so they belong next to `defineSearchType` and `SearchField`. A schema author reaching them only through `@lde/search/adapter` was importing from a layer whose contract is “for engine adapters” and whose every other export is irrelevant to them. They stay on `/adapter` too, for the query compiler and the GraphQL surface.

Also documents the derive return-value contract on `SearchFieldBase.derive` and the codec’s place on the authoring surface in `docs/reference/search.md`.

Fix #726
