### PR TITLE
fix(search): reject a surfaced reference that declares no ref typeName

### DIFF
--- a/docs/reference/search.md
+++ b/docs/reference/search.md
@@ -698,20 +698,20 @@ inline on every referring document.
 Filters you write side by side must **all** match:
 
 ```graphql
-where: { material: { in: ["oil"] }, status: { in: ["valid"] } }
+where: { material: { in: ["https://vocab.getty.edu/aat/300015050"] }, status: { in: ["valid"] } }
 ```
 
 When you want a value matched in **any** of several fields instead, put those
 alternatives under `or`. This is the query behind an entity page – “everything
-related to Van Gogh”, where the link may be recorded as `creator`, `about` or
-`contentLocation` depending on the source:
+related to Van Gogh”, where the link may be recorded as `creator`, `contributor`
+or `publisher` depending on the source:
 
 ```graphql
-query Related($iri: PersonFilter!) {
+query Related($agent: PersonFilter!) {
   heritageObjects(
     where: {
-      material: { in: ["oil"] }
-      or: [{ creator: $iri }, { about: $iri }, { contentLocation: $iri }]
+      material: { in: ["https://vocab.getty.edu/aat/300015050"] }
+      or: [{ creator: $agent }, { contributor: $agent }, { publisher: $agent }]
     }
   ) {
     pagination {
@@ -732,12 +732,21 @@ You get one search, so `total`, the ranking and the facet counts are all correct
 each of them.
 
 Add `id` to the alternatives to include the entity’s **own** record alongside
-everything referring to it: `or: [{ id: $iri }, { creator: $iri }, …]`.
+everything referring to it – `or: [{ id: $work }, { isPartOf: $work }]` asks for a
+work together with its parts.
+
+Note what the alternatives have in common: they all accept IRIs **of the same
+type**, so one variable serves them all. That is not a coincidence – it is what
+[the GraphQL surface](./search-api-graphql#finding-which-fields-accept-an-iri)
+lets a consumer discover: given a collection, which fields of which collections
+accept its IRIs. Fields pointing at _different_ targets carry different filter
+types, and since GraphQL checks variable usage nominally, each needs its own
+variable.
 
 Three things to know when writing `or`:
 
 - **It sits alongside your other filters**, which still all apply. Above, every
-  hit is an oil painting _and_ related to the IRI.
+  hit is an oil painting _and_ related to the agent.
 - **Each alternative names one field.** `{ creator: $a, about: $b }` in a single
   entry is rejected by the schema – write it as two entries.
 - **A field may appear more than once**, which is how you ask for two ranges on
@@ -765,8 +774,8 @@ That is the only thing `and` is needed for. For plain filters it changes nothing
 since side-by-side keys already all apply – these are the same query:
 
 ```graphql
-where: { status: { in: ["valid"] }, material: { in: ["oil"] } }
-where: { and: [{ status: { in: ["valid"] } }, { material: { in: ["oil"] } }] }
+where: { status: { in: ["valid"] }, material: { in: ["https://vocab.getty.edu/aat/300015050"] } }
+where: { and: [{ status: { in: ["valid"] } }, { material: { in: ["https://vocab.getty.edu/aat/300015050"] } }] }
 ```
 
 #### Facet counts under an `or`

--- a/packages/search/src/schema.ts
+++ b/packages/search/src/schema.ts
@@ -830,6 +830,7 @@ export interface SearchTypeIssue {
     | 'unknown-kind'
     | 'invalid-locale'
     | 'missing-ref'
+    | 'missing-ref-type-name'
     | 'ref-not-allowed'
     | 'text-requires-locales'
     | 'locales-not-allowed'
@@ -932,7 +933,9 @@ const LOCALE_PATTERN = /^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$/;
  * - a `text` field’s declared locales are BCP-47-shaped (no `_`, which is the
  *   reserved name↔locale separator);
  * - a `reference` field that is `output` declares `ref` (the API surfaces
- *   need the reference type name); `ref` on any other kind is meaningless;
+ *   need the reference type name), and – unless its strategy is `idOnly`, which
+ *   emits no type of its own – that `ref` declares a `typeName`; `ref` on any
+ *   other kind is meaningless;
  * - `joinable` only on a `reference` field, and only alongside a `labelSource`
  *   – the join addresses the referent’s collection, which is the one the label
  *   source names, so without it the flag states an edge to nowhere – and never
@@ -1001,6 +1004,19 @@ export function validateSearchType(
     if (field.kind === 'reference') {
       if (field.output === true && field.ref === undefined) {
         issue('missing-ref');
+      }
+      // `typeName` is optional only for `idOnly`, which emits no type and so
+      // needs no name to emit one under. Every other surfaced strategy is
+      // served AS a named type, and without a name an API surface has nothing
+      // to emit – the GraphQL one silently prints `undefined` as the field’s
+      // type, publishing a contract that is not a schema.
+      if (
+        field.output === true &&
+        field.ref !== undefined &&
+        field.ref.strategy !== 'idOnly' &&
+        field.ref.typeName === undefined
+      ) {
+        issue('missing-ref-type-name');
       }
       // A join addresses the referent’s collection, which is the collection the
       // label source names: without one the flag states an edge to nowhere.

--- a/packages/search/test/schema.test.ts
+++ b/packages/search/test/schema.test.ts
@@ -467,6 +467,49 @@ describe('validateSearchType', () => {
     ).toEqual([]);
   });
 
+  it('requires a ref typeName on every surfaced strategy but idOnly', () => {
+    // An `idOnly` reference emits no type of its own, so it needs no name to
+    // emit one under – `sameAs` points at a vocabulary nobody indexes. Every
+    // other surfaced strategy IS served as a named type, and without a name the
+    // GraphQL surface prints `undefined` as the field's type: a published
+    // contract that is not a schema. TypeScript's union already forbids it, so
+    // this guards a declaration built outside it (plain JS, a generator).
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'creator',
+          kind: 'reference',
+          output: true,
+          ref: { strategy: 'labelOnly' },
+        } as never),
+      ),
+    ).toEqual([{ field: 'creator', reason: 'missing-ref-type-name' }]);
+
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'sameAs',
+          kind: 'reference',
+          output: true,
+          ref: { strategy: 'idOnly' },
+        }),
+      ),
+    ).toEqual([]);
+
+    // Not surfaced, so nothing has to be emitted for it: a filter-only
+    // reference falls back to the target-less IRI filter.
+    expect(
+      validateSearchType(
+        typeWith({
+          name: 'seeAlso',
+          kind: 'reference',
+          filterable: true,
+          ref: { strategy: 'labelOnly' },
+        } as never),
+      ),
+    ).toEqual([]);
+  });
+
   it('rejects ref on a non-reference kind', () => {
     const type = typeWith({
       name: 'format',

--- a/packages/search/vite.config.ts
+++ b/packages/search/vite.config.ts
@@ -12,7 +12,7 @@ export default mergeConfig(
         thresholds: {
           functions: 100,
           lines: 100,
-          branches: 99.49,
+          branches: 99.5,
           statements: 100,
         },
       },


### PR DESCRIPTION
Two code-review findings against #723 / #728 that were not addressed before that PR merged. Both are consequences of the per-target filter typing it introduced.

## A surfaced reference with no `ref.typeName` publishes an invalid contract

`typeName` became optional when `idOnly` landed, because that strategy emits no type and so needs no name to emit one under. Every **other** surfaced strategy is served *as* a named type – but nothing checked it had a name: `validateSearchType` only checked that `ref` existed at all.

The failure is silent rather than loud. `registerReferenceType` skips the field, `outputFieldType` then resolves `referenceTypes.get('')` to `undefined`, and the SDL comes out as:

```graphql
type Thing {
  id: IRI!
  creator: undefined
}
```

A published contract that is not a schema. Now:

```
Invalid search type “Thing”: “creator” (missing-ref-type-name).
```

TypeScript's union already forbids this, so it only bites a declaration built outside it – plain JS, or a generator – which is exactly the case `validateSearchType` exists to guard. A **filter-only** reference is deliberately left alone: nothing has to be emitted for it, so it falls back to the target-less `IRIFilter`.

Same issue name as the fix on `feat/search-lookup-strategy` (#731), with the predicate inverted: there `lookup` replaces `labelOnly`, whereas here `idOnly` is precisely the strategy that legitimately carries no `typeName`.

## The documented cross-field `or` example no longer validates

`docs/reference/search.md` declared one `PersonFilter` variable and fed it to `creator`, `about` and `contentLocation` – three fields whose filters now carry different input types. GraphQL checks variable usage nominally, so the documented query is rejected before it runs.

The same section also filtered `material` on `"oil"` – a bare token on a field that keys on identity, which now fails coercion. That one was not in the review.

Fixed by drawing the alternatives from a single target (`creator`, `contributor`, `publisher`) – which is both ADR 18's own motivating example and what the refined discovery strategy actually returns for an agent IRI – filtering `material` on an AAT IRI, and stating why the alternatives can share a variable while fields pointing at different targets each need their own.

## Notes

- `packages/search/vite.config.ts` moves the branch threshold 99.49 → 99.5, an `autoUpdate` re-anchor from the new covered branch.
- Ships as `fix`, not `feat!`: a declaration this now rejects was already emitting an invalid schema, so nothing that worked stops working.
- Branched off `main` after #728 merged, so it does not overlap the projection-side IRI hardening still in flight.
